### PR TITLE
Harden local validation for enterprise scale

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,20 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,6 +124,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,6 +152,12 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
 name = "bstr"
@@ -140,6 +175,12 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytes"
@@ -320,8 +361,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "embrasure-cli"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -329,6 +379,7 @@ dependencies = [
  "chrono",
  "clap",
  "globset",
+ "jsonschema",
  "openssl",
  "predicates",
  "rand 0.8.7",
@@ -361,6 +412,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -379,6 +441,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "fluent-uri"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1918b65d96df47d3591bed19c5cca17e3fa5d0707318e4b5ef2eae01764df7e5"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
 ]
 
 [[package]]
@@ -403,6 +476,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
+dependencies = [
+ "lazy_static",
+ "num",
 ]
 
 [[package]]
@@ -463,6 +546,18 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
@@ -470,7 +565,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasm-bindgen",
 ]
@@ -813,6 +908,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d46662859bc5f60a145b75f4632fbadc84e829e45df6c5de74cfc8e05acb96b5"
+dependencies = [
+ "ahash",
+ "base64",
+ "bytecount",
+ "email_address",
+ "fancy-regex",
+ "fraction",
+ "idna",
+ "itoa",
+ "num-cmp",
+ "num-traits",
+ "once_cell",
+ "percent-encoding",
+ "referencing",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "uuid-simd",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -829,6 +956,15 @@ name = "litemap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -870,6 +1006,75 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -985,6 +1190,35 @@ dependencies = [
  "openssl-src",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
 ]
 
 [[package]]
@@ -1129,6 +1363,12 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -1187,6 +1427,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "referencing"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e9c261f7ce75418b3beadfb3f0eb1299fe8eb9640deba45ffa2cb783098697d"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "once_cell",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
 ]
 
 [[package]]
@@ -1353,6 +1636,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
@@ -1785,6 +2074,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "uuid",
+ "vsimd",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1795,6 +2095,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "wait-timeout"
@@ -1829,6 +2135,15 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -2079,6 +2394,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embrasure-cli"
-version = "0.3.3"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Embrasure CLI for validating dbt changes against production Snowflake data"
@@ -36,6 +36,7 @@ webbrowser = "1.0"
 
 [dev-dependencies]
 assert_cmd = "2.0"
+jsonschema = { version = "0.33", default-features = false }
 predicates = "3.1"
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 <p align="center"><strong>Catch unexpected data changes before a dbt PR is reviewed.</strong></p>
 
-Embrasure builds the dbt models changed on your branch and their downstream dependents in a temporary Snowflake schema. It compares them with production, runs your existing dbt tests, reports downstream impact, and removes the schema when it finishes.
+Embrasure builds the dbt models changed on your branch and the paths to critical downstream models in temporary Snowflake schemas. It compares them with production, runs your existing dbt tests, reports the full downstream impact, and removes the schemas when it finishes.
 
 Use it locally or in CI. It connects directly to Snowflake, so no Embrasure account or hosted service is required.
 
@@ -16,6 +16,7 @@ Use it locally or in CI. It connects directly to Snowflake, so no Embrasure acco
 - Columns added, removed, renamed, or changed to an incompatible type
 - Unexpected shifts in row counts, null rates, cardinality, ranges, averages, and percentiles
 - Primary-key values that appear or disappear
+- Duplicate and null primary keys introduced by the branch
 - Failures in your existing dbt tests
 - Downstream dbt models, exposures, cross-account dependencies, and optional Metabase dashboards affected by the change
 - Models affected by non-dbt changes you map in the configuration
@@ -44,7 +45,10 @@ Example result:
 ```text
 embrasure: PASS
 2 selected · 2 built · 2 compared · 0 findings · 0 coverage gaps
+5 impacted · 2 validated · 3 not validated
 ```
+
+The default checks changed models plus every path to critical models: models tagged `critical`, marked critical in Embrasure, or directly used by a dbt exposure. Use `--downstream all` for every downstream model or `--downstream none` for changed models only. The complete impact is reported in every mode.
 
 ## Use it with an agent or CI
 
@@ -55,7 +59,7 @@ embrasure check --base origin/main --json
 embrasure check --base origin/main --json --markdown embrasure-check.md
 ```
 
-For a faster first pass on large tables, add `--mode quick`. Deep mode remains the default and includes exact cardinality plus numeric percentiles.
+For a faster first pass on large tables, add `--mode quick`. Deep mode remains the default and includes exact cardinality plus numeric percentiles. Primary-key integrity remains exact in both modes.
 
 The intended agent loop is simple:
 
@@ -76,13 +80,13 @@ Do not request review until it exits 0.
 
 ## Advanced setup
 
-The guided setup creates the smallest configuration needed for one Snowflake account. For service credentials, multiple accounts, primary keys, large-table filters, concurrency and time limits, custom thresholds, non-dbt changes, cross-account dependencies, or Metabase, use the [example configuration](embrasure-check.example.yml) and [enterprise setup guide](docs/enterprise.md).
+The guided setup creates the smallest configuration needed for one Snowflake account. For service credentials, multiple accounts, critical-model policies, primary keys, large-table filters, per-model thresholds, concurrency and time limits, non-dbt changes, cross-account dependencies, or Metabase, use the [example configuration](embrasure-check.example.yml) and [enterprise setup guide](docs/enterprise.md).
 
 ## Safety
 
 Embrasure uses a dedicated warehouse, query tags, statement timeouts, and a configurable model limit. Every temporary schema has a unique name and ownership marker. The CLI checks both before dropping it and treats cleanup failures as execution failures.
 
-Use a Snowflake role that can read the production relations under test and create temporary schemas in the configured CI database. Credentials are never written to reports or normal terminal output.
+Use a Snowflake role that can read and clone production tables under test and create temporary schemas in each relevant database. Credentials are never written to reports or normal terminal output.
 
 See [Security and data flow](docs/security-and-data-flow.md) for the exact network connections, local files, data returned from Snowflake, credential handling, cleanup behavior, and release-verification steps.
 
@@ -95,7 +99,7 @@ If you previously installed `@embrasure/cli` with npm, uninstall it first with `
 ## Current limits
 
 - Snowflake is the only supported warehouse.
-- dbt model lineage and exposures are authoritative. Missing column-level lineage is reported as unknown.
+- dbt model lineage and exposures are authoritative. dbt artifacts alone cannot provide authoritative warehouse-to-dashboard column lineage; the CLI states this as an informational limit.
 - Metabase matching covers native SQL cards that reference fully qualified production relations. Unsupported or inaccessible metadata is reported as a coverage gap.
 
 ## Development
@@ -107,5 +111,7 @@ cargo fmt --check
 cargo clippy --all-targets --all-features -- -D warnings
 cargo test --locked
 ```
+
+The opt-in Snowflake suite is gated by `EMBRASURE_RUN_SNOWFLAKE_TESTS=1` and the `EMBRASURE_TEST_SNOWFLAKE_*` account, user, role, database, warehouse, and token variables. It exercises two schemas, zero-copy incremental seeding, full refresh, duplicate detection, cleanup, and 100,000 synthetic rows.
 
 Contributions are welcome under the [Apache 2.0 license](LICENSE).

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ embrasure check --base origin/main --json
 embrasure check --base origin/main --json --markdown embrasure-check.md
 ```
 
+For a faster first pass on large tables, add `--mode quick`. Deep mode remains the default and includes exact cardinality plus numeric percentiles.
+
 The intended agent loop is simple:
 
 ```text
@@ -74,7 +76,7 @@ Do not request review until it exits 0.
 
 ## Advanced setup
 
-The guided setup creates the smallest configuration needed for one Snowflake account. For service credentials, multiple accounts, primary keys, custom thresholds, non-dbt changes, cross-account dependencies, or Metabase, use the [example configuration](embrasure-check.example.yml) and [enterprise setup guide](docs/enterprise.md).
+The guided setup creates the smallest configuration needed for one Snowflake account. For service credentials, multiple accounts, primary keys, large-table filters, concurrency and time limits, custom thresholds, non-dbt changes, cross-account dependencies, or Metabase, use the [example configuration](embrasure-check.example.yml) and [enterprise setup guide](docs/enterprise.md).
 
 ## Safety
 

--- a/docs/enterprise.md
+++ b/docs/enterprise.md
@@ -10,7 +10,18 @@ Each Snowflake account gets its own `accounts` entry, dbt selector, user, role, 
 
 ## Large projects
 
-Embrasure only builds changed dbt models and their downstream dependents. Independent Snowflake comparisons run concurrently, bounded by `comparison.concurrency`.
+Embrasure reports the complete downstream blast radius. By default, it validates changed models and every model on the path to a critical downstream target. A target is critical when it has a configured critical dbt tag, `critical: true` in Embrasure, or directly supports a dbt exposure.
+
+```yaml
+validation:
+  downstream: critical # none | critical | all
+  critical_tags: [critical, tier_1]
+  incremental_mode: clone
+```
+
+Override this for one run with `--downstream` and repeatable `--critical-tag`. Policy-excluded models remain in the report as not validated. If the requested models exceed `safety.max_models`, Embrasure exits `2` before it creates any Snowflake schema; it never truncates the selection.
+
+Independent Snowflake comparisons run concurrently, bounded by `comparison.concurrency`.
 
 Use quick mode for an inexpensive first pass:
 
@@ -18,7 +29,7 @@ Use quick mode for an inexpensive first pass:
 embrasure check --base origin/main --mode quick
 ```
 
-Quick mode estimates cardinality, ignores estimated cardinality changes below 2%, and skips numeric percentiles. Deep mode is the default and runs exact cardinality plus percentiles. Both modes still check schema, row counts, null rates, ranges, averages, dbt tests, downstream impact, and configured primary keys.
+Quick mode estimates cardinality, ignores estimated cardinality changes below 2%, and skips numeric percentiles. Deep mode is the default and runs exact cardinality plus percentiles. Both modes still check schema, row counts, null rates, ranges, averages, dbt tests, downstream impact, and primary keys exactly.
 
 Set a total comparison budget and limit scans on large fact tables:
 
@@ -32,9 +43,28 @@ models:
   model.analytics.orders:
     primary_key: [order_id]
     where: "order_date >= DATEADD(day, -30, CURRENT_DATE)"
+    thresholds:
+      row_count_relative: 0.05
 ```
 
-The predicate is applied to both the CI and production relation. Use a stable boundary so the two sides cover the same data. Snowflake also enforces `safety.statement_timeout_seconds` on each statement.
+Explicit `primary_key` takes precedence over a simple dbt `unique_key`. Identifier strings and lists are inferred; SQL expressions are not guessed. By default, duplicate and null keys fail only when CI introduces or worsens them. Set `key_policy: strict` on a model to require zero CI duplicate and null keys.
+
+The predicate is applied to both relations. Use a stable boundary so both sides cover the same data. Snowflake also enforces `safety.statement_timeout_seconds` on each statement.
+
+## Incremental models
+
+The default `clone` mode tests the next incremental run without copying production data:
+
+1. Clone the production table into a run-owned baseline schema.
+2. Clone that baseline into the exact dbt candidate relation.
+3. Run dbt incrementally against the candidate.
+4. Compare the result with the unchanged baseline.
+
+All required baseline and candidate clones are created before dbt starts. An unsupported relation or permission error stops the run; there is no automatic full refresh. The report marks this strategy as `incremental_clone` and notes that historical recomputation was not tested.
+
+Use `--incremental-mode full-refresh` to build each candidate from scratch. Embrasure still creates a stable baseline clone for comparison, so production changes during the run cannot move the reference point. A new incremental model gets a normal first build and a report entry that no production comparison exists.
+
+Table-level zero-copy clones preserve Snowflake micro-partitions and avoid cloning unrelated schema objects. Views, hybrid tables, external tables, and other objects that do not support `CREATE TABLE … CLONE` must be redesigned or excluded; Embrasure does not copy them with CTAS.
 
 ## 1. Grant a narrow validation role
 
@@ -55,9 +85,11 @@ GRANT SELECT ON ALL VIEWS IN SCHEMA ANALYTICS.PROD TO ROLE DBT_CHANGE_VALIDATOR;
 GRANT SELECT ON FUTURE VIEWS IN SCHEMA ANALYTICS.PROD TO ROLE DBT_CHANGE_VALIDATOR;
 ```
 
-Grant this role to each person or service user that runs the CLI. The role owns only the temporary schemas it creates; the CLI refuses to remove schemas outside its configured prefix.
+`SELECT` on each source table plus ownership of the run-created target schema permits table cloning. `embrasure doctor` creates a temporary schema, zero-copy clones one visible production table, and removes the schema. Use `embrasure doctor --read-only` when this write test is not allowed.
 
-If production parents live in more schemas or databases, add `USAGE` and `SELECT` grants for those objects too. Keep the warehouse resource monitor, size, and auto-suspend policy under normal Snowflake administration.
+Grant this role to each person or service user that runs the CLI. The role owns only the temporary schemas it creates; the CLI refuses to remove schemas outside its configured prefix and ownership marker.
+
+If selected models live in more schemas or databases, add `USAGE`, `SELECT`, and `CREATE SCHEMA` grants for those databases too. Keep the warehouse resource monitor, size, and auto-suspend policy under normal Snowflake administration.
 
 ## 2. Choose authentication
 
@@ -155,7 +187,7 @@ accounts:
       token_env: SNOWFLAKE_ACCOUNT_B_PAT
 ```
 
-`doctor` checks both accounts. A normal run creates and cleans a separate CI schema in each account and reports declared cross-account dependencies; missing column evidence remains explicitly `unknown`.
+`doctor` checks both accounts. A normal run creates and cleans run-owned CI and baseline schemas in each required account/database and reports declared cross-account dependencies.
 
 ## 4. Optional Metabase impact
 
@@ -177,3 +209,15 @@ embrasure check --base origin/main --json --markdown embrasure-check.md
 ```
 
 Treat exit `0` as ready for review, `1` as a data finding, `2` as missing evidence, and `3` as setup/execution failure.
+
+Report v2 is the default JSON contract and includes validation scope, skipped models, notices, duplicate/null-key metrics, build strategy, and dbt topology changes. Legacy consumers can request the unchanged v1 shape only with JSON output:
+
+```sh
+embrasure check --json --report-version 1
+```
+
+## Lineage boundary
+
+Embrasure treats dbt model lineage, dbt exposures, declared cross-account edges, and optional Metabase SQL matches as the evidence available locally. It does not claim complete column-to-dashboard lineage from dbt artifacts.
+
+Authoritative warehouse-to-BI column lineage requires a separate provider using Snowflake access history and BI APIs. Enterprise limits include additional Snowflake permissions, metadata latency, dynamic SQL that cannot be resolved, separate BI credentials, and gaps for inaccessible assets.

--- a/docs/enterprise.md
+++ b/docs/enterprise.md
@@ -8,6 +8,34 @@ The clean enterprise split is:
 
 Each Snowflake account gets its own `accounts` entry, dbt selector, user, role, warehouse, and credential. Run `embrasure doctor` after setup; it verifies each one independently.
 
+## Large projects
+
+Embrasure only builds changed dbt models and their downstream dependents. Independent Snowflake comparisons run concurrently, bounded by `comparison.concurrency`.
+
+Use quick mode for an inexpensive first pass:
+
+```sh
+embrasure check --base origin/main --mode quick
+```
+
+Quick mode estimates cardinality, ignores estimated cardinality changes below 2%, and skips numeric percentiles. Deep mode is the default and runs exact cardinality plus percentiles. Both modes still check schema, row counts, null rates, ranges, averages, dbt tests, downstream impact, and configured primary keys.
+
+Set a total comparison budget and limit scans on large fact tables:
+
+```yaml
+comparison:
+  mode: deep
+  concurrency: 4
+  timeout_seconds: 900
+
+models:
+  model.analytics.orders:
+    primary_key: [order_id]
+    where: "order_date >= DATEADD(day, -30, CURRENT_DATE)"
+```
+
+The predicate is applied to both the CI and production relation. Use a stable boundary so the two sides cover the same data. Snowflake also enforces `safety.statement_timeout_seconds` on each statement.
+
 ## 1. Grant a narrow validation role
 
 Run equivalent grants in every Snowflake account. Replace the example object names with yours.

--- a/docs/security-and-data-flow.md
+++ b/docs/security-and-data-flow.md
@@ -36,8 +36,8 @@ Snowflake returns the comparison evidence used in the local report:
 - Database, schema, table, and column names
 - Snowflake types
 - Row counts, null rates, cardinality, min/max values, averages, and percentiles
-- Counts of primary-key values found on only one side
-- Optional primary-key examples, up to `safety.primary_key_sample_limit`
+- Counts of primary-key values found on only one side, duplicate rows, and null-key rows
+- Optional deterministic primary-key and duplicate-key examples, up to `safety.primary_key_sample_limit`
 
 Set `primary_key_sample_limit: 0` when key values must not appear in process memory or JSON output. Reports are written to stdout unless `--markdown <path>` is provided.
 
@@ -57,13 +57,16 @@ Use a dedicated role and warehouse. The role needs:
 
 - `USAGE` on the validation warehouse and database
 - Read access only to the production relations under test
-- Permission to create and drop temporary schemas in the configured validation database
+- `SELECT` on production tables that must be zero-copy cloned
+- Permission to create temporary run-owned schemas in every database containing selected models
 
-The [enterprise setup guide](enterprise.md) contains example grants. `embrasure doctor --read-only` checks authentication and production visibility without creating a schema. A normal check must create and remove its validation schema.
+The [enterprise setup guide](enterprise.md) contains example grants. `embrasure doctor --read-only` checks authentication and production visibility without creating a schema. A normal `doctor` run also proves that a visible production table can be cloned. A normal check creates and removes candidate and baseline schemas.
+
+Incremental baselines use Snowflake table-level zero-copy clones. Embrasure never seeds them with CTAS, `INSERT`, or a local data copy. Clone metadata remains in Snowflake; only aggregate comparison results and bounded examples return to the local process.
 
 ## Schema cleanup
 
-Each run uses a unique schema name and writes an ownership marker to that schema. Cleanup requires both the expected name prefix and matching marker. The CLI refuses to drop a schema that fails either check.
+Each run uses unique candidate and baseline schema names and writes an ownership marker to every schema. Cleanup requires both the exact run namespace and matching marker. The CLI refuses to drop a schema that fails either check.
 
 Cleanup is attempted after success, findings, execution failures, Ctrl-C, and normal termination signals. No process can clean up after `SIGKILL`, a machine crash, or power loss. Administrators should periodically remove stale schemas with the configured prefix after confirming their ownership markers.
 
@@ -74,7 +77,7 @@ Releases include native archives for macOS and Linux on Intel and ARM, a `SHA256
 Verify an archive checksum:
 
 ```sh
-archive=embrasure-0.3.2-aarch64-apple-darwin.tar.gz
+archive=embrasure-0.4.0-aarch64-apple-darwin.tar.gz
 grep " ${archive}$" SHA256SUMS | shasum -a 256 --check
 ```
 

--- a/embrasure-check.example.yml
+++ b/embrasure-check.example.yml
@@ -20,6 +20,14 @@ comparison:
   concurrency: 4
   timeout_seconds: 900
 
+validation:
+  # critical is the default. Use all for complete downstream validation or none
+  # for changed models only. Full downstream impact is always reported.
+  downstream: critical
+  critical_tags: [critical]
+  # Existing incremental models start from zero-copy production clones.
+  incremental_mode: clone
+
 thresholds:
   row_count_relative: 0.001
   null_rate_absolute: 0.001
@@ -57,6 +65,13 @@ models:
   # Keys may be dbt unique IDs or model names.
   model.orders:
     primary_key: [order_id]
+    # Fail if CI has any duplicate or null keys, even when production already does.
+    # key_policy: strict
+    # Select this model as a critical downstream target without adding a dbt tag.
+    # critical: true
+    # Override only the thresholds that are intentionally different for this model.
+    # thresholds:
+    #   row_count_relative: 0.05
     # Optional: limit both CI and production scans for a large fact table.
     # where: "order_date >= DATEADD(day, -30, CURRENT_DATE)"
     # Set this only for an intentional deletion after checking reported impact.

--- a/embrasure-check.example.yml
+++ b/embrasure-check.example.yml
@@ -14,6 +14,12 @@ safety:
   max_columns_per_model: 100
   primary_key_sample_limit: 20
 
+comparison:
+  # quick estimates cardinality and skips percentiles; deep runs every metric.
+  mode: deep
+  concurrency: 4
+  timeout_seconds: 900
+
 thresholds:
   row_count_relative: 0.001
   null_rate_absolute: 0.001
@@ -51,6 +57,8 @@ models:
   # Keys may be dbt unique IDs or model names.
   model.orders:
     primary_key: [order_id]
+    # Optional: limit both CI and production scans for a large fact table.
+    # where: "order_date >= DATEADD(day, -30, CURRENT_DATE)"
     # Set this only for an intentional deletion after checking reported impact.
     # allow_removal: true
 

--- a/schemas/report-v2.schema.json
+++ b/schemas/report-v2.schema.json
@@ -1,0 +1,194 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/EmbrasureAI/embrasure-cli/schemas/report-v2.schema.json",
+  "title": "Embrasure check report v2",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version", "status", "exit_code", "base", "ci_schemas", "thresholds",
+    "summary", "validation_scope", "models", "impact", "findings", "coverage_gaps",
+    "notices", "execution_errors"
+  ],
+  "properties": {
+    "schema_version": { "const": 2 },
+    "status": { "enum": ["pass", "findings", "incomplete", "execution_failure"] },
+    "exit_code": { "enum": [0, 1, 2, 3] },
+    "base": { "type": "string" },
+    "ci_schemas": { "type": "array", "items": { "$ref": "#/$defs/ci_schema" } },
+    "thresholds": { "$ref": "#/$defs/thresholds" },
+    "summary": { "$ref": "#/$defs/summary" },
+    "validation_scope": { "$ref": "#/$defs/validation_scope" },
+    "models": { "type": "array", "items": { "$ref": "#/$defs/model" } },
+    "impact": { "$ref": "#/$defs/impact" },
+    "findings": { "type": "array", "items": { "$ref": "#/$defs/finding" } },
+    "coverage_gaps": { "type": "array", "items": { "$ref": "#/$defs/coverage_gap" } },
+    "notices": { "type": "array", "items": { "$ref": "#/$defs/notice" } },
+    "execution_errors": { "type": "array", "items": { "type": "string" } }
+  },
+  "$defs": {
+    "ci_schema": {
+      "type": "object", "additionalProperties": false,
+      "required": ["account", "database", "schema", "cleaned_up"],
+      "properties": {
+        "account": { "type": "string" }, "database": { "type": "string" },
+        "schema": { "type": "string" }, "cleaned_up": { "type": "boolean" }
+      }
+    },
+    "thresholds": {
+      "type": "object", "additionalProperties": false,
+      "required": ["row_count_relative", "null_rate_absolute", "cardinality_relative", "numeric_relative"],
+      "properties": {
+        "row_count_relative": { "type": "number", "minimum": 0 },
+        "null_rate_absolute": { "type": "number", "minimum": 0 },
+        "cardinality_relative": { "type": "number", "minimum": 0 },
+        "numeric_relative": { "type": "number", "minimum": 0 }
+      }
+    },
+    "summary": {
+      "type": "object", "additionalProperties": false,
+      "required": ["models_selected", "models_built", "models_compared", "findings", "coverage_gaps"],
+      "properties": {
+        "models_selected": { "type": "integer", "minimum": 0 },
+        "models_built": { "type": "integer", "minimum": 0 },
+        "models_compared": { "type": "integer", "minimum": 0 },
+        "findings": { "type": "integer", "minimum": 0 },
+        "coverage_gaps": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "validation_scope": {
+      "type": "object", "additionalProperties": false,
+      "required": ["downstream", "impacted_models", "requested_models", "validated_models", "skipped_models"],
+      "properties": {
+        "downstream": { "enum": ["none", "critical", "all"] },
+        "impacted_models": { "type": "integer", "minimum": 0 },
+        "requested_models": { "type": "integer", "minimum": 0 },
+        "validated_models": { "type": "array", "items": { "type": "string" } },
+        "skipped_models": { "type": "array", "items": { "$ref": "#/$defs/skipped_model" } }
+      }
+    },
+    "skipped_model": {
+      "type": "object", "additionalProperties": false,
+      "required": ["id", "reason"],
+      "properties": { "id": { "type": "string" }, "reason": { "type": "string" } }
+    },
+    "model": {
+      "type": "object", "additionalProperties": false,
+      "required": ["unique_id", "name", "account", "ci_relation", "production_relation", "dbt_build", "build_strategy", "comparison"],
+      "properties": {
+        "unique_id": { "type": "string" }, "name": { "type": "string" },
+        "account": { "type": "string" }, "ci_relation": { "type": "string" },
+        "production_relation": { "type": ["string", "null"] },
+        "dbt_build": { "enum": ["pending", "passed", "failed"] },
+        "build_strategy": { "enum": ["standard", "first_build", "incremental_clone", "full_refresh"] },
+        "comparison": { "anyOf": [{ "$ref": "#/$defs/model_comparison" }, { "type": "null" }] }
+      }
+    },
+    "model_comparison": {
+      "type": "object", "additionalProperties": false,
+      "required": ["ci_row_count", "production_row_count", "row_count_relative_change", "columns", "primary_key"],
+      "properties": {
+        "ci_row_count": { "type": "integer", "minimum": 0 },
+        "production_row_count": { "type": "integer", "minimum": 0 },
+        "row_count_relative_change": { "type": "number", "minimum": 0 },
+        "columns": { "type": "array", "items": { "$ref": "#/$defs/column_comparison" } },
+        "primary_key": { "anyOf": [{ "$ref": "#/$defs/primary_key_comparison" }, { "type": "null" }] }
+      }
+    },
+    "column_comparison": {
+      "type": "object", "additionalProperties": false,
+      "required": ["name", "ci_type", "production_type", "ci", "production"],
+      "properties": {
+        "name": { "type": "string" }, "ci_type": { "type": ["string", "null"] },
+        "production_type": { "type": ["string", "null"] },
+        "ci": { "anyOf": [{ "$ref": "#/$defs/column_metrics" }, { "type": "null" }] },
+        "production": { "anyOf": [{ "$ref": "#/$defs/column_metrics" }, { "type": "null" }] }
+      }
+    },
+    "column_metrics": {
+      "type": "object", "additionalProperties": false,
+      "required": ["null_count", "null_rate", "cardinality"],
+      "properties": {
+        "null_count": { "type": "integer", "minimum": 0 },
+        "null_rate": { "type": "number", "minimum": 0, "maximum": 1 },
+        "cardinality": { "type": "integer", "minimum": 0 },
+        "min": { "type": "string" }, "max": { "type": "string" },
+        "average": { "type": "number" }, "p05": { "type": "number" },
+        "p50": { "type": "number" }, "p95": { "type": "number" }
+      }
+    },
+    "primary_key_comparison": {
+      "type": "object", "additionalProperties": false,
+      "required": [
+        "columns", "ci_only_count", "production_only_count", "ci_only_examples",
+        "production_only_examples", "ci_duplicate_key_count", "production_duplicate_key_count",
+        "ci_duplicate_rows", "production_duplicate_rows",
+        "ci_null_key_rows", "production_null_key_rows", "ci_duplicate_examples"
+      ],
+      "properties": {
+        "columns": { "type": "array", "minItems": 1, "items": { "type": "string" } },
+        "ci_only_count": { "type": "integer", "minimum": 0 },
+        "production_only_count": { "type": "integer", "minimum": 0 },
+        "ci_only_examples": { "$ref": "#/$defs/key_examples" },
+        "production_only_examples": { "$ref": "#/$defs/key_examples" },
+        "ci_duplicate_key_count": { "type": "integer", "minimum": 0 },
+        "production_duplicate_key_count": { "type": "integer", "minimum": 0 },
+        "ci_duplicate_rows": { "type": "integer", "minimum": 0 },
+        "production_duplicate_rows": { "type": "integer", "minimum": 0 },
+        "ci_null_key_rows": { "type": "integer", "minimum": 0 },
+        "production_null_key_rows": { "type": "integer", "minimum": 0 },
+        "ci_duplicate_examples": { "$ref": "#/$defs/key_examples" }
+      }
+    },
+    "key_examples": {
+      "type": "array", "items": { "type": "array", "items": { "type": ["string", "null"] } }
+    },
+    "finding": {
+      "type": "object", "additionalProperties": false, "required": ["model", "check", "message"],
+      "properties": { "model": { "type": "string" }, "check": { "type": "string" }, "message": { "type": "string" } }
+    },
+    "coverage_gap": {
+      "type": "object", "additionalProperties": false, "required": ["scope", "check", "reason"],
+      "properties": { "scope": { "type": "string" }, "check": { "type": "string" }, "reason": { "type": "string" } }
+    },
+    "notice": {
+      "type": "object", "additionalProperties": false, "required": ["scope", "code", "message"],
+      "properties": { "scope": { "type": "string" }, "code": { "type": "string" }, "message": { "type": "string" } }
+    },
+    "asset": {
+      "type": "object", "additionalProperties": false, "required": ["id", "name"],
+      "properties": { "id": { "type": "string" }, "name": { "type": "string" }, "url": { "type": "string" } }
+    },
+    "lineage_edge": {
+      "type": "object", "additionalProperties": false, "required": ["from", "from_name", "to", "to_name"],
+      "properties": {
+        "from": { "type": "string" }, "from_name": { "type": "string" },
+        "to": { "type": "string" }, "to_name": { "type": "string" }
+      }
+    },
+    "lineage_change": {
+      "type": "object", "additionalProperties": false, "required": ["change", "edge"],
+      "properties": {
+        "change": { "enum": ["added", "removed"] }, "edge": { "$ref": "#/$defs/lineage_edge" }
+      }
+    },
+    "cross_account_dependency": {
+      "type": "object", "additionalProperties": false, "required": ["from", "to", "columns"],
+      "properties": {
+        "from": { "type": "string" }, "to": { "type": "string" },
+        "columns": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "impact": {
+      "type": "object", "additionalProperties": false,
+      "required": ["dbt_models", "dbt_exposures", "dbt_lineage", "dbt_lineage_changes", "metabase_dashboards", "cross_account_dependencies"],
+      "properties": {
+        "dbt_models": { "type": "array", "items": { "$ref": "#/$defs/asset" } },
+        "dbt_exposures": { "type": "array", "items": { "$ref": "#/$defs/asset" } },
+        "dbt_lineage": { "type": "array", "items": { "$ref": "#/$defs/lineage_edge" } },
+        "dbt_lineage_changes": { "type": "array", "items": { "$ref": "#/$defs/lineage_change" } },
+        "metabase_dashboards": { "type": "array", "items": { "$ref": "#/$defs/asset" } },
+        "cross_account_dependencies": { "type": "array", "items": { "$ref": "#/$defs/cross_account_dependency" } }
+      }
+    }
+  }
+}

--- a/src/compare.rs
+++ b/src/compare.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use anyhow::{Context, Result, bail};
 
 use crate::{
-    config::{SafetyConfig, Thresholds},
+    config::{ComparisonMode, SafetyConfig, Thresholds},
     report::{ColumnComparison, ColumnMetrics, Finding, ModelComparison, PrimaryKeyComparison},
     snowflake::{Relation, ResultColumn, SnowflakeClient, quote_identifier},
 };
@@ -13,10 +13,15 @@ pub async fn compare_model(
     model_id: &str,
     ci: &Relation,
     production: &Relation,
-    primary_key: &[String],
-    safety: &SafetyConfig,
-    thresholds: Thresholds,
+    options: CompareOptions<'_>,
 ) -> Result<(ModelComparison, Vec<Finding>)> {
+    let CompareOptions {
+        primary_key,
+        where_clause,
+        mode,
+        safety,
+        thresholds,
+    } = options;
     let ci_columns = relation_columns(client, ci)
         .await
         .with_context(|| format!("could not inspect CI relation {}", ci.sql()))?;
@@ -43,8 +48,16 @@ pub async fn compare_model(
         .cloned()
         .collect::<Vec<_>>();
 
-    let ci_metrics = relation_metrics(client, ci, &common, &ci_map).await?;
-    let prod_metrics = relation_metrics(client, production, &common, &production_map).await?;
+    let ci_metrics = relation_metrics(client, ci, &common, &ci_map, where_clause, mode).await?;
+    let prod_metrics = relation_metrics(
+        client,
+        production,
+        &common,
+        &production_map,
+        where_clause,
+        mode,
+    )
+    .await?;
     let mut findings = vec![];
     let row_change = relative_change(ci_metrics.row_count as f64, prod_metrics.row_count as f64);
     if row_change > thresholds.row_count_relative {
@@ -101,10 +114,16 @@ pub async fn compare_model(
             }
             let cardinality_change =
                 relative_change(ci_value.cardinality as f64, prod_value.cardinality as f64);
-            if cardinality_change > thresholds.cardinality_relative {
+            let cardinality_threshold = effective_cardinality_threshold(mode, thresholds);
+            if cardinality_change > cardinality_threshold {
+                let qualifier = if mode == ComparisonMode::Quick {
+                    "estimated "
+                } else {
+                    ""
+                };
                 findings.push(finding(model_id, "cardinality", format!(
-                    "column {name} cardinality is {} in CI vs {} in production (relative change {:.6}, allowed {:.6})",
-                    ci_value.cardinality, prod_value.cardinality, cardinality_change, thresholds.cardinality_relative,
+                    "column {name} {qualifier}cardinality is {} in CI vs {} in production (relative change {:.6}, allowed {:.6})",
+                    ci_value.cardinality, prod_value.cardinality, cardinality_change, cardinality_threshold,
                 )));
             }
             let numeric = ci_column.is_some_and(|column| is_numeric(&column.data_type))
@@ -178,6 +197,7 @@ pub async fn compare_model(
             production,
             &resolved_primary_key,
             safety.primary_key_sample_limit,
+            where_clause,
         )
         .await?;
         if comparison.ci_only_count > 0 || comparison.production_only_count > 0 {
@@ -212,6 +232,14 @@ pub async fn compare_model(
     ))
 }
 
+pub struct CompareOptions<'a> {
+    pub primary_key: &'a [String],
+    pub where_clause: Option<&'a str>,
+    pub mode: ComparisonMode,
+    pub safety: &'a SafetyConfig,
+    pub thresholds: Thresholds,
+}
+
 async fn relation_columns(
     client: &SnowflakeClient,
     relation: &Relation,
@@ -233,12 +261,17 @@ async fn relation_metrics(
     relation: &Relation,
     names: &[String],
     types: &BTreeMap<String, ResultColumn>,
+    where_clause: Option<&str>,
+    mode: ComparisonMode,
 ) -> Result<RelationMetrics> {
     let mut expressions = vec!["COUNT(*)".to_owned()];
     for name in names {
         let column = quote_identifier(name);
         expressions.push(format!("COUNT_IF({column} IS NULL)"));
-        expressions.push(format!("COUNT(DISTINCT {column})"));
+        expressions.push(match mode {
+            ComparisonMode::Quick => format!("APPROX_COUNT_DISTINCT({column})"),
+            ComparisonMode::Deep => format!("COUNT(DISTINCT {column})"),
+        });
         if types
             .get(name)
             .is_some_and(|value| is_orderable(&value.data_type))
@@ -253,19 +286,22 @@ async fn relation_metrics(
             .get(name)
             .is_some_and(|value| is_numeric(&value.data_type))
         {
-            expressions.extend([
-                format!("AVG({column})::DOUBLE"),
-                format!("APPROX_PERCENTILE({column}, 0.05)::DOUBLE"),
-                format!("APPROX_PERCENTILE({column}, 0.50)::DOUBLE"),
-                format!("APPROX_PERCENTILE({column}, 0.95)::DOUBLE"),
-            ]);
+            expressions.push(format!("AVG({column})::DOUBLE"));
+            if mode == ComparisonMode::Deep {
+                expressions.extend([
+                    format!("APPROX_PERCENTILE({column}, 0.05)::DOUBLE"),
+                    format!("APPROX_PERCENTILE({column}, 0.50)::DOUBLE"),
+                    format!("APPROX_PERCENTILE({column}, 0.95)::DOUBLE"),
+                ]);
+            }
         }
     }
+    let source = filtered_relation(relation, where_clause);
     let result = client
         .execute(&format!(
             "SELECT {} FROM {}",
             expressions.join(", "),
-            relation.sql()
+            source
         ))
         .await?;
     let row = result
@@ -298,10 +334,13 @@ async fn relation_metrics(
             .is_some_and(|value| is_numeric(&value.data_type))
         {
             metrics.average = parse_optional_f64(row.get(index).and_then(Option::as_deref))?;
-            metrics.p05 = parse_optional_f64(row.get(index + 1).and_then(Option::as_deref))?;
-            metrics.p50 = parse_optional_f64(row.get(index + 2).and_then(Option::as_deref))?;
-            metrics.p95 = parse_optional_f64(row.get(index + 3).and_then(Option::as_deref))?;
-            index += 4;
+            index += 1;
+            if mode == ComparisonMode::Deep {
+                metrics.p05 = parse_optional_f64(row.get(index).and_then(Option::as_deref))?;
+                metrics.p50 = parse_optional_f64(row.get(index + 1).and_then(Option::as_deref))?;
+                metrics.p95 = parse_optional_f64(row.get(index + 2).and_then(Option::as_deref))?;
+                index += 3;
+            }
         }
         columns.insert(name.clone(), metrics);
     }
@@ -314,21 +353,20 @@ async fn compare_primary_key(
     production: &Relation,
     keys: &[String],
     sample_limit: usize,
+    where_clause: Option<&str>,
 ) -> Result<PrimaryKeyComparison> {
     let selected = keys
         .iter()
         .map(|key| quote_identifier(key))
         .collect::<Vec<_>>()
         .join(", ");
+    let ci_source = filtered_relation(ci, where_clause);
+    let production_source = filtered_relation(production, where_clause);
     let ci_only = format!(
-        "SELECT {selected} FROM {} MINUS SELECT {selected} FROM {}",
-        ci.sql(),
-        production.sql()
+        "SELECT {selected} FROM {ci_source} MINUS SELECT {selected} FROM {production_source}"
     );
     let production_only = format!(
-        "SELECT {selected} FROM {} MINUS SELECT {selected} FROM {}",
-        production.sql(),
-        ci.sql()
+        "SELECT {selected} FROM {production_source} MINUS SELECT {selected} FROM {ci_source}"
     );
     let counts = client
         .execute(&format!(
@@ -368,6 +406,13 @@ async fn compare_primary_key(
         ci_only_examples: ci_examples,
         production_only_examples: production_examples,
     })
+}
+
+fn filtered_relation(relation: &Relation, where_clause: Option<&str>) -> String {
+    match where_clause {
+        Some(predicate) => format!("{} WHERE ({predicate})", relation.sql()),
+        None => relation.sql(),
+    }
 }
 
 fn column_map(columns: &[ResultColumn]) -> BTreeMap<String, ResultColumn> {
@@ -436,6 +481,14 @@ fn relative_change(current: f64, production: f64) -> f64 {
     }
 }
 
+fn effective_cardinality_threshold(mode: ComparisonMode, thresholds: Thresholds) -> f64 {
+    match mode {
+        // Snowflake's HLL estimate is fast but should not be treated as sub-percent precision.
+        ComparisonMode::Quick => thresholds.cardinality_relative.max(0.02),
+        ComparisonMode::Deep => thresholds.cardinality_relative,
+    }
+}
+
 fn parse_u64(value: Option<&str>) -> Result<u64> {
     value
         .context("Snowflake returned NULL for an integer metric")?
@@ -480,5 +533,31 @@ mod tests {
     fn non_finite_metrics_cannot_break_json_output() {
         assert!(parse_optional_f64(Some("NaN")).is_err());
         assert!(parse_optional_f64(Some("inf")).is_err());
+    }
+
+    #[test]
+    fn filters_are_applied_inside_each_relation() {
+        let relation = Relation {
+            database: "D".into(),
+            schema: "S".into(),
+            identifier: "ORDERS".into(),
+        };
+        assert_eq!(
+            filtered_relation(&relation, Some("ORDER_DATE >= CURRENT_DATE - 30")),
+            r#""D"."S"."ORDERS" WHERE (ORDER_DATE >= CURRENT_DATE - 30)"#
+        );
+    }
+
+    #[test]
+    fn quick_cardinality_has_an_estimation_margin() {
+        let thresholds = Thresholds::default();
+        assert_eq!(
+            effective_cardinality_threshold(ComparisonMode::Quick, thresholds),
+            0.02
+        );
+        assert_eq!(
+            effective_cardinality_threshold(ComparisonMode::Deep, thresholds),
+            thresholds.cardinality_relative
+        );
     }
 }

--- a/src/compare.rs
+++ b/src/compare.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use anyhow::{Context, Result, bail};
 
 use crate::{
-    config::{ComparisonMode, SafetyConfig, Thresholds},
+    config::{ComparisonMode, KeyPolicy, SafetyConfig, Thresholds},
     report::{ColumnComparison, ColumnMetrics, Finding, ModelComparison, PrimaryKeyComparison},
     snowflake::{Relation, ResultColumn, SnowflakeClient, quote_identifier},
 };
@@ -19,6 +19,7 @@ pub async fn compare_model(
         primary_key,
         where_clause,
         mode,
+        key_policy,
         safety,
         thresholds,
     } = options;
@@ -210,6 +211,25 @@ pub async fn compare_model(
                 ),
             ));
         }
+        if key_integrity_fails(&comparison, key_policy) {
+            findings.push(finding(
+                model_id,
+                "primary_key",
+                format!(
+                    "CI has {} duplicate keys ({} extra rows) and {} null-key rows vs {} ({} extra rows) and {} in production ({})",
+                    comparison.ci_duplicate_key_count,
+                    comparison.ci_duplicate_rows,
+                    comparison.ci_null_key_rows,
+                    comparison.production_duplicate_key_count,
+                    comparison.production_duplicate_rows,
+                    comparison.production_null_key_rows,
+                    match key_policy {
+                        KeyPolicy::Regression => "regressions fail",
+                        KeyPolicy::Strict => "strict policy requires zero",
+                    }
+                ),
+            ));
+        }
         Some(comparison)
     } else {
         findings.push(finding(
@@ -232,10 +252,24 @@ pub async fn compare_model(
     ))
 }
 
+fn key_integrity_fails(comparison: &PrimaryKeyComparison, policy: KeyPolicy) -> bool {
+    match policy {
+        KeyPolicy::Regression => {
+            comparison.ci_duplicate_key_count > comparison.production_duplicate_key_count
+                || comparison.ci_duplicate_rows > comparison.production_duplicate_rows
+                || comparison.ci_null_key_rows > comparison.production_null_key_rows
+        }
+        KeyPolicy::Strict => {
+            comparison.ci_duplicate_key_count > 0 || comparison.ci_null_key_rows > 0
+        }
+    }
+}
+
 pub struct CompareOptions<'a> {
     pub primary_key: &'a [String],
     pub where_clause: Option<&'a str>,
     pub mode: ComparisonMode,
+    pub key_policy: KeyPolicy,
     pub safety: &'a SafetyConfig,
     pub thresholds: Thresholds,
 }
@@ -362,15 +396,46 @@ async fn compare_primary_key(
         .join(", ");
     let ci_source = filtered_relation(ci, where_clause);
     let production_source = filtered_relation(production, where_clause);
-    let ci_only = format!(
-        "SELECT {selected} FROM {ci_source} MINUS SELECT {selected} FROM {production_source}"
+    let ci_keys = format!(
+        "SELECT {selected}, COUNT(*) AS KEY_ROWS, 1 AS PRESENT FROM {ci_source} GROUP BY {selected}"
     );
-    let production_only = format!(
-        "SELECT {selected} FROM {production_source} MINUS SELECT {selected} FROM {ci_source}"
+    let production_keys = format!(
+        "SELECT {selected}, COUNT(*) AS KEY_ROWS, 1 AS PRESENT FROM {production_source} GROUP BY {selected}"
     );
+    let join = keys
+        .iter()
+        .map(|key| {
+            let key = quote_identifier(key);
+            format!("EQUAL_NULL(C.{key}, P.{key})")
+        })
+        .collect::<Vec<_>>()
+        .join(" AND ");
+    let ci_null = keys
+        .iter()
+        .map(|key| format!("C.{} IS NULL", quote_identifier(key)))
+        .collect::<Vec<_>>()
+        .join(" OR ");
+    let production_null = keys
+        .iter()
+        .map(|key| format!("P.{} IS NULL", quote_identifier(key)))
+        .collect::<Vec<_>>()
+        .join(" OR ");
+    let ci_null_unqualified = keys
+        .iter()
+        .map(|key| format!("{} IS NULL", quote_identifier(key)))
+        .collect::<Vec<_>>()
+        .join(" OR ");
     let counts = client
         .execute(&format!(
-            "SELECT (SELECT COUNT(*) FROM ({ci_only})), (SELECT COUNT(*) FROM ({production_only}))"
+            "WITH CI_KEYS AS ({ci_keys}), PRODUCTION_KEYS AS ({production_keys}) \
+             SELECT COUNT_IF(P.PRESENT IS NULL), COUNT_IF(C.PRESENT IS NULL), \
+             COUNT_IF(C.PRESENT IS NOT NULL AND NOT ({ci_null}) AND C.KEY_ROWS > 1), \
+             COUNT_IF(P.PRESENT IS NOT NULL AND NOT ({production_null}) AND P.KEY_ROWS > 1), \
+             COALESCE(SUM(IFF(C.PRESENT IS NOT NULL AND NOT ({ci_null}), GREATEST(C.KEY_ROWS - 1, 0), 0)), 0), \
+             COALESCE(SUM(IFF(P.PRESENT IS NOT NULL AND NOT ({production_null}), GREATEST(P.KEY_ROWS - 1, 0), 0)), 0), \
+             COALESCE(SUM(IFF(C.PRESENT IS NOT NULL AND ({ci_null}), C.KEY_ROWS, 0)), 0), \
+             COALESCE(SUM(IFF(P.PRESENT IS NOT NULL AND ({production_null}), P.KEY_ROWS, 0)), 0) \
+             FROM CI_KEYS C FULL OUTER JOIN PRODUCTION_KEYS P ON {join}"
         ))
         .await?;
     let row = counts
@@ -379,12 +444,30 @@ async fn compare_primary_key(
         .context("primary-key count returned no row")?;
     let ci_only_count = parse_u64(row.first().and_then(Option::as_deref))?;
     let production_only_count = parse_u64(row.get(1).and_then(Option::as_deref))?;
+    let ci_duplicate_key_count = parse_u64(row.get(2).and_then(Option::as_deref))?;
+    let production_duplicate_key_count = parse_u64(row.get(3).and_then(Option::as_deref))?;
+    let ci_duplicate_rows = parse_u64(row.get(4).and_then(Option::as_deref))?;
+    let production_duplicate_rows = parse_u64(row.get(5).and_then(Option::as_deref))?;
+    let ci_null_key_rows = parse_u64(row.get(6).and_then(Option::as_deref))?;
+    let production_null_key_rows = parse_u64(row.get(7).and_then(Option::as_deref))?;
+    let ci_selected = keys
+        .iter()
+        .map(|key| format!("C.{}", quote_identifier(key)))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let production_selected = keys
+        .iter()
+        .map(|key| format!("P.{}", quote_identifier(key)))
+        .collect::<Vec<_>>()
+        .join(", ");
     let ci_examples = if ci_only_count == 0 {
         vec![]
     } else {
         client
             .execute(&format!(
-                "SELECT * FROM ({ci_only}) ORDER BY {selected} LIMIT {sample_limit}"
+                "WITH CI_KEYS AS ({ci_keys}), PRODUCTION_KEYS AS ({production_keys}) \
+                 SELECT {ci_selected} FROM CI_KEYS C LEFT JOIN PRODUCTION_KEYS P ON {join} \
+                 WHERE P.PRESENT IS NULL ORDER BY {ci_selected} LIMIT {sample_limit}"
             ))
             .await?
             .rows
@@ -394,7 +477,22 @@ async fn compare_primary_key(
     } else {
         client
             .execute(&format!(
-                "SELECT * FROM ({production_only}) ORDER BY {selected} LIMIT {sample_limit}"
+                "WITH CI_KEYS AS ({ci_keys}), PRODUCTION_KEYS AS ({production_keys}) \
+                 SELECT {production_selected} FROM PRODUCTION_KEYS P LEFT JOIN CI_KEYS C ON {join} \
+                 WHERE C.PRESENT IS NULL ORDER BY {production_selected} LIMIT {sample_limit}"
+            ))
+            .await?
+            .rows
+    };
+    let ci_duplicate_examples = if ci_duplicate_rows == 0 {
+        vec![]
+    } else {
+        client
+            .execute(&format!(
+                "SELECT {selected} FROM (SELECT * FROM {ci_source}) AS CI_SOURCE \
+                 WHERE NOT ({ci_null_unqualified}) \
+                 GROUP BY {selected} HAVING COUNT(*) > 1 \
+                 ORDER BY COUNT(*) DESC, {selected} LIMIT {sample_limit}"
             ))
             .await?
             .rows
@@ -405,6 +503,13 @@ async fn compare_primary_key(
         production_only_count,
         ci_only_examples: ci_examples,
         production_only_examples: production_examples,
+        ci_duplicate_key_count,
+        production_duplicate_key_count,
+        ci_duplicate_rows,
+        production_duplicate_rows,
+        ci_null_key_rows,
+        production_null_key_rows,
+        ci_duplicate_examples,
     })
 }
 
@@ -559,5 +664,78 @@ mod tests {
             effective_cardinality_threshold(ComparisonMode::Deep, thresholds),
             thresholds.cardinality_relative
         );
+    }
+
+    fn key_metrics(
+        ci_duplicate_keys: u64,
+        production_duplicate_keys: u64,
+        ci_duplicate_rows: u64,
+        production_duplicate_rows: u64,
+        ci_nulls: u64,
+        production_nulls: u64,
+    ) -> PrimaryKeyComparison {
+        PrimaryKeyComparison {
+            columns: vec!["ID".into()],
+            ci_only_count: 0,
+            production_only_count: 0,
+            ci_only_examples: vec![],
+            production_only_examples: vec![],
+            ci_duplicate_key_count: ci_duplicate_keys,
+            production_duplicate_key_count: production_duplicate_keys,
+            ci_duplicate_rows,
+            production_duplicate_rows,
+            ci_null_key_rows: ci_nulls,
+            production_null_key_rows: production_nulls,
+            ci_duplicate_examples: vec![],
+        }
+    }
+
+    #[test]
+    fn regression_policy_allows_existing_key_debt_but_not_worse_ci() {
+        assert!(!key_integrity_fails(
+            &key_metrics(1, 1, 4, 4, 2, 2),
+            KeyPolicy::Regression
+        ));
+        assert!(key_integrity_fails(
+            &key_metrics(2, 1, 4, 4, 2, 2),
+            KeyPolicy::Regression
+        ));
+        assert!(key_integrity_fails(
+            &key_metrics(1, 1, 4, 4, 3, 2),
+            KeyPolicy::Regression
+        ));
+    }
+
+    #[test]
+    fn strict_policy_requires_clean_ci_keys() {
+        assert!(key_integrity_fails(
+            &key_metrics(1, 10, 1, 20, 0, 0),
+            KeyPolicy::Strict
+        ));
+        assert!(!key_integrity_fails(
+            &key_metrics(0, 10, 0, 20, 0, 5),
+            KeyPolicy::Strict
+        ));
+    }
+
+    #[test]
+    fn key_columns_resolve_case_only_when_unambiguous() {
+        let unique = column_map(&[ResultColumn {
+            name: "ORDER_ID".into(),
+            data_type: "NUMBER".into(),
+        }]);
+        assert_eq!(resolve_column(&unique, "order_id"), Some("ORDER_ID".into()));
+
+        let ambiguous = column_map(&[
+            ResultColumn {
+                name: "ID".into(),
+                data_type: "NUMBER".into(),
+            },
+            ResultColumn {
+                name: "id".into(),
+                data_type: "NUMBER".into(),
+            },
+        ]);
+        assert_eq!(resolve_column(&ambiguous, "Id"), None);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,8 @@ pub struct Config {
     #[serde(default)]
     pub safety: SafetyConfig,
     #[serde(default)]
+    pub comparison: ComparisonConfig,
+    #[serde(default)]
     pub thresholds: Thresholds,
     pub accounts: Vec<AccountConfig>,
     #[serde(default)]
@@ -66,6 +68,35 @@ pub struct SafetyConfig {
     pub max_columns_per_model: usize,
     #[serde(default = "default_pk_limit")]
     pub primary_key_sample_limit: usize,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ComparisonConfig {
+    #[serde(default)]
+    pub mode: ComparisonMode,
+    #[serde(default = "default_comparison_concurrency")]
+    pub concurrency: usize,
+    #[serde(default = "default_comparison_timeout")]
+    pub timeout_seconds: u64,
+}
+
+impl Default for ComparisonConfig {
+    fn default() -> Self {
+        Self {
+            mode: ComparisonMode::default(),
+            concurrency: default_comparison_concurrency(),
+            timeout_seconds: default_comparison_timeout(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ComparisonMode {
+    Quick,
+    #[default]
+    Deep,
 }
 
 impl Default for SafetyConfig {
@@ -144,6 +175,9 @@ pub struct ModelConfig {
     pub primary_key: Vec<String>,
     #[serde(default)]
     pub allow_removal: bool,
+    /// Optional SQL predicate applied to both CI and production comparisons.
+    #[serde(default, rename = "where")]
+    pub where_clause: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -209,6 +243,12 @@ impl Config {
         }
         if self.safety.statement_timeout_seconds > 604_800 {
             bail!("statement timeout must not exceed Snowflake's 604800-second maximum");
+        }
+        if self.comparison.concurrency == 0 || self.comparison.concurrency > 32 {
+            bail!("comparison.concurrency must be between 1 and 32");
+        }
+        if self.comparison.timeout_seconds == 0 || self.comparison.timeout_seconds > 604_800 {
+            bail!("comparison.timeout_seconds must be between 1 and 604800");
         }
         if self.safety.schema_prefix.is_empty()
             || self.safety.schema_prefix.len() > 200
@@ -313,6 +353,19 @@ impl Config {
                 bail!("metabase.api_key_env must not be empty");
             }
         }
+        for (model, config) in &self.models {
+            if let Some(predicate) = &config.where_clause
+                && (predicate.trim().is_empty()
+                    || predicate.contains(';')
+                    || predicate.contains("--")
+                    || predicate.contains("/*")
+                    || predicate.contains("*/"))
+            {
+                bail!(
+                    "models.{model}.where must be one non-empty SQL predicate without comments or semicolons"
+                );
+            }
+        }
         Ok(())
     }
 
@@ -388,6 +441,12 @@ fn default_max_columns() -> usize {
 }
 fn default_pk_limit() -> usize {
     20
+}
+fn default_comparison_concurrency() -> usize {
+    4
+}
+fn default_comparison_timeout() -> u64 {
+    900
 }
 fn default_row_threshold() -> f64 {
     0.001
@@ -533,6 +592,42 @@ accounts:
         assert_eq!(
             private_key_path,
             &directory.path().join("config/secrets/key.p8")
+        );
+    }
+
+    #[test]
+    fn comparison_limits_and_model_filters_are_validated() {
+        let yaml = r#"
+version: 1
+comparison:
+  mode: quick
+  concurrency: 4
+  timeout_seconds: 600
+accounts:
+  - name: primary
+    account: org-account
+    user: ci
+    role: ci
+    database: analytics
+    warehouse: ci
+    production_schema: prod
+    auth: { type: oauth_local }
+models:
+  model.analytics.orders:
+    where: "order_date >= current_date - 30"
+"#;
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        config.validate().unwrap();
+        assert_eq!(config.comparison.mode, ComparisonMode::Quick);
+
+        let invalid = yaml.replace("current_date - 30", "current_date; DROP SCHEMA PROD");
+        let config: Config = serde_yaml::from_str(&invalid).unwrap();
+        assert!(
+            config
+                .validate()
+                .unwrap_err()
+                .to_string()
+                .contains("predicate")
         );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,6 +18,8 @@ pub struct Config {
     #[serde(default)]
     pub comparison: ComparisonConfig,
     #[serde(default)]
+    pub validation: ValidationConfig,
+    #[serde(default)]
     pub thresholds: Thresholds,
     pub accounts: Vec<AccountConfig>,
     #[serde(default)]
@@ -79,6 +81,44 @@ pub struct ComparisonConfig {
     pub concurrency: usize,
     #[serde(default = "default_comparison_timeout")]
     pub timeout_seconds: u64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ValidationConfig {
+    #[serde(default)]
+    pub downstream: DownstreamPolicy,
+    #[serde(default = "default_critical_tags")]
+    pub critical_tags: Vec<String>,
+    #[serde(default)]
+    pub incremental_mode: IncrementalMode,
+}
+
+impl Default for ValidationConfig {
+    fn default() -> Self {
+        Self {
+            downstream: DownstreamPolicy::default(),
+            critical_tags: default_critical_tags(),
+            incremental_mode: IncrementalMode::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum DownstreamPolicy {
+    None,
+    #[default]
+    Critical,
+    All,
+}
+
+#[derive(Debug, Clone, Copy, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum IncrementalMode {
+    #[default]
+    Clone,
+    FullRefresh,
 }
 
 impl Default for ComparisonConfig {
@@ -175,9 +215,49 @@ pub struct ModelConfig {
     pub primary_key: Vec<String>,
     #[serde(default)]
     pub allow_removal: bool,
+    #[serde(default)]
+    pub critical: bool,
+    #[serde(default)]
+    pub key_policy: KeyPolicy,
+    #[serde(default)]
+    pub thresholds: ThresholdOverrides,
     /// Optional SQL predicate applied to both CI and production comparisons.
     #[serde(default, rename = "where")]
     pub where_clause: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum KeyPolicy {
+    #[default]
+    Regression,
+    Strict,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ThresholdOverrides {
+    pub row_count_relative: Option<f64>,
+    pub null_rate_absolute: Option<f64>,
+    pub cardinality_relative: Option<f64>,
+    pub numeric_relative: Option<f64>,
+}
+
+impl ThresholdOverrides {
+    pub fn apply(&self, defaults: Thresholds) -> Thresholds {
+        Thresholds {
+            row_count_relative: self
+                .row_count_relative
+                .unwrap_or(defaults.row_count_relative),
+            null_rate_absolute: self
+                .null_rate_absolute
+                .unwrap_or(defaults.null_rate_absolute),
+            cardinality_relative: self
+                .cardinality_relative
+                .unwrap_or(defaults.cardinality_relative),
+            numeric_relative: self.numeric_relative.unwrap_or(defaults.numeric_relative),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -249,6 +329,14 @@ impl Config {
         }
         if self.comparison.timeout_seconds == 0 || self.comparison.timeout_seconds > 604_800 {
             bail!("comparison.timeout_seconds must be between 1 and 604800");
+        }
+        if self
+            .validation
+            .critical_tags
+            .iter()
+            .any(|tag| tag.trim().is_empty())
+        {
+            bail!("validation.critical_tags must not contain empty tags");
         }
         if self.safety.schema_prefix.is_empty()
             || self.safety.schema_prefix.len() > 200
@@ -365,6 +453,14 @@ impl Config {
                     "models.{model}.where must be one non-empty SQL predicate without comments or semicolons"
                 );
             }
+            let effective = config.thresholds.apply(self.thresholds);
+            if !valid_rate(effective.row_count_relative)
+                || !valid_rate(effective.null_rate_absolute)
+                || !valid_rate(effective.cardinality_relative)
+                || !valid_rate(effective.numeric_relative)
+            {
+                bail!("models.{model}.thresholds must be finite non-negative numbers");
+            }
         }
         Ok(())
     }
@@ -447,6 +543,9 @@ fn default_comparison_concurrency() -> usize {
 }
 fn default_comparison_timeout() -> u64 {
     900
+}
+fn default_critical_tags() -> Vec<String> {
+    vec!["critical".into()]
 }
 fn default_row_threshold() -> f64 {
     0.001

--- a/src/dbt.rs
+++ b/src/dbt.rs
@@ -16,7 +16,9 @@ use uuid::Uuid;
 use crate::{
     auth::ResolvedAuth,
     config::{AccountConfig, Config},
-    report::{CoverageGap, ImpactReport, ImpactedAsset},
+    report::{
+        CoverageGap, ImpactReport, ImpactedAsset, LineageChange, LineageChangeKind, LineageEdge,
+    },
 };
 
 #[derive(Debug, Clone, Deserialize)]
@@ -222,14 +224,122 @@ impl Manifest {
                 url: exposure.url.clone(),
             })
             .collect::<Vec<_>>();
+        let mut dbt_lineage = self
+            .nodes
+            .values()
+            .filter(|node| node.resource_type == "model" && downstream.contains(&node.unique_id))
+            .flat_map(|node| {
+                node.depends_on.nodes.iter().filter_map(|dependency| {
+                    let parent = self.nodes.get(dependency)?;
+                    (parent.resource_type == "model" && downstream.contains(dependency)).then(
+                        || LineageEdge {
+                            from: parent.unique_id.clone(),
+                            from_name: parent.name.clone(),
+                            to: node.unique_id.clone(),
+                            to_name: node.name.clone(),
+                        },
+                    )
+                })
+            })
+            .collect::<Vec<_>>();
+        dbt_lineage.extend(self.exposures.values().flat_map(|exposure| {
+            exposure.depends_on.nodes.iter().filter_map(|dependency| {
+                let parent = self.nodes.get(dependency)?;
+                downstream.contains(dependency).then(|| LineageEdge {
+                    from: parent.unique_id.clone(),
+                    from_name: parent.name.clone(),
+                    to: exposure.unique_id.clone(),
+                    to_name: exposure.name.clone(),
+                })
+            })
+        }));
         dbt_models.sort();
         dbt_exposures.sort();
+        dbt_lineage.sort();
         ImpactReport {
             dbt_models,
             dbt_exposures,
+            dbt_lineage,
             ..ImpactReport::default()
         }
     }
+
+    pub fn lineage_changes(&self, production: &Manifest) -> Vec<LineageChange> {
+        let current_edges = self.direct_lineage_edges();
+        let production_edges = production.direct_lineage_edges();
+        let current_keys = current_edges.keys().cloned().collect::<BTreeSet<_>>();
+        let production_keys = production_edges.keys().cloned().collect::<BTreeSet<_>>();
+        let mut changes = current_keys
+            .difference(&production_keys)
+            .filter_map(|key| current_edges.get(key))
+            .cloned()
+            .map(|edge| LineageChange {
+                change: LineageChangeKind::Added,
+                edge,
+            })
+            .chain(
+                production_keys
+                    .difference(&current_keys)
+                    .filter_map(|key| production_edges.get(key))
+                    .cloned()
+                    .map(|edge| LineageChange {
+                        change: LineageChangeKind::Removed,
+                        edge,
+                    }),
+            )
+            .collect::<Vec<_>>();
+        changes.sort();
+        changes
+    }
+
+    fn direct_lineage_edges(&self) -> BTreeMap<(String, String), LineageEdge> {
+        let mut edges = self
+            .nodes
+            .values()
+            .filter(|node| node.resource_type == "model")
+            .flat_map(|node| {
+                node.depends_on.nodes.iter().map(move |dependency| {
+                    let from_name = self
+                        .nodes
+                        .get(dependency)
+                        .map(|parent| parent.name.clone())
+                        .unwrap_or_else(|| short_dbt_name(dependency));
+                    (
+                        (dependency.clone(), node.unique_id.clone()),
+                        LineageEdge {
+                            from: dependency.clone(),
+                            from_name,
+                            to: node.unique_id.clone(),
+                            to_name: node.name.clone(),
+                        },
+                    )
+                })
+            })
+            .collect::<BTreeMap<_, _>>();
+        edges.extend(self.exposures.values().flat_map(|exposure| {
+            exposure.depends_on.nodes.iter().map(move |dependency| {
+                let from_name = self
+                    .nodes
+                    .get(dependency)
+                    .map(|parent| parent.name.clone())
+                    .unwrap_or_else(|| short_dbt_name(dependency));
+                (
+                    (dependency.clone(), exposure.unique_id.clone()),
+                    LineageEdge {
+                        from: dependency.clone(),
+                        from_name,
+                        to: exposure.unique_id.clone(),
+                        to_name: exposure.name.clone(),
+                    },
+                )
+            })
+        }));
+        edges
+    }
+}
+
+fn short_dbt_name(unique_id: &str) -> String {
+    unique_id.rsplit('.').next().unwrap_or(unique_id).to_owned()
 }
 
 pub fn prepare(
@@ -953,6 +1063,77 @@ mod tests {
             manifest.descendants(&BTreeSet::from(["a".into()])),
             BTreeSet::from(["a".into(), "b".into(), "c".into()])
         );
+    }
+
+    #[test]
+    fn impact_contains_model_and_exposure_edges() {
+        let mut summary = node("model.project.summary");
+        summary.depends_on.nodes = vec!["model.project.orders".into()];
+        let manifest = Manifest {
+            nodes: BTreeMap::from([
+                ("model.project.orders".into(), node("model.project.orders")),
+                ("model.project.summary".into(), summary),
+            ]),
+            exposures: BTreeMap::from([(
+                "exposure.project.dashboard".into(),
+                Exposure {
+                    unique_id: "exposure.project.dashboard".into(),
+                    name: "dashboard".into(),
+                    url: None,
+                    depends_on: DependsOn {
+                        nodes: vec!["model.project.summary".into()],
+                    },
+                },
+            )]),
+            child_map: BTreeMap::from([(
+                "model.project.orders".into(),
+                vec!["model.project.summary".into()],
+            )]),
+        };
+
+        let impact = manifest.impact(&BTreeSet::from(["model.project.orders".into()]));
+        assert!(impact.dbt_lineage.iter().any(|edge| {
+            edge.from == "model.project.orders" && edge.to == "model.project.summary"
+        }));
+        assert!(impact.dbt_lineage.iter().any(|edge| {
+            edge.from == "model.project.summary" && edge.to == "exposure.project.dashboard"
+        }));
+    }
+
+    #[test]
+    fn lineage_changes_compare_current_and_production_edges() {
+        let mut production_summary = node("model.project.summary");
+        production_summary.depends_on.nodes = vec!["model.project.orders".into()];
+        let production = Manifest {
+            nodes: BTreeMap::from([
+                ("model.project.orders".into(), node("model.project.orders")),
+                ("model.project.summary".into(), production_summary),
+            ]),
+            exposures: BTreeMap::new(),
+            child_map: BTreeMap::new(),
+        };
+        let mut current_summary = node("model.project.summary");
+        current_summary.depends_on.nodes = vec!["model.project.refunds".into()];
+        let current = Manifest {
+            nodes: BTreeMap::from([
+                (
+                    "model.project.refunds".into(),
+                    node("model.project.refunds"),
+                ),
+                ("model.project.summary".into(), current_summary),
+            ]),
+            exposures: BTreeMap::new(),
+            child_map: BTreeMap::new(),
+        };
+
+        let changes = current.lineage_changes(&production);
+        assert!(changes.iter().any(|change| {
+            change.change == LineageChangeKind::Added && change.edge.from == "model.project.refunds"
+        }));
+        assert!(changes.iter().any(|change| {
+            change.change == LineageChangeKind::Removed
+                && change.edge.from == "model.project.orders"
+        }));
     }
 
     #[test]

--- a/src/dbt.rs
+++ b/src/dbt.rs
@@ -16,9 +16,7 @@ use uuid::Uuid;
 use crate::{
     auth::ResolvedAuth,
     config::{AccountConfig, Config},
-    report::{
-        CoverageGap, ImpactReport, ImpactedAsset, LineageChange, LineageChangeKind, LineageEdge,
-    },
+    report::{ImpactReport, ImpactedAsset, LineageChange, LineageChangeKind, LineageEdge},
 };
 
 #[derive(Debug, Clone, Deserialize)]
@@ -40,6 +38,8 @@ pub struct ManifestNode {
     pub alias: String,
     pub fqn: Vec<String>,
     #[serde(default)]
+    pub tags: Vec<String>,
+    #[serde(default)]
     pub depends_on: DependsOn,
     #[serde(default)]
     pub config: NodeConfig,
@@ -49,6 +49,10 @@ pub struct ManifestNode {
 pub struct NodeConfig {
     #[serde(default)]
     pub quoting: QuotePolicy,
+    #[serde(default)]
+    pub materialized: String,
+    #[serde(default)]
+    pub unique_key: Option<Value>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -153,6 +157,117 @@ impl Manifest {
             }
         }
         found
+    }
+
+    pub fn model_descendants(&self, roots: &BTreeSet<String>) -> BTreeSet<String> {
+        self.descendants(roots)
+            .into_iter()
+            .filter(|id| {
+                self.nodes
+                    .get(id)
+                    .is_some_and(|node| node.resource_type == "model")
+            })
+            .collect()
+    }
+
+    pub fn critical_targets(
+        &self,
+        impacted: &BTreeSet<String>,
+        critical_tags: &BTreeSet<String>,
+        configured: &BTreeSet<String>,
+    ) -> BTreeSet<String> {
+        let mut targets = impacted
+            .iter()
+            .filter(|id| {
+                configured.contains(*id)
+                    || self
+                        .nodes
+                        .get(*id)
+                        .is_some_and(|node| node.tags.iter().any(|tag| critical_tags.contains(tag)))
+            })
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        for exposure in self.exposures.values() {
+            targets.extend(
+                exposure
+                    .depends_on
+                    .nodes
+                    .iter()
+                    .filter(|id| impacted.contains(*id))
+                    .cloned(),
+            );
+        }
+        targets
+    }
+
+    pub fn paths_between(
+        &self,
+        roots: &BTreeSet<String>,
+        targets: &BTreeSet<String>,
+    ) -> BTreeSet<String> {
+        let downstream = self.descendants(roots);
+        let mut selected = targets
+            .intersection(&downstream)
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        let mut queue = selected.iter().cloned().collect::<VecDeque<_>>();
+        while let Some(id) = queue.pop_front() {
+            let Some(node) = self.nodes.get(&id) else {
+                continue;
+            };
+            for parent in &node.depends_on.nodes {
+                if downstream.contains(parent) && selected.insert(parent.clone()) {
+                    queue.push_back(parent.clone());
+                }
+            }
+        }
+        selected.extend(
+            roots
+                .iter()
+                .filter(|id| self.nodes.contains_key(*id))
+                .cloned(),
+        );
+        selected
+            .into_iter()
+            .filter(|id| {
+                self.nodes
+                    .get(id)
+                    .is_some_and(|node| node.resource_type == "model")
+            })
+            .collect()
+    }
+
+    pub fn inferred_primary_key(&self, id: &str) -> Result<Option<Vec<String>>> {
+        let Some(value) = self
+            .nodes
+            .get(id)
+            .and_then(|node| node.config.unique_key.as_ref())
+        else {
+            return Ok(None);
+        };
+        let keys = match value {
+            Value::String(key) => vec![key.clone()],
+            Value::Array(values) => values
+                .iter()
+                .map(|value| {
+                    value
+                        .as_str()
+                        .map(ToOwned::to_owned)
+                        .context("dbt unique_key list contains a non-string value")
+                })
+                .collect::<Result<Vec<_>>>()?,
+            _ => bail!("dbt unique_key is not a string or string list"),
+        };
+        if keys.is_empty() || keys.iter().any(|key| !is_simple_identifier(key)) {
+            bail!("dbt unique_key is an expression rather than a column identifier list");
+        }
+        Ok(Some(keys))
+    }
+
+    pub fn is_incremental(&self, id: &str) -> bool {
+        self.nodes
+            .get(id)
+            .is_some_and(|node| node.config.materialized.eq_ignore_ascii_case("incremental"))
     }
 
     pub fn node_id(&self, id_or_name: &str) -> Option<String> {
@@ -548,15 +663,14 @@ impl Drop for DbtContext {
     }
 }
 
-pub fn select_models(
+pub fn select_changed_models(
     config: &Config,
     context: &DbtContext,
     account: &AccountConfig,
     changed_paths: &[String],
 ) -> Result<BTreeSet<String>> {
     let manifest = context.manifest(&account.name)?;
-    let production_manifest = context.production_manifest(&account.name)?;
-    let mut selector = String::from("state:modified+");
+    let mut selector = String::from("state:modified");
     if let Some(account_selector) = &account.selector {
         selector.push(',');
         selector.push_str(account_selector);
@@ -607,19 +721,6 @@ pub fn select_models(
     )?;
     selected.extend(manifest.model_dependencies(&unique_ids(&modified_tests)?));
 
-    let removed = production_manifest.removed_models(manifest);
-    selected.extend(
-        production_manifest
-            .descendants(&removed)
-            .into_iter()
-            .filter(|id| {
-                manifest
-                    .nodes
-                    .get(id)
-                    .is_some_and(|node| node.resource_type == "model")
-            }),
-    );
-
     for mapping in &config.external_changes {
         let matcher = Glob::new(&mapping.path)
             .with_context(|| format!("invalid external change glob {}", mapping.path))?
@@ -629,7 +730,7 @@ pub fn select_models(
                 let id = manifest.node_id(configured).with_context(|| {
                     format!("external change model {configured} is missing or ambiguous")
                 })?;
-                selected.extend(manifest.descendants(&BTreeSet::from([id])));
+                selected.insert(id);
             }
         }
     }
@@ -665,6 +766,14 @@ pub fn select_models(
     Ok(selected)
 }
 
+fn is_simple_identifier(value: &str) -> bool {
+    let mut characters = value.chars();
+    characters
+        .next()
+        .is_some_and(|character| character.is_ascii_alphabetic() || character == '_')
+        && characters.all(|character| character.is_ascii_alphanumeric() || character == '_')
+}
+
 fn unique_ids(output: &str) -> Result<BTreeSet<String>> {
     let mut ids = BTreeSet::new();
     for line in output.lines().filter(|line| !line.trim().is_empty()) {
@@ -688,6 +797,7 @@ pub fn build_models(
     context: &DbtContext,
     account: &AccountConfig,
     selected: &BTreeSet<String>,
+    full_refresh: bool,
 ) -> Result<BuildResult> {
     if selected.is_empty() {
         return Ok(BuildResult {
@@ -706,8 +816,11 @@ pub fn build_models(
         "--fail-fast".to_owned(),
         "--target-path".to_owned(),
         path_str(&target_path)?.to_owned(),
-        "--select".to_owned(),
     ];
+    if full_refresh {
+        owned.push("--full-refresh".to_owned());
+    }
+    owned.push("--select".to_owned());
     let manifest = context.manifest(&account.name)?;
     for id in selected {
         let node = manifest
@@ -818,33 +931,6 @@ pub fn ci_schema_name(prefix: &str, repo: &Path) -> Result<String> {
         timestamp,
         random.to_ascii_uppercase()
     ))
-}
-
-pub fn coverage_gaps(manifest: &Manifest, selected: &BTreeSet<String>) -> Vec<CoverageGap> {
-    selected
-        .iter()
-        .filter_map(|id| manifest.nodes.get(id))
-        .filter(|node| {
-            manifest
-                .child_map
-                .get(&node.unique_id)
-                .into_iter()
-                .flatten()
-                .any(|child| {
-                    manifest
-                        .nodes
-                        .get(child)
-                        .is_some_and(|child_node| child_node.resource_type == "model")
-                })
-        })
-        .map(|node| CoverageGap {
-            scope: node.unique_id.clone(),
-            check: "column_lineage".into(),
-            reason:
-                "dbt manifest artifacts do not contain authoritative column-level dependency edges"
-                    .into(),
-        })
-        .collect()
 }
 
 struct WorktreeRegistration {
@@ -1040,6 +1126,7 @@ mod tests {
             schema: "s".into(),
             alias: id.into(),
             fqn: vec!["test".into(), id.into()],
+            tags: vec![],
             depends_on: DependsOn::default(),
             config: NodeConfig::default(),
         }
@@ -1063,6 +1150,99 @@ mod tests {
             manifest.descendants(&BTreeSet::from(["a".into()])),
             BTreeSet::from(["a".into(), "b".into(), "c".into()])
         );
+    }
+
+    #[test]
+    fn critical_selection_keeps_every_path_through_a_diamond() {
+        let mut left = node("left");
+        left.depends_on.nodes = vec!["root".into()];
+        let mut right = node("right");
+        right.depends_on.nodes = vec!["root".into()];
+        let mut critical = node("critical");
+        critical.tags = vec!["tier_1".into()];
+        critical.depends_on.nodes = vec!["left".into(), "right".into()];
+        let manifest = Manifest {
+            nodes: BTreeMap::from([
+                ("root".into(), node("root")),
+                ("left".into(), left),
+                ("right".into(), right),
+                ("critical".into(), critical),
+            ]),
+            exposures: BTreeMap::new(),
+            child_map: BTreeMap::from([
+                ("root".into(), vec!["left".into(), "right".into()]),
+                ("left".into(), vec!["critical".into()]),
+                ("right".into(), vec!["critical".into()]),
+            ]),
+        };
+        let roots = BTreeSet::from(["root".into()]);
+        let impacted = manifest.model_descendants(&roots);
+        let targets = manifest.critical_targets(
+            &impacted,
+            &BTreeSet::from(["tier_1".into()]),
+            &BTreeSet::new(),
+        );
+        assert_eq!(
+            manifest.paths_between(&roots, &targets),
+            BTreeSet::from([
+                "root".into(),
+                "left".into(),
+                "right".into(),
+                "critical".into(),
+            ])
+        );
+    }
+
+    #[test]
+    fn models_directly_supporting_exposures_are_critical() {
+        let manifest = Manifest {
+            nodes: BTreeMap::from([("dashboard_model".into(), node("dashboard_model"))]),
+            exposures: BTreeMap::from([(
+                "exposure.dashboard".into(),
+                Exposure {
+                    unique_id: "exposure.dashboard".into(),
+                    name: "dashboard".into(),
+                    url: None,
+                    depends_on: DependsOn {
+                        nodes: vec!["dashboard_model".into()],
+                    },
+                },
+            )]),
+            child_map: BTreeMap::new(),
+        };
+        let impacted = BTreeSet::from(["dashboard_model".into()]);
+        assert_eq!(
+            manifest.critical_targets(&impacted, &BTreeSet::new(), &BTreeSet::new()),
+            impacted
+        );
+    }
+
+    #[test]
+    fn simple_dbt_unique_keys_are_inferred_but_expressions_are_rejected() {
+        let mut scalar = node("scalar");
+        scalar.config.unique_key = Some(Value::String("order_id".into()));
+        let mut composite = node("composite");
+        composite.config.unique_key = Some(serde_json::json!(["order_id", "line_id"]));
+        let mut expression = node("expression");
+        expression.config.unique_key = Some(Value::String("coalesce(order_id, -1)".into()));
+        let manifest = Manifest {
+            nodes: BTreeMap::from([
+                ("scalar".into(), scalar),
+                ("composite".into(), composite),
+                ("expression".into(), expression),
+            ]),
+            exposures: BTreeMap::new(),
+            child_map: BTreeMap::new(),
+        };
+        assert_eq!(
+            manifest.inferred_primary_key("scalar").unwrap(),
+            Some(vec!["order_id".into()])
+        );
+        assert_eq!(
+            manifest.inferred_primary_key("composite").unwrap(),
+            Some(vec!["order_id".into(), "line_id".into()])
+        );
+        assert!(manifest.inferred_primary_key("expression").is_err());
     }
 
     #[test]

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -8,7 +8,7 @@ use crate::{
     auth,
     config::Config,
     metabase,
-    snowflake::{QueryResult, SnowflakeClient, quote_identifier},
+    snowflake::{QueryResult, Relation, SnowflakeClient, quote_identifier},
 };
 
 #[derive(Debug, Serialize)]
@@ -129,6 +129,7 @@ pub async fn run(config_path: &Path, write_test: bool) -> DoctorReport {
                 continue;
             }
         }
+        let mut clone_source = None;
         let production = format!(
             "SHOW TABLES IN SCHEMA {}.{}",
             quote_identifier(&account.database),
@@ -137,6 +138,7 @@ pub async fn run(config_path: &Path, write_test: bool) -> DoctorReport {
         match client.execute(&production).await {
             Ok(tables) => {
                 let mut relations = relation_names(&tables);
+                clone_source = relations.first().cloned();
                 let views = format!(
                     "SHOW VIEWS IN SCHEMA {}.{}",
                     quote_identifier(&account.database),
@@ -187,21 +189,55 @@ pub async fn run(config_path: &Path, write_test: bool) -> DoctorReport {
                 Uuid::new_v4().simple()
             );
             match client.create_schema(&account.database, &schema).await {
-                Ok(()) => match client
-                    .drop_schema(&account.database, &schema, &schema)
-                    .await
-                {
-                    Ok(()) => report.pass(
-                        &scope,
-                        "ci_schema_lifecycle",
-                        "created and removed a temporary schema",
-                    ),
-                    Err(error) => report.fail(
-                        &scope,
-                        "ci_schema_lifecycle",
-                        format!("created {schema}, but cleanup failed: {error:#}"),
-                    ),
-                },
+                Ok(()) => {
+                    if let Some(identifier) = clone_source {
+                        let source = Relation {
+                            database: account.database.clone(),
+                            schema: account.production_schema.clone(),
+                            identifier,
+                        };
+                        let target = Relation {
+                            database: account.database.clone(),
+                            schema: schema.clone(),
+                            identifier: "EMBRASURE_CLONE_CHECK".into(),
+                        };
+                        match client.clone_table(&source, &target).await {
+                            Ok(()) => report.pass(
+                                &scope,
+                                "incremental_clone",
+                                "can zero-copy clone a production table",
+                            ),
+                            Err(error) => report.fail(
+                                &scope,
+                                "incremental_clone",
+                                format!(
+                                    "cannot clone a production table: {error:#}; confirm the relation type and update grants"
+                                ),
+                            ),
+                        }
+                    } else {
+                        report.skip(
+                            &scope,
+                            "incremental_clone",
+                            "no production table was available to test (views cannot be cloned)",
+                        );
+                    }
+                    match client
+                        .drop_schema(&account.database, &schema, &schema)
+                        .await
+                    {
+                        Ok(()) => report.pass(
+                            &scope,
+                            "ci_schema_lifecycle",
+                            "created and removed a temporary schema",
+                        ),
+                        Err(error) => report.fail(
+                            &scope,
+                            "ci_schema_lifecycle",
+                            format!("created {schema}, but cleanup failed: {error:#}"),
+                        ),
+                    }
+                }
                 Err(error) => report.fail(
                     &scope,
                     "ci_schema_lifecycle",
@@ -210,6 +246,7 @@ pub async fn run(config_path: &Path, write_test: bool) -> DoctorReport {
             }
         } else {
             report.skip(&scope, "ci_schema_lifecycle", "skipped by --read-only");
+            report.skip(&scope, "incremental_clone", "skipped by --read-only");
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ use std::{path::PathBuf, process::ExitCode};
 use clap::{Parser, Subcommand, ValueEnum};
 
 use crate::config::ComparisonMode;
+use crate::config::{DownstreamPolicy, IncrementalMode};
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
 enum ModeArg {
@@ -26,6 +27,55 @@ impl From<ModeArg> for ComparisonMode {
         match value {
             ModeArg::Quick => Self::Quick,
             ModeArg::Deep => Self::Deep,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum DownstreamArg {
+    None,
+    Critical,
+    All,
+}
+
+impl From<DownstreamArg> for DownstreamPolicy {
+    fn from(value: DownstreamArg) -> Self {
+        match value {
+            DownstreamArg::None => Self::None,
+            DownstreamArg::Critical => Self::Critical,
+            DownstreamArg::All => Self::All,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum IncrementalModeArg {
+    Clone,
+    FullRefresh,
+}
+
+impl From<IncrementalModeArg> for IncrementalMode {
+    fn from(value: IncrementalModeArg) -> Self {
+        match value {
+            IncrementalModeArg::Clone => Self::Clone,
+            IncrementalModeArg::FullRefresh => Self::FullRefresh,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum ReportVersionArg {
+    #[value(name = "1")]
+    V1,
+    #[value(name = "2")]
+    V2,
+}
+
+impl ReportVersionArg {
+    fn number(self) -> u8 {
+        match self {
+            Self::V1 => 1,
+            Self::V2 => 2,
         }
     }
 }
@@ -84,6 +134,21 @@ enum Command {
         /// Validation depth. Quick skips percentiles and estimates cardinality.
         #[arg(long, value_enum)]
         mode: Option<ModeArg>,
+        /// Downstream validation scope. Full impact is always reported.
+        #[arg(long, value_enum)]
+        downstream: Option<DownstreamArg>,
+        /// Replace configured critical tags. Repeat for multiple tags.
+        #[arg(long = "critical-tag")]
+        critical_tags: Vec<String>,
+        /// How existing incremental models are built for validation.
+        #[arg(long, value_enum)]
+        incremental_mode: Option<IncrementalModeArg>,
+        /// JSON report contract version.
+        #[arg(long, value_enum, requires = "json")]
+        report_version: Option<ReportVersionArg>,
+        /// Show every finding and impacted lineage node.
+        #[arg(long)]
+        verbose: bool,
     },
     /// Check local tools, credentials, Snowflake permissions, and optional Metabase access.
     Doctor {
@@ -170,9 +235,24 @@ async fn main() -> ExitCode {
             json,
             markdown,
             mode,
+            downstream,
+            critical_tags,
+            incremental_mode,
+            report_version,
+            verbose,
         } => {
             eprintln!("embrasure: validating changes against {base}");
-            let mut report = run::run_check(&config, &base, mode.map(Into::into)).await;
+            let mut report = run::run_check(
+                &config,
+                &base,
+                run::CheckOptions {
+                    mode: mode.map(Into::into),
+                    downstream: downstream.map(Into::into),
+                    critical_tags: (!critical_tags.is_empty()).then_some(critical_tags),
+                    incremental_mode: incremental_mode.map(Into::into),
+                },
+            )
+            .await;
             if let Some(path) = markdown
                 && let Err(error) = report.write_markdown(&path)
             {
@@ -182,7 +262,7 @@ async fn main() -> ExitCode {
                 report.finalize();
             }
             if json {
-                match serde_json::to_string_pretty(&report) {
+                match report.json(report_version.unwrap_or(ReportVersionArg::V2).number()) {
                     Ok(value) => println!("{value}"),
                     Err(error) => {
                         eprintln!("embrasure: could not serialize JSON report: {error}");
@@ -190,7 +270,7 @@ async fn main() -> ExitCode {
                     }
                 }
             } else {
-                print!("{}", report.human());
+                print!("{}", report.human(verbose));
             }
             ExitCode::from(report.exit_code)
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,24 @@ mod snowflake;
 
 use std::{path::PathBuf, process::ExitCode};
 
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
+
+use crate::config::ComparisonMode;
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum ModeArg {
+    Quick,
+    Deep,
+}
+
+impl From<ModeArg> for ComparisonMode {
+    fn from(value: ModeArg) -> Self {
+        match value {
+            ModeArg::Quick => Self::Quick,
+            ModeArg::Deep => Self::Deep,
+        }
+    }
+}
 
 #[derive(Debug, Parser)]
 #[command(
@@ -64,6 +81,9 @@ enum Command {
         /// Also write a deterministic Markdown report.
         #[arg(long, value_name = "PATH")]
         markdown: Option<PathBuf>,
+        /// Validation depth. Quick skips percentiles and estimates cardinality.
+        #[arg(long, value_enum)]
+        mode: Option<ModeArg>,
     },
     /// Check local tools, credentials, Snowflake permissions, and optional Metabase access.
     Doctor {
@@ -149,9 +169,10 @@ async fn main() -> ExitCode {
             config,
             json,
             markdown,
+            mode,
         } => {
             eprintln!("embrasure: validating changes against {base}");
-            let mut report = run::run_check(&config, &base).await;
+            let mut report = run::run_check(&config, &base, mode.map(Into::into)).await;
             if let Some(path) = markdown
                 && let Err(error) = report.write_markdown(&path)
             {

--- a/src/report.rs
+++ b/src/report.rs
@@ -3,7 +3,7 @@ use std::{fmt::Write as _, fs, path::Path};
 use anyhow::{Context, Result};
 use serde::Serialize;
 
-use crate::config::{CrossAccountDependency, Thresholds};
+use crate::config::{CrossAccountDependency, DownstreamPolicy, Thresholds};
 
 pub const EXIT_PASS: u8 = 0;
 pub const EXIT_FINDINGS: u8 = 1;
@@ -28,10 +28,12 @@ pub struct Report {
     pub ci_schemas: Vec<CiSchema>,
     pub thresholds: Thresholds,
     pub summary: Summary,
+    pub validation_scope: ValidationScope,
     pub models: Vec<ModelReport>,
     pub impact: ImpactReport,
     pub findings: Vec<Finding>,
     pub coverage_gaps: Vec<CoverageGap>,
+    pub notices: Vec<Notice>,
     pub execution_errors: Vec<String>,
 }
 
@@ -60,6 +62,7 @@ pub struct ModelReport {
     pub ci_relation: String,
     pub production_relation: Option<String>,
     pub dbt_build: String,
+    pub build_strategy: String,
     pub comparison: Option<ModelComparison>,
 }
 
@@ -107,6 +110,13 @@ pub struct PrimaryKeyComparison {
     pub production_only_count: u64,
     pub ci_only_examples: Vec<Vec<Option<String>>>,
     pub production_only_examples: Vec<Vec<Option<String>>>,
+    pub ci_duplicate_key_count: u64,
+    pub production_duplicate_key_count: u64,
+    pub ci_duplicate_rows: u64,
+    pub production_duplicate_rows: u64,
+    pub ci_null_key_rows: u64,
+    pub production_null_key_rows: u64,
+    pub ci_duplicate_examples: Vec<Vec<Option<String>>>,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq, PartialOrd, Ord)]
@@ -120,6 +130,28 @@ pub struct Finding {
 pub struct CoverageGap {
     pub scope: String,
     pub check: String,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Notice {
+    pub scope: String,
+    pub code: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct ValidationScope {
+    pub downstream: DownstreamPolicy,
+    pub impacted_models: usize,
+    pub requested_models: usize,
+    pub validated_models: Vec<String>,
+    pub skipped_models: Vec<SkippedModel>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct SkippedModel {
+    pub id: String,
     pub reason: String,
 }
 
@@ -165,17 +197,19 @@ pub struct LineageChange {
 impl Report {
     pub fn empty(base: String, thresholds: Thresholds) -> Self {
         Self {
-            schema_version: 1,
+            schema_version: 2,
             status: Status::Pass,
             exit_code: EXIT_PASS,
             base,
             ci_schemas: vec![],
             thresholds,
             summary: Summary::default(),
+            validation_scope: ValidationScope::default(),
             models: vec![],
             impact: ImpactReport::default(),
             findings: vec![],
             coverage_gaps: vec![],
+            notices: vec![],
             execution_errors: vec![],
         }
     }
@@ -190,6 +224,12 @@ impl Report {
         self.findings.dedup();
         self.coverage_gaps.sort();
         self.coverage_gaps.dedup();
+        self.notices.sort();
+        self.notices.dedup();
+        self.validation_scope.validated_models.sort();
+        self.validation_scope.validated_models.dedup();
+        self.validation_scope.skipped_models.sort();
+        self.validation_scope.skipped_models.dedup();
         self.impact.dbt_models.sort();
         self.impact.dbt_models.dedup();
         self.impact.dbt_exposures.sort();
@@ -245,7 +285,7 @@ impl Report {
             .with_context(|| format!("could not write Markdown report {}", path.display()))
     }
 
-    pub fn human(&self) -> String {
+    pub fn human(&self, verbose: bool) -> String {
         let label = match self.status {
             Status::Pass => "PASS",
             Status::Findings => "FINDINGS",
@@ -253,20 +293,17 @@ impl Report {
             Status::ExecutionFailure => "EXECUTION FAILURE",
         };
         let mut output = format!(
-            "embrasure: {label}\n{} selected · {} built · {} compared · {} findings · {} coverage gaps\n",
+            "embrasure: {label}\n{} selected · {} built · {} compared · {} findings · {} coverage gaps\n{} impacted · {} validated · {} not validated\n",
             self.summary.models_selected,
             self.summary.models_built,
             self.summary.models_compared,
             self.summary.findings,
             self.summary.coverage_gaps,
+            self.validation_scope.impacted_models,
+            self.validation_scope.validated_models.len(),
+            self.validation_scope.skipped_models.len(),
         );
-        for finding in &self.findings {
-            let _ = writeln!(
-                output,
-                "- [{}] {}: {}",
-                finding.check, finding.model, finding.message
-            );
-        }
+        self.write_human_findings(&mut output, verbose);
         for gap in &self.coverage_gaps {
             let _ = writeln!(
                 output,
@@ -277,7 +314,31 @@ impl Report {
         for error in &self.execution_errors {
             let _ = writeln!(output, "- [error] {error}");
         }
-        for model in &self.models {
+        let visible_notices = if verbose { self.notices.len() } else { 3 };
+        for notice in self.notices.iter().take(visible_notices) {
+            let _ = writeln!(
+                output,
+                "- [note:{}] {}: {}",
+                notice.code, notice.scope, notice.message
+            );
+        }
+        if self.notices.len() > visible_notices {
+            let _ = writeln!(
+                output,
+                "- {} more notices; rerun with --verbose",
+                self.notices.len() - visible_notices
+            );
+        }
+        if verbose {
+            for skipped in &self.validation_scope.skipped_models {
+                let _ = writeln!(
+                    output,
+                    "- [not-validated] {}: {}",
+                    skipped.id, skipped.reason
+                );
+            }
+        }
+        for model in self.models.iter().filter(|_| verbose) {
             if let Some(comparison) = &model.comparison {
                 let _ = writeln!(
                     output,
@@ -289,7 +350,7 @@ impl Report {
                 );
             }
         }
-        self.write_human_lineage(&mut output);
+        self.write_human_lineage(&mut output, verbose);
         if !self.impact.dbt_lineage_changes.is_empty() {
             output.push_str("Lineage changes\n");
             for change in &self.impact.dbt_lineage_changes {
@@ -317,6 +378,13 @@ impl Report {
         output
     }
 
+    pub fn json(&self, version: u8) -> serde_json::Result<String> {
+        match version {
+            1 => serde_json::to_string_pretty(&ReportV1::from(self)),
+            _ => serde_json::to_string_pretty(self),
+        }
+    }
+
     pub fn markdown(&self) -> String {
         let mut output = String::from("# Embrasure check report\n\n");
         let _ = writeln!(output, "**Status:** `{:?}`  ", self.status);
@@ -331,6 +399,35 @@ impl Report {
             self.summary.findings,
             self.summary.coverage_gaps,
         );
+        output.push_str("## Validation scope\n\n");
+        let _ = writeln!(
+            output,
+            "- Downstream policy: `{:?}`",
+            self.validation_scope.downstream
+        );
+        let _ = writeln!(
+            output,
+            "- Impacted models: `{}`",
+            self.validation_scope.impacted_models
+        );
+        let _ = writeln!(
+            output,
+            "- Requested models: `{}`",
+            self.validation_scope.requested_models
+        );
+        let _ = writeln!(
+            output,
+            "- Validated models: `{}`",
+            self.validation_scope.validated_models.len()
+        );
+        for skipped in &self.validation_scope.skipped_models {
+            let _ = writeln!(
+                output,
+                "- Not validated: `{}` — {}",
+                skipped.id, skipped.reason
+            );
+        }
+        output.push('\n');
         output.push_str("## Findings\n\n");
         if self.findings.is_empty() {
             output.push_str("None.\n\n");
@@ -353,6 +450,17 @@ impl Report {
                 gap.scope, gap.check, gap.reason
             );
         }
+        output.push_str("\n## Notices\n\n");
+        if self.notices.is_empty() {
+            output.push_str("None.\n\n");
+        }
+        for notice in &self.notices {
+            let _ = writeln!(
+                output,
+                "- **{} · {}:** {}",
+                notice.scope, notice.code, notice.message
+            );
+        }
         output.push_str("\n## Model evidence\n\n");
         if self.models.is_empty() {
             output.push_str("No models selected.\n\n");
@@ -360,6 +468,7 @@ impl Report {
         for model in &self.models {
             let _ = writeln!(output, "### `{}` ({})\n", model.unique_id, model.account);
             let _ = writeln!(output, "- dbt build: `{}`", model.dbt_build);
+            let _ = writeln!(output, "- Build strategy: `{}`", model.build_strategy);
             let _ = writeln!(output, "- CI relation: `{}`", model.ci_relation);
             if let Some(relation) = &model.production_relation {
                 let _ = writeln!(output, "- Production relation: `{relation}`");
@@ -462,7 +571,42 @@ impl Report {
         output
     }
 
-    fn write_human_lineage(&self, output: &mut String) {
+    fn write_human_findings(&self, output: &mut String, verbose: bool) {
+        use std::collections::BTreeMap;
+
+        let mut prioritized = self.findings.iter().collect::<Vec<_>>();
+        prioritized.sort_by_key(|finding| {
+            (
+                finding_priority(&finding.check),
+                &finding.model,
+                &finding.check,
+            )
+        });
+        let visible = if verbose {
+            prioritized.len()
+        } else {
+            prioritized.len().min(3)
+        };
+        let mut grouped = BTreeMap::<&str, Vec<&Finding>>::new();
+        for finding in prioritized.iter().take(visible) {
+            grouped.entry(&finding.model).or_default().push(finding);
+        }
+        for (model, findings) in grouped {
+            let _ = writeln!(output, "- {model}:");
+            for finding in findings {
+                let _ = writeln!(output, "  - [{}] {}", finding.check, finding.message);
+            }
+        }
+        if self.findings.len() > visible {
+            let _ = writeln!(
+                output,
+                "- {} more findings; rerun with --verbose",
+                self.findings.len() - visible
+            );
+        }
+    }
+
+    fn write_human_lineage(&self, output: &mut String, verbose: bool) {
         if self.impact.dbt_models.is_empty() && self.impact.dbt_exposures.is_empty() {
             return;
         }
@@ -505,16 +649,44 @@ impl Report {
         }
 
         output.push_str("Lineage impact\n");
-        let mut rendered = BTreeSet::new();
+        let mut state = LineageRenderState {
+            rendered: BTreeSet::new(),
+            count: 0,
+            limit: if verbose { usize::MAX } else { 20 },
+        };
         for root in roots {
-            write_lineage_node(output, root, "  ", None, &names, &children, &mut rendered);
+            write_lineage_node(output, root, "  ", None, &names, &children, &mut state);
         }
         for asset in &self.impact.dbt_exposures {
-            if rendered.insert(asset.id.as_str()) {
+            if state.count < state.limit && state.rendered.insert(asset.id.as_str()) {
                 let _ = writeln!(output, "  exposure: {}", asset.name);
+                state.count += 1;
             }
         }
+        let total = self.impact.dbt_models.len() + self.impact.dbt_exposures.len();
+        if state.count < total {
+            let _ = writeln!(
+                output,
+                "  ... {} more; rerun with --verbose",
+                total - state.count
+            );
+        }
     }
+}
+
+fn finding_priority(check: &str) -> u8 {
+    match check {
+        "model_removed" | "dbt_build" | "dbt_test" | "primary_key" => 0,
+        "column_removed" | "column_type" | "column_added" => 1,
+        "row_count" | "null_rate" => 2,
+        _ => 3,
+    }
+}
+
+struct LineageRenderState<'a> {
+    rendered: std::collections::BTreeSet<&'a str>,
+    count: usize,
+    limit: usize,
 }
 
 fn write_lineage_node<'a>(
@@ -524,8 +696,11 @@ fn write_lineage_node<'a>(
     connector: Option<&str>,
     names: &std::collections::BTreeMap<&'a str, &'a str>,
     children: &std::collections::BTreeMap<&'a str, Vec<&'a LineageEdge>>,
-    rendered: &mut std::collections::BTreeSet<&'a str>,
+    state: &mut LineageRenderState<'a>,
 ) {
+    if state.count >= state.limit {
+        return;
+    }
     let label = names.get(id).copied().unwrap_or(id);
     let kind = if id.starts_with("exposure.") {
         "exposure: "
@@ -537,7 +712,8 @@ fn write_lineage_node<'a>(
         "{prefix}{}{kind}{label}",
         connector.unwrap_or_default()
     );
-    if !rendered.insert(id) {
+    state.count += 1;
+    if !state.rendered.insert(id) {
         return;
     }
     let edges = children.get(id).map(Vec::as_slice).unwrap_or_default();
@@ -559,8 +735,116 @@ fn write_lineage_node<'a>(
             Some(child_connector),
             names,
             children,
-            rendered,
+            state,
         );
+    }
+}
+
+#[derive(Serialize)]
+struct ReportV1<'a> {
+    schema_version: u8,
+    status: Status,
+    exit_code: u8,
+    base: &'a str,
+    ci_schemas: &'a [CiSchema],
+    thresholds: Thresholds,
+    summary: &'a Summary,
+    models: Vec<ModelReportV1<'a>>,
+    impact: ImpactReportV1<'a>,
+    findings: &'a [Finding],
+    coverage_gaps: &'a [CoverageGap],
+    execution_errors: &'a [String],
+}
+
+#[derive(Serialize)]
+struct ModelReportV1<'a> {
+    unique_id: &'a str,
+    name: &'a str,
+    account: &'a str,
+    ci_relation: &'a str,
+    production_relation: &'a Option<String>,
+    dbt_build: &'a str,
+    comparison: Option<ModelComparisonV1<'a>>,
+}
+
+#[derive(Serialize)]
+struct ModelComparisonV1<'a> {
+    ci_row_count: u64,
+    production_row_count: u64,
+    row_count_relative_change: f64,
+    columns: &'a [ColumnComparison],
+    primary_key: Option<PrimaryKeyComparisonV1<'a>>,
+}
+
+#[derive(Serialize)]
+struct PrimaryKeyComparisonV1<'a> {
+    columns: &'a [String],
+    ci_only_count: u64,
+    production_only_count: u64,
+    ci_only_examples: &'a [Vec<Option<String>>],
+    production_only_examples: &'a [Vec<Option<String>>],
+}
+
+#[derive(Serialize)]
+struct ImpactReportV1<'a> {
+    dbt_models: &'a [ImpactedAsset],
+    dbt_exposures: &'a [ImpactedAsset],
+    metabase_dashboards: &'a [ImpactedAsset],
+    cross_account_dependencies: &'a [CrossAccountDependency],
+}
+
+impl<'a> From<&'a Report> for ReportV1<'a> {
+    fn from(report: &'a Report) -> Self {
+        Self {
+            schema_version: 1,
+            status: report.status,
+            exit_code: report.exit_code,
+            base: &report.base,
+            ci_schemas: &report.ci_schemas,
+            thresholds: report.thresholds,
+            summary: &report.summary,
+            models: report.models.iter().map(ModelReportV1::from).collect(),
+            impact: ImpactReportV1 {
+                dbt_models: &report.impact.dbt_models,
+                dbt_exposures: &report.impact.dbt_exposures,
+                metabase_dashboards: &report.impact.metabase_dashboards,
+                cross_account_dependencies: &report.impact.cross_account_dependencies,
+            },
+            findings: &report.findings,
+            coverage_gaps: &report.coverage_gaps,
+            execution_errors: &report.execution_errors,
+        }
+    }
+}
+
+impl<'a> From<&'a ModelReport> for ModelReportV1<'a> {
+    fn from(model: &'a ModelReport) -> Self {
+        Self {
+            unique_id: &model.unique_id,
+            name: &model.name,
+            account: &model.account,
+            ci_relation: &model.ci_relation,
+            production_relation: &model.production_relation,
+            dbt_build: &model.dbt_build,
+            comparison: model
+                .comparison
+                .as_ref()
+                .map(|comparison| ModelComparisonV1 {
+                    ci_row_count: comparison.ci_row_count,
+                    production_row_count: comparison.production_row_count,
+                    row_count_relative_change: comparison.row_count_relative_change,
+                    columns: &comparison.columns,
+                    primary_key: comparison.primary_key.as_ref().map(|key| {
+                        PrimaryKeyComparisonV1 {
+                            columns: &key.columns,
+                            ci_only_count: key.ci_only_count,
+                            production_only_count: key.production_only_count,
+                            ci_only_examples: &key.ci_only_examples,
+                            production_only_examples: &key.production_only_examples,
+                        }
+                    }),
+                }),
+        }
     }
 }
 
@@ -581,6 +865,70 @@ fn optional_number(value: Option<f64>) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn representative_report() -> Report {
+        let mut report = Report::empty("main".into(), Thresholds::default());
+        report.validation_scope.downstream = DownstreamPolicy::Critical;
+        report.validation_scope.impacted_models = 2;
+        report.validation_scope.requested_models = 1;
+        report.validation_scope.validated_models = vec!["primary:model.project.orders".into()];
+        report.validation_scope.skipped_models = vec![SkippedModel {
+            id: "primary:model.project.other".into(),
+            reason: "outside policy".into(),
+        }];
+        report.models.push(ModelReport {
+            unique_id: "model.project.orders".into(),
+            name: "orders".into(),
+            account: "primary".into(),
+            ci_relation: r#""DB"."CI"."ORDERS""#.into(),
+            production_relation: Some(r#""DB"."PROD"."ORDERS""#.into()),
+            dbt_build: "passed".into(),
+            build_strategy: "incremental_clone".into(),
+            comparison: Some(ModelComparison {
+                ci_row_count: 10,
+                production_row_count: 9,
+                row_count_relative_change: 1.0 / 9.0,
+                columns: vec![ColumnComparison {
+                    name: "ID".into(),
+                    ci_type: Some("NUMBER".into()),
+                    production_type: Some("NUMBER".into()),
+                    ci: Some(ColumnMetrics::default()),
+                    production: Some(ColumnMetrics::default()),
+                }],
+                primary_key: Some(PrimaryKeyComparison {
+                    columns: vec!["ID".into()],
+                    ci_only_count: 1,
+                    production_only_count: 0,
+                    ci_only_examples: vec![vec![Some("10".into())]],
+                    production_only_examples: vec![],
+                    ci_duplicate_key_count: 1,
+                    production_duplicate_key_count: 0,
+                    ci_duplicate_rows: 1,
+                    production_duplicate_rows: 0,
+                    ci_null_key_rows: 0,
+                    production_null_key_rows: 0,
+                    ci_duplicate_examples: vec![vec![Some("10".into())]],
+                }),
+            }),
+        });
+        report.notices.push(Notice {
+            scope: "model.project.orders".into(),
+            code: "incremental_history_not_recomputed".into(),
+            message: "historical rows were not recomputed".into(),
+        });
+        report.finalize();
+        report
+    }
+
+    fn assert_matches_schema(report: &Report, version: u8, schema: &str) {
+        let schema: serde_json::Value = serde_json::from_str(schema).unwrap();
+        let validator = jsonschema::validator_for(&schema).unwrap();
+        let instance: serde_json::Value =
+            serde_json::from_str(&report.json(version).unwrap()).unwrap();
+        if let Err(error) = validator.validate(&instance) {
+            panic!("report v{version} violates its schema: {error}");
+        }
+    }
 
     #[test]
     fn coverage_is_distinct_from_findings() {
@@ -629,8 +977,54 @@ mod tests {
         });
         report.finalize();
 
-        let output = report.human();
+        let output = report.human(false);
         assert!(output.contains("Lineage impact\n  orders\n  └─ order_summary"));
         assert!(output.contains("Lineage changes\n  + orders -> order_summary"));
+    }
+
+    #[test]
+    fn reports_match_their_published_json_schemas() {
+        let report = representative_report();
+        assert_matches_schema(&report, 1, include_str!("../schemas/report-v1.schema.json"));
+        assert_matches_schema(&report, 2, include_str!("../schemas/report-v2.schema.json"));
+
+        let v1: serde_json::Value = serde_json::from_str(&report.json(1).unwrap()).unwrap();
+        assert!(v1.get("validation_scope").is_none());
+        assert!(v1["models"][0].get("build_strategy").is_none());
+        assert!(
+            v1["models"][0]["comparison"]["primary_key"]
+                .get("ci_duplicate_rows")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn compact_terminal_output_caps_findings_and_lineage() {
+        let mut report = Report::empty("main".into(), Thresholds::default());
+        for index in 0..5 {
+            report.findings.push(Finding {
+                model: format!("model.project.m{index}"),
+                check: "row_count".into(),
+                message: format!("change {index}"),
+            });
+        }
+        for index in 0..25 {
+            report.impact.dbt_models.push(ImpactedAsset {
+                id: format!("model.project.lineage_{index:02}"),
+                name: format!("lineage_{index:02}"),
+                url: None,
+            });
+        }
+        report.finalize();
+
+        let compact = report.human(false);
+        assert!(compact.contains("2 more findings; rerun with --verbose"));
+        assert!(!compact.contains("change 3"));
+        assert!(compact.contains("... 5 more; rerun with --verbose"));
+        assert!(!compact.contains("lineage_20"));
+
+        let verbose = report.human(true);
+        assert!(verbose.contains("change 4"));
+        assert!(verbose.contains("lineage_24"));
     }
 }

--- a/src/report.rs
+++ b/src/report.rs
@@ -127,6 +127,8 @@ pub struct CoverageGap {
 pub struct ImpactReport {
     pub dbt_models: Vec<ImpactedAsset>,
     pub dbt_exposures: Vec<ImpactedAsset>,
+    pub dbt_lineage: Vec<LineageEdge>,
+    pub dbt_lineage_changes: Vec<LineageChange>,
     pub metabase_dashboards: Vec<ImpactedAsset>,
     pub cross_account_dependencies: Vec<CrossAccountDependency>,
 }
@@ -137,6 +139,27 @@ pub struct ImpactedAsset {
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct LineageEdge {
+    pub from: String,
+    pub from_name: String,
+    pub to: String,
+    pub to_name: String,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "snake_case")]
+pub enum LineageChangeKind {
+    Added,
+    Removed,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct LineageChange {
+    pub change: LineageChangeKind,
+    pub edge: LineageEdge,
 }
 
 impl Report {
@@ -171,6 +194,10 @@ impl Report {
         self.impact.dbt_models.dedup();
         self.impact.dbt_exposures.sort();
         self.impact.dbt_exposures.dedup();
+        self.impact.dbt_lineage.sort();
+        self.impact.dbt_lineage.dedup();
+        self.impact.dbt_lineage_changes.sort();
+        self.impact.dbt_lineage_changes.dedup();
         self.impact.metabase_dashboards.sort();
         self.impact.metabase_dashboards.dedup();
         for dependency in &mut self.impact.cross_account_dependencies {
@@ -262,11 +289,20 @@ impl Report {
                 );
             }
         }
-        for asset in &self.impact.dbt_models {
-            let _ = writeln!(output, "- [impact:dbt] {}", asset.id);
-        }
-        for asset in &self.impact.dbt_exposures {
-            let _ = writeln!(output, "- [impact:exposure] {}", asset.id);
+        self.write_human_lineage(&mut output);
+        if !self.impact.dbt_lineage_changes.is_empty() {
+            output.push_str("Lineage changes\n");
+            for change in &self.impact.dbt_lineage_changes {
+                let marker = match change.change {
+                    LineageChangeKind::Added => "+",
+                    LineageChangeKind::Removed => "-",
+                };
+                let _ = writeln!(
+                    output,
+                    "  {marker} {} -> {}",
+                    change.edge.from_name, change.edge.to_name
+                );
+            }
         }
         for asset in &self.impact.metabase_dashboards {
             let _ = writeln!(output, "- [impact:metabase] {}", asset.name);
@@ -403,6 +439,20 @@ impl Report {
                 dependency.from, dependency.to
             );
         }
+        if !self.impact.dbt_lineage_changes.is_empty() {
+            output.push_str("\n## Lineage changes\n\n");
+            for change in &self.impact.dbt_lineage_changes {
+                let label = match change.change {
+                    LineageChangeKind::Added => "Added",
+                    LineageChangeKind::Removed => "Removed",
+                };
+                let _ = writeln!(
+                    output,
+                    "- **{label}:** `{}` → `{}`",
+                    change.edge.from_name, change.edge.to_name
+                );
+            }
+        }
         if !self.execution_errors.is_empty() {
             output.push_str("\n## Execution errors\n\n");
             for error in &self.execution_errors {
@@ -410,6 +460,107 @@ impl Report {
             }
         }
         output
+    }
+
+    fn write_human_lineage(&self, output: &mut String) {
+        if self.impact.dbt_models.is_empty() && self.impact.dbt_exposures.is_empty() {
+            return;
+        }
+
+        use std::collections::{BTreeMap, BTreeSet};
+
+        let model_ids = self
+            .impact
+            .dbt_models
+            .iter()
+            .map(|asset| asset.id.as_str())
+            .collect::<BTreeSet<_>>();
+        let mut names = self
+            .impact
+            .dbt_models
+            .iter()
+            .chain(&self.impact.dbt_exposures)
+            .map(|asset| (asset.id.as_str(), asset.name.as_str()))
+            .collect::<BTreeMap<_, _>>();
+        let mut children = BTreeMap::<&str, Vec<&LineageEdge>>::new();
+        let mut model_children = BTreeSet::new();
+        for edge in &self.impact.dbt_lineage {
+            names.entry(&edge.from).or_insert(&edge.from_name);
+            names.entry(&edge.to).or_insert(&edge.to_name);
+            children.entry(&edge.from).or_default().push(edge);
+            if model_ids.contains(edge.to.as_str()) {
+                model_children.insert(edge.to.as_str());
+            }
+        }
+
+        let mut roots = self
+            .impact
+            .dbt_models
+            .iter()
+            .filter(|asset| !model_children.contains(asset.id.as_str()))
+            .map(|asset| asset.id.as_str())
+            .collect::<Vec<_>>();
+        if roots.is_empty() {
+            roots.extend(model_ids.iter().copied());
+        }
+
+        output.push_str("Lineage impact\n");
+        let mut rendered = BTreeSet::new();
+        for root in roots {
+            write_lineage_node(output, root, "  ", None, &names, &children, &mut rendered);
+        }
+        for asset in &self.impact.dbt_exposures {
+            if rendered.insert(asset.id.as_str()) {
+                let _ = writeln!(output, "  exposure: {}", asset.name);
+            }
+        }
+    }
+}
+
+fn write_lineage_node<'a>(
+    output: &mut String,
+    id: &'a str,
+    prefix: &str,
+    connector: Option<&str>,
+    names: &std::collections::BTreeMap<&'a str, &'a str>,
+    children: &std::collections::BTreeMap<&'a str, Vec<&'a LineageEdge>>,
+    rendered: &mut std::collections::BTreeSet<&'a str>,
+) {
+    let label = names.get(id).copied().unwrap_or(id);
+    let kind = if id.starts_with("exposure.") {
+        "exposure: "
+    } else {
+        ""
+    };
+    let _ = writeln!(
+        output,
+        "{prefix}{}{kind}{label}",
+        connector.unwrap_or_default()
+    );
+    if !rendered.insert(id) {
+        return;
+    }
+    let edges = children.get(id).map(Vec::as_slice).unwrap_or_default();
+    let child_prefix = match connector {
+        Some("├─ ") => format!("{prefix}│  "),
+        Some(_) => format!("{prefix}   "),
+        None => prefix.to_owned(),
+    };
+    for (index, edge) in edges.iter().enumerate() {
+        let child_connector = if index + 1 == edges.len() {
+            "└─ "
+        } else {
+            "├─ "
+        };
+        write_lineage_node(
+            output,
+            &edge.to,
+            &child_prefix,
+            Some(child_connector),
+            names,
+            children,
+            rendered,
+        );
     }
 }
 
@@ -448,5 +599,38 @@ mod tests {
         });
         report.finalize();
         assert_eq!(report.exit_code, EXIT_FINDINGS);
+    }
+
+    #[test]
+    fn human_report_shows_lineage_tree_and_dependency_changes() {
+        let mut report = Report::empty("main".into(), Thresholds::default());
+        report.impact.dbt_models = vec![
+            ImpactedAsset {
+                id: "model.project.orders".into(),
+                name: "orders".into(),
+                url: None,
+            },
+            ImpactedAsset {
+                id: "model.project.order_summary".into(),
+                name: "order_summary".into(),
+                url: None,
+            },
+        ];
+        let edge = LineageEdge {
+            from: "model.project.orders".into(),
+            from_name: "orders".into(),
+            to: "model.project.order_summary".into(),
+            to_name: "order_summary".into(),
+        };
+        report.impact.dbt_lineage.push(edge.clone());
+        report.impact.dbt_lineage_changes.push(LineageChange {
+            change: LineageChangeKind::Added,
+            edge,
+        });
+        report.finalize();
+
+        let output = report.human();
+        assert!(output.contains("Lineage impact\n  orders\n  └─ order_summary"));
+        assert!(output.contains("Lineage changes\n  + orders -> order_summary"));
     }
 }

--- a/src/run.rs
+++ b/src/run.rs
@@ -1,4 +1,8 @@
-use std::{collections::BTreeSet, path::Path, time::Duration};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    path::Path,
+    time::Duration,
+};
 
 use anyhow::{Context, Result, bail};
 use tokio::{task::JoinSet, time::timeout};
@@ -7,18 +11,17 @@ use uuid::Uuid;
 use crate::{
     auth,
     compare::{CompareOptions, compare_model},
-    config::{ComparisonMode, Config, ModelConfig, SafetyConfig, Thresholds},
+    config::{
+        ComparisonMode, Config, DownstreamPolicy, IncrementalMode, ModelConfig, SafetyConfig,
+        Thresholds,
+    },
     dbt::{self, DbtContext, ManifestNode},
     metabase,
-    report::{CiSchema, CoverageGap, Finding, ModelReport, Report},
+    report::{CiSchema, CoverageGap, Finding, ModelReport, Notice, Report, SkippedModel},
     snowflake::{Relation, SnowflakeClient, is_managed_schema},
 };
 
-pub async fn run_check(
-    config_path: &Path,
-    base: &str,
-    mode_override: Option<ComparisonMode>,
-) -> Report {
+pub async fn run_check(config_path: &Path, base: &str, options: CheckOptions) -> Report {
     if base.trim().is_empty() || base.starts_with('-') {
         return error_report(
             base,
@@ -29,19 +32,40 @@ pub async fn run_check(
         Ok(config) => config,
         Err(error) => return error_report(base, error),
     };
-    if let Some(mode) = mode_override {
+    if let Some(mode) = options.mode {
         config.comparison.mode = mode;
+    }
+    if let Some(downstream) = options.downstream {
+        config.validation.downstream = downstream;
+    }
+    if let Some(tags) = options.critical_tags {
+        if tags.iter().any(|tag| tag.trim().is_empty()) {
+            return error_report(base, anyhow::anyhow!("--critical-tag must not be empty"));
+        }
+        config.validation.critical_tags = tags;
+    }
+    if let Some(mode) = options.incremental_mode {
+        config.validation.incremental_mode = mode;
     }
     if let Err(error) = config.resolve_from(config_path) {
         return error_report(base, error);
     }
     let mut report = Report::empty(base.to_owned(), config.thresholds);
+    report.validation_scope.downstream = config.validation.downstream;
     let run_result = execute(&config, base, &mut report).await;
     if let Err(error) = run_result {
         report.execution_errors.push(format_error(&error));
     }
     report.finalize();
     report
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct CheckOptions {
+    pub mode: Option<ComparisonMode>,
+    pub downstream: Option<DownstreamPolicy>,
+    pub critical_tags: Option<Vec<String>>,
+    pub incremental_mode: Option<IncrementalMode>,
 }
 
 async fn execute(config: &Config, base: &str, report: &mut Report) -> Result<()> {
@@ -67,24 +91,29 @@ async fn execute(config: &Config, base: &str, report: &mut Report) -> Result<()>
                     format!("could not initialize Snowflake account {}", account.name)
                 })?;
                 clients.push(client);
-                report.ci_schemas.push(CiSchema {
-                    account: account.name.clone(),
-                    database: account.database.clone(),
-                    schema: schema.clone(),
-                    cleaned_up: false,
-                });
-                clients
-                    .last()
-                    .context("internal error: Snowflake client was not retained for cleanup")?
-                    .create_schema(&account.database, &schema)
-                    .await
-                    .with_context(|| {
-                        format!("could not create CI schema for account {}", account.name)
-                    })?;
             }
 
             let mut context = dbt::prepare(config, &resolved_auth, base, &schema, &query_tag)?;
-            let result = execute_with_dbt(config, &mut context, &clients, &schema, report).await;
+            let selections = plan_selections(config, &context, report)?;
+            let result = if let Some(selections) = selections {
+                for (index, account) in config.accounts.iter().enumerate() {
+                    report.ci_schemas.push(CiSchema {
+                        account: account.name.clone(),
+                        database: account.database.clone(),
+                        schema: schema.clone(),
+                        cleaned_up: false,
+                    });
+                    clients[index]
+                        .create_schema(&account.database, &schema)
+                        .await
+                        .with_context(|| {
+                            format!("could not create CI schema for account {}", account.name)
+                        })?;
+                }
+                execute_with_dbt(config, &mut context, &clients, &schema, &selections, report).await
+            } else {
+                Ok(())
+            };
             if let Err(error) = context.cleanup_worktree() {
                 report
                     .execution_errors
@@ -107,6 +136,152 @@ async fn execute(config: &Config, base: &str, report: &mut Report) -> Result<()>
     }
     cleanup_schemas(config, &clients, &schema, report).await;
     Ok(())
+}
+
+#[derive(Debug, Clone)]
+struct AccountSelection {
+    selected: BTreeSet<String>,
+    removed: BTreeSet<String>,
+}
+
+fn plan_selections(
+    config: &Config,
+    context: &DbtContext,
+    report: &mut Report,
+) -> Result<Option<Vec<AccountSelection>>> {
+    let changed_paths = context.changed_paths(&report.base)?;
+    let critical_tags = config
+        .validation
+        .critical_tags
+        .iter()
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let mut selections = Vec::new();
+    let mut selected_count = 0;
+    for account in &config.accounts {
+        let manifest = context.manifest(&account.name)?;
+        let production = context.production_manifest(&account.name)?;
+        report
+            .impact
+            .dbt_lineage_changes
+            .extend(manifest.lineage_changes(production));
+        let changed = dbt::select_changed_models(config, context, account, &changed_paths)
+            .with_context(|| format!("could not select dbt models for account {}", account.name))?;
+        let removed = production.removed_models(manifest);
+        let current_impacted = manifest.model_descendants(&changed);
+        let removed_impacted = production.model_descendants(&removed);
+        let surviving_removed_impact = removed_impacted
+            .iter()
+            .filter(|id| manifest.nodes.contains_key(*id))
+            .cloned()
+            .collect::<BTreeSet<_>>();
+
+        let current_impact = manifest.impact(&changed);
+        report.impact.dbt_models.extend(current_impact.dbt_models);
+        report
+            .impact
+            .dbt_exposures
+            .extend(current_impact.dbt_exposures);
+        report.impact.dbt_lineage.extend(current_impact.dbt_lineage);
+        let removal_impact = production.impact(&removed);
+        report.impact.dbt_models.extend(removal_impact.dbt_models);
+        report
+            .impact
+            .dbt_exposures
+            .extend(removal_impact.dbt_exposures);
+        report.impact.dbt_lineage.extend(removal_impact.dbt_lineage);
+
+        let configured_critical = manifest
+            .nodes
+            .values()
+            .filter(|node| {
+                node.resource_type == "model"
+                    && model_config(config, &node.unique_id, &node.name).critical
+            })
+            .map(|node| node.unique_id.clone())
+            .collect::<BTreeSet<_>>();
+        let production_configured_critical = production
+            .nodes
+            .values()
+            .filter(|node| {
+                node.resource_type == "model"
+                    && model_config(config, &node.unique_id, &node.name).critical
+            })
+            .map(|node| node.unique_id.clone())
+            .collect::<BTreeSet<_>>();
+        let selected = match config.validation.downstream {
+            DownstreamPolicy::None => changed.clone(),
+            DownstreamPolicy::All => current_impacted
+                .union(&surviving_removed_impact)
+                .cloned()
+                .collect(),
+            DownstreamPolicy::Critical => {
+                let current_targets = manifest.critical_targets(
+                    &current_impacted,
+                    &critical_tags,
+                    &configured_critical,
+                );
+                let mut selected = manifest.paths_between(&changed, &current_targets);
+                let production_targets = production.critical_targets(
+                    &removed_impacted,
+                    &critical_tags,
+                    &production_configured_critical,
+                );
+                selected.extend(
+                    production
+                        .paths_between(&removed, &production_targets)
+                        .into_iter()
+                        .filter(|id| manifest.nodes.contains_key(id)),
+                );
+                selected
+            }
+        };
+        let impacted = current_impacted
+            .union(&removed_impacted)
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        report.validation_scope.impacted_models += impacted.len();
+        report.validation_scope.requested_models += selected.len();
+        for id in impacted.difference(&selected) {
+            report.validation_scope.skipped_models.push(SkippedModel {
+                id: format!("{}:{id}", account.name),
+                reason: if removed.contains(id) {
+                    "removed model cannot be built".into()
+                } else {
+                    "outside the configured downstream validation policy".into()
+                },
+            });
+        }
+        selected_count += selected.len();
+        selections.push(AccountSelection { selected, removed });
+    }
+    if !report.impact.dbt_models.is_empty() {
+        report.notices.push(Notice {
+            scope: "dbt".into(),
+            code: "column_lineage_unavailable".into(),
+            message: "dbt artifacts provide model-level, not authoritative column-level, dependency edges".into(),
+        });
+    }
+    if selected_count > config.safety.max_models {
+        for (account, selection) in config.accounts.iter().zip(&selections) {
+            for id in &selection.selected {
+                report.validation_scope.skipped_models.push(SkippedModel {
+                    id: format!("{}:{id}", account.name),
+                    reason: "validation stopped because the requested model count exceeded safety.max_models".into(),
+                });
+            }
+        }
+        report.coverage_gaps.push(CoverageGap {
+            scope: "validation".into(),
+            check: "model_budget".into(),
+            reason: format!(
+                "{selected_count} account/model builds were requested, above safety.max_models {}; increase the limit or narrow downstream validation",
+                config.safety.max_models
+            ),
+        });
+        return Ok(None);
+    }
+    Ok(Some(selections))
 }
 
 #[cfg(unix)]
@@ -132,29 +307,16 @@ async fn execute_with_dbt(
     context: &mut DbtContext,
     clients: &[SnowflakeClient],
     ci_schema: &str,
+    selections: &[AccountSelection],
     report: &mut Report,
 ) -> Result<()> {
-    let changed_paths = context.changed_paths(&report.base)?;
-    let mut selected_by_account = Vec::new();
     let mut all_selected = BTreeSet::new();
     let mut removed_production_relations = Vec::new();
-    for account in &config.accounts {
-        let manifest = context.manifest(&account.name)?;
+    for (account, selection) in config.accounts.iter().zip(selections) {
         let production_manifest = context.production_manifest(&account.name)?;
-        report
-            .impact
-            .dbt_lineage_changes
-            .extend(manifest.lineage_changes(production_manifest));
-        let removed = production_manifest.removed_models(manifest);
-        all_selected.extend(removed.iter().cloned());
-        let removal_impact = production_manifest.impact(&removed);
-        report.impact.dbt_models.extend(removal_impact.dbt_models);
-        report
-            .impact
-            .dbt_exposures
-            .extend(removal_impact.dbt_exposures);
-        report.impact.dbt_lineage.extend(removal_impact.dbt_lineage);
-        for model in &removed {
+        all_selected.extend(selection.removed.iter().cloned());
+        all_selected.extend(selection.selected.iter().cloned());
+        for model in &selection.removed {
             let production_node = &production_manifest.nodes[model];
             removed_production_relations.push((
                 model.clone(),
@@ -168,20 +330,10 @@ async fn execute_with_dbt(
                 });
             }
         }
-        let selected = dbt::select_models(config, context, account, &changed_paths)
-            .with_context(|| format!("could not select dbt models for account {}", account.name))?;
-        all_selected.extend(selected.iter().cloned());
-        selected_by_account.push(selected);
-    }
-    let selected_count: usize = selected_by_account.iter().map(BTreeSet::len).sum();
-    if selected_count > config.safety.max_models {
-        bail!(
-            "dbt selected {selected_count} account/model builds, above safety.max_models {}",
-            config.safety.max_models
-        );
     }
 
-    for (index, selected) in selected_by_account.iter().enumerate() {
+    for (index, selection) in selections.iter().enumerate() {
+        let selected = &selection.selected;
         let account = &config.accounts[index];
         let manifest = context.manifest(&account.name)?;
         let derived_schemas = selected
@@ -228,17 +380,89 @@ async fn execute_with_dbt(
         }
     }
 
-    let mut downstream = BTreeSet::new();
-    for (account, selected) in config.accounts.iter().zip(&selected_by_account) {
+    let mut baseline_relations = BTreeMap::<(String, String), Relation>::new();
+    for (index, (account, selection)) in config.accounts.iter().zip(selections).enumerate() {
         let manifest = context.manifest(&account.name)?;
-        let impact = manifest.impact(selected);
-        report.impact.dbt_models.extend(impact.dbt_models);
-        report.impact.dbt_exposures.extend(impact.dbt_exposures);
-        report.impact.dbt_lineage.extend(impact.dbt_lineage);
+        let production = context.production_manifest(&account.name)?;
+        let incrementals = selection
+            .selected
+            .iter()
+            .filter(|id| manifest.is_incremental(id) && production.nodes.contains_key(*id))
+            .cloned()
+            .collect::<Vec<_>>();
+        if incrementals.is_empty() {
+            continue;
+        }
+        let baseline_schema = format!("{ci_schema}_BASELINE");
+        let baseline_databases = incrementals
+            .iter()
+            .map(|id| {
+                let node = &production.nodes[id];
+                snowflake_identifier(
+                    node.database.as_deref().unwrap_or(&account.database),
+                    node.config.quoting.database,
+                )
+            })
+            .collect::<BTreeSet<_>>();
+        for baseline_database in baseline_databases {
+            clients[index]
+                .create_schema(&baseline_database, &baseline_schema)
+                .await
+                .with_context(|| {
+                    format!(
+                        "could not create incremental baseline schema in {baseline_database} for account {}",
+                        account.name
+                    )
+                })?;
+            report.ci_schemas.push(CiSchema {
+                account: account.name.clone(),
+                database: baseline_database,
+                schema: baseline_schema.clone(),
+                cleaned_up: false,
+            });
+        }
+        for (position, id) in incrementals.into_iter().enumerate() {
+            let current_node = &manifest.nodes[&id];
+            let production_node = &production.nodes[&id];
+            let source = relation_for(production_node, &account.database, &production_node.schema);
+            let baseline = Relation {
+                database: source.database.clone(),
+                schema: baseline_schema.clone(),
+                identifier: format!("EMBRASURE_BASELINE_{position}"),
+            };
+            clients[index]
+                .clone_table(&source, &baseline)
+                .await
+                .with_context(|| {
+                    format!(
+                        "could not create a stable baseline clone for incremental model {id}; confirm the production relation is a Snowflake table and grant SELECT on it"
+                    )
+                })?;
+            if config.validation.incremental_mode == IncrementalMode::Clone {
+                let candidate = relation_for(current_node, &account.database, &current_node.schema);
+                clients[index]
+                    .clone_table(&baseline, &candidate)
+                    .await
+                    .with_context(|| {
+                        format!(
+                            "could not seed incremental model {id} from its baseline clone; rerun with --incremental-mode full-refresh"
+                        )
+                    })?;
+                report.notices.push(Notice {
+                    scope: id.clone(),
+                    code: "incremental_history_not_recomputed".into(),
+                    message: "validation mirrors the next incremental run; historical rows were not recomputed".into(),
+                });
+            }
+            baseline_relations.insert((account.name.clone(), id), baseline);
+        }
+    }
+
+    let mut downstream = BTreeSet::new();
+    for (account, selection) in config.accounts.iter().zip(selections) {
+        let selected = &selection.selected;
+        let manifest = context.manifest(&account.name)?;
         downstream.extend(manifest.descendants(selected));
-        report
-            .coverage_gaps
-            .extend(dbt::coverage_gaps(manifest, selected));
     }
     report.impact.cross_account_dependencies = config
         .cross_account_dependencies
@@ -257,8 +481,8 @@ async fn execute_with_dbt(
     }
     let mut production_relations = removed_production_relations;
     let mut comparison_jobs = Vec::new();
-    for (index, (account, selected)) in config.accounts.iter().zip(&selected_by_account).enumerate()
-    {
+    for (index, (account, selection)) in config.accounts.iter().zip(selections).enumerate() {
+        let selected = &selection.selected;
         let manifest = context.manifest(&account.name)?;
         let production_manifest = context.production_manifest(&account.name)?;
         for id in selected {
@@ -276,6 +500,18 @@ async fn execute_with_dbt(
                     relation_for(node, &account.database, &account.production_schema)
                 }),
             ));
+            let build_strategy = if manifest.is_incremental(id) {
+                if production_relation.is_none() {
+                    "first_build"
+                } else {
+                    match config.validation.incremental_mode {
+                        IncrementalMode::Clone => "incremental_clone",
+                        IncrementalMode::FullRefresh => "full_refresh",
+                    }
+                }
+            } else {
+                "standard"
+            };
             report.models.push(ModelReport {
                 unique_id: id.clone(),
                 name: node.name.clone(),
@@ -283,12 +519,19 @@ async fn execute_with_dbt(
                 ci_relation: ci_relation.sql(),
                 production_relation: production_relation.as_ref().map(Relation::sql),
                 dbt_build: "pending".into(),
+                build_strategy: build_strategy.into(),
                 comparison: None,
             });
         }
 
-        let build = dbt::build_models(config, context, account, selected)
-            .with_context(|| format!("could not execute dbt build for account {}", account.name))?;
+        let build = dbt::build_models(
+            config,
+            context,
+            account,
+            selected,
+            config.validation.incremental_mode == IncrementalMode::FullRefresh,
+        )
+        .with_context(|| format!("could not execute dbt build for account {}", account.name))?;
         if !build.passed {
             for id in selected {
                 if let Some(model) = find_model_mut(report, id, &account.name) {
@@ -314,6 +557,10 @@ async fn execute_with_dbt(
             if let Some(model) = find_model_mut(report, id, &account.name) {
                 model.dbt_build = "passed".into();
             }
+            report
+                .validation_scope
+                .validated_models
+                .push(format!("{}:{id}", account.name));
             let Some(production_node) = production_manifest.nodes.get(id) else {
                 report.coverage_gaps.push(CoverageGap {
                     scope: id.clone(),
@@ -323,17 +570,39 @@ async fn execute_with_dbt(
                 continue;
             };
             let ci_relation = relation_for(node, &account.database, &node.schema);
-            let production_relation =
-                relation_for(production_node, &account.database, &production_node.schema);
+            let production_relation = baseline_relations
+                .get(&(account.name.clone(), id.clone()))
+                .cloned()
+                .unwrap_or_else(|| {
+                    relation_for(production_node, &account.database, &production_node.schema)
+                });
             let model_config = model_config(config, id, &node.name);
+            let primary_key = if model_config.primary_key.is_empty() {
+                match manifest.inferred_primary_key(id) {
+                    Ok(Some(key)) => key,
+                    Ok(None) => vec![],
+                    Err(error) => {
+                        report.notices.push(Notice {
+                            scope: id.clone(),
+                            code: "unique_key_not_inferred".into(),
+                            message: error.to_string(),
+                        });
+                        vec![]
+                    }
+                }
+            } else {
+                model_config.primary_key.clone()
+            };
             comparison_jobs.push(ComparisonJob {
                 client: clients[index].clone(),
                 model_id: id.clone(),
                 account: account.name.clone(),
                 ci: ci_relation,
                 production: production_relation,
-                primary_key: model_config.primary_key.clone(),
+                primary_key,
+                key_policy: model_config.key_policy,
                 where_clause: model_config.where_clause.clone(),
+                thresholds: model_config.thresholds.apply(config.thresholds),
             });
         }
     }
@@ -345,7 +614,6 @@ async fn execute_with_dbt(
             config.comparison.concurrency,
             config.comparison.mode,
             config.safety.clone(),
-            config.thresholds,
         ),
     )
     .await
@@ -390,7 +658,9 @@ struct ComparisonJob {
     ci: Relation,
     production: Relation,
     primary_key: Vec<String>,
+    key_policy: crate::config::KeyPolicy,
     where_clause: Option<String>,
+    thresholds: Thresholds,
 }
 
 struct CompletedComparison {
@@ -404,7 +674,6 @@ async fn run_comparisons(
     concurrency: usize,
     mode: ComparisonMode,
     safety: SafetyConfig,
-    thresholds: Thresholds,
 ) -> Result<Vec<CompletedComparison>> {
     let mut pending = jobs.into_iter();
     let mut running = JoinSet::new();
@@ -412,12 +681,12 @@ async fn run_comparisons(
 
     for _ in 0..concurrency {
         let Some(job) = pending.next() else { break };
-        spawn_comparison(&mut running, job, mode, safety.clone(), thresholds);
+        spawn_comparison(&mut running, job, mode, safety.clone());
     }
     while let Some(result) = running.join_next().await {
         completed.push(result.context("comparison worker stopped unexpectedly")?);
         if let Some(job) = pending.next() {
-            spawn_comparison(&mut running, job, mode, safety.clone(), thresholds);
+            spawn_comparison(&mut running, job, mode, safety.clone());
         }
     }
     Ok(completed)
@@ -428,7 +697,6 @@ fn spawn_comparison(
     job: ComparisonJob,
     mode: ComparisonMode,
     safety: SafetyConfig,
-    thresholds: Thresholds,
 ) {
     running.spawn(async move {
         let result = compare_model(
@@ -440,8 +708,9 @@ fn spawn_comparison(
                 primary_key: &job.primary_key,
                 where_clause: job.where_clause.as_deref(),
                 mode,
+                key_policy: job.key_policy,
                 safety: &safety,
-                thresholds,
+                thresholds: job.thresholds,
             },
         )
         .await
@@ -536,6 +805,14 @@ fn model_config<'a>(config: &'a Config, id: &str, name: &str) -> &'a ModelConfig
 static EMPTY_MODEL_CONFIG: ModelConfig = ModelConfig {
     primary_key: vec![],
     allow_removal: false,
+    critical: false,
+    key_policy: crate::config::KeyPolicy::Regression,
+    thresholds: crate::config::ThresholdOverrides {
+        row_count_relative: None,
+        null_rate_absolute: None,
+        cardinality_relative: None,
+        numeric_relative: None,
+    },
     where_clause: None,
 };
 
@@ -576,6 +853,7 @@ mod tests {
             schema: "PROD".into(),
             alias: "Y".into(),
             fqn: vec!["x".into(), "y".into()],
+            tags: vec![],
             depends_on: DependsOn::default(),
             config: NodeConfig::default(),
         };
@@ -584,7 +862,7 @@ mod tests {
 
     #[tokio::test]
     async fn git_revisions_cannot_be_parsed_as_options() {
-        let report = run_check(Path::new("unused.yml"), "--help", None).await;
+        let report = run_check(Path::new("unused.yml"), "--help", CheckOptions::default()).await;
         assert_eq!(report.status, crate::report::Status::ExecutionFailure);
         assert!(report.execution_errors[0].contains("must not start"));
     }
@@ -599,6 +877,7 @@ mod tests {
             schema: "prod".into(),
             alias: "orders".into(),
             fqn: vec!["x".into(), "orders".into()],
+            tags: vec![],
             depends_on: DependsOn::default(),
             config: NodeConfig::default(),
         };
@@ -619,6 +898,7 @@ mod tests {
             schema: "Prod".into(),
             alias: "OrderLines".into(),
             fqn: vec!["x".into(), "orders".into()],
+            tags: vec![],
             depends_on: DependsOn::default(),
             config: NodeConfig {
                 quoting: QuotePolicy {
@@ -626,6 +906,8 @@ mod tests {
                     schema: Some(true),
                     identifier: Some(true),
                 },
+                materialized: String::new(),
+                unique_key: None,
             },
         };
 

--- a/src/run.rs
+++ b/src/run.rs
@@ -141,6 +141,10 @@ async fn execute_with_dbt(
     for account in &config.accounts {
         let manifest = context.manifest(&account.name)?;
         let production_manifest = context.production_manifest(&account.name)?;
+        report
+            .impact
+            .dbt_lineage_changes
+            .extend(manifest.lineage_changes(production_manifest));
         let removed = production_manifest.removed_models(manifest);
         all_selected.extend(removed.iter().cloned());
         let removal_impact = production_manifest.impact(&removed);
@@ -149,6 +153,7 @@ async fn execute_with_dbt(
             .impact
             .dbt_exposures
             .extend(removal_impact.dbt_exposures);
+        report.impact.dbt_lineage.extend(removal_impact.dbt_lineage);
         for model in &removed {
             let production_node = &production_manifest.nodes[model];
             removed_production_relations.push((
@@ -229,6 +234,7 @@ async fn execute_with_dbt(
         let impact = manifest.impact(selected);
         report.impact.dbt_models.extend(impact.dbt_models);
         report.impact.dbt_exposures.extend(impact.dbt_exposures);
+        report.impact.dbt_lineage.extend(impact.dbt_lineage);
         downstream.extend(manifest.descendants(selected));
         report
             .coverage_gaps

--- a/src/run.rs
+++ b/src/run.rs
@@ -1,19 +1,24 @@
-use std::{collections::BTreeSet, path::Path};
+use std::{collections::BTreeSet, path::Path, time::Duration};
 
 use anyhow::{Context, Result, bail};
+use tokio::{task::JoinSet, time::timeout};
 use uuid::Uuid;
 
 use crate::{
     auth,
-    compare::compare_model,
-    config::{Config, ModelConfig},
+    compare::{CompareOptions, compare_model},
+    config::{ComparisonMode, Config, ModelConfig, SafetyConfig, Thresholds},
     dbt::{self, DbtContext, ManifestNode},
     metabase,
     report::{CiSchema, CoverageGap, Finding, ModelReport, Report},
     snowflake::{Relation, SnowflakeClient, is_managed_schema},
 };
 
-pub async fn run_check(config_path: &Path, base: &str) -> Report {
+pub async fn run_check(
+    config_path: &Path,
+    base: &str,
+    mode_override: Option<ComparisonMode>,
+) -> Report {
     if base.trim().is_empty() || base.starts_with('-') {
         return error_report(
             base,
@@ -24,6 +29,9 @@ pub async fn run_check(config_path: &Path, base: &str) -> Report {
         Ok(config) => config,
         Err(error) => return error_report(base, error),
     };
+    if let Some(mode) = mode_override {
+        config.comparison.mode = mode;
+    }
     if let Err(error) = config.resolve_from(config_path) {
         return error_report(base, error);
     }
@@ -242,6 +250,7 @@ async fn execute_with_dbt(
         }
     }
     let mut production_relations = removed_production_relations;
+    let mut comparison_jobs = Vec::new();
     for (index, (account, selected)) in config.accounts.iter().zip(&selected_by_account).enumerate()
     {
         let manifest = context.manifest(&account.name)?;
@@ -311,21 +320,44 @@ async fn execute_with_dbt(
             let production_relation =
                 relation_for(production_node, &account.database, &production_node.schema);
             let model_config = model_config(config, id, &node.name);
-            let (comparison, findings) = compare_model(
-                &clients[index],
-                id,
-                &ci_relation,
-                &production_relation,
-                &model_config.primary_key,
-                &config.safety,
-                config.thresholds,
-            )
-            .await
-            .with_context(|| format!("comparison failed for {id} in account {}", account.name))?;
-            if let Some(model) = find_model_mut(report, id, &account.name) {
-                model.comparison = Some(comparison);
+            comparison_jobs.push(ComparisonJob {
+                client: clients[index].clone(),
+                model_id: id.clone(),
+                account: account.name.clone(),
+                ci: ci_relation,
+                production: production_relation,
+                primary_key: model_config.primary_key.clone(),
+                where_clause: model_config.where_clause.clone(),
+            });
+        }
+    }
+
+    let completed = timeout(
+        Duration::from_secs(config.comparison.timeout_seconds),
+        run_comparisons(
+            comparison_jobs,
+            config.comparison.concurrency,
+            config.comparison.mode,
+            config.safety.clone(),
+            config.thresholds,
+        ),
+    )
+    .await
+    .with_context(|| {
+        format!(
+            "Snowflake comparisons exceeded comparison.timeout_seconds ({})",
+            config.comparison.timeout_seconds
+        )
+    })??;
+    for item in completed {
+        match item.result {
+            Ok((comparison, findings)) => {
+                if let Some(model) = find_model_mut(report, &item.model_id, &item.account) {
+                    model.comparison = Some(comparison);
+                }
+                report.findings.extend(findings);
             }
-            report.findings.extend(findings);
+            Err(error) => report.execution_errors.push(format_error(&error)),
         }
     }
 
@@ -343,6 +375,82 @@ async fn execute_with_dbt(
         }
     }
     Ok(())
+}
+
+struct ComparisonJob {
+    client: SnowflakeClient,
+    model_id: String,
+    account: String,
+    ci: Relation,
+    production: Relation,
+    primary_key: Vec<String>,
+    where_clause: Option<String>,
+}
+
+struct CompletedComparison {
+    model_id: String,
+    account: String,
+    result: Result<(crate::report::ModelComparison, Vec<Finding>)>,
+}
+
+async fn run_comparisons(
+    jobs: Vec<ComparisonJob>,
+    concurrency: usize,
+    mode: ComparisonMode,
+    safety: SafetyConfig,
+    thresholds: Thresholds,
+) -> Result<Vec<CompletedComparison>> {
+    let mut pending = jobs.into_iter();
+    let mut running = JoinSet::new();
+    let mut completed = Vec::new();
+
+    for _ in 0..concurrency {
+        let Some(job) = pending.next() else { break };
+        spawn_comparison(&mut running, job, mode, safety.clone(), thresholds);
+    }
+    while let Some(result) = running.join_next().await {
+        completed.push(result.context("comparison worker stopped unexpectedly")?);
+        if let Some(job) = pending.next() {
+            spawn_comparison(&mut running, job, mode, safety.clone(), thresholds);
+        }
+    }
+    Ok(completed)
+}
+
+fn spawn_comparison(
+    running: &mut JoinSet<CompletedComparison>,
+    job: ComparisonJob,
+    mode: ComparisonMode,
+    safety: SafetyConfig,
+    thresholds: Thresholds,
+) {
+    running.spawn(async move {
+        let result = compare_model(
+            &job.client,
+            &job.model_id,
+            &job.ci,
+            &job.production,
+            CompareOptions {
+                primary_key: &job.primary_key,
+                where_clause: job.where_clause.as_deref(),
+                mode,
+                safety: &safety,
+                thresholds,
+            },
+        )
+        .await
+        .with_context(|| {
+            format!(
+                "comparison failed for {} in account {}",
+                job.model_id, job.account
+            )
+        });
+        CompletedComparison {
+            model_id: job.model_id,
+            account: job.account,
+            result,
+        }
+    });
 }
 
 async fn cleanup_schemas(
@@ -422,6 +530,7 @@ fn model_config<'a>(config: &'a Config, id: &str, name: &str) -> &'a ModelConfig
 static EMPTY_MODEL_CONFIG: ModelConfig = ModelConfig {
     primary_key: vec![],
     allow_removal: false,
+    where_clause: None,
 };
 
 fn find_model_mut<'a>(
@@ -469,7 +578,7 @@ mod tests {
 
     #[tokio::test]
     async fn git_revisions_cannot_be_parsed_as_options() {
-        let report = run_check(Path::new("unused.yml"), "--help").await;
+        let report = run_check(Path::new("unused.yml"), "--help", None).await;
         assert_eq!(report.status, crate::report::Status::ExecutionFailure);
         assert!(report.execution_errors[0].contains("must not start"));
     }

--- a/src/snowflake.rs
+++ b/src/snowflake.rs
@@ -239,6 +239,11 @@ impl SnowflakeClient {
         Ok(())
     }
 
+    pub async fn clone_table(&self, source: &Relation, target: &Relation) -> Result<()> {
+        self.execute(&clone_table_statement(source, target)).await?;
+        Ok(())
+    }
+
     pub async fn drop_schema(&self, database: &str, schema: &str, run_schema: &str) -> Result<()> {
         if !is_managed_schema(schema, run_schema) {
             bail!("refusing to drop schema {schema}: it is not owned by this run ({run_schema})");
@@ -301,6 +306,10 @@ impl SnowflakeClient {
         );
         Ok(headers)
     }
+}
+
+fn clone_table_statement(source: &Relation, target: &Relation) -> String {
+    format!("CREATE TABLE {} CLONE {}", target.sql(), source.sql())
 }
 
 fn statement_body(
@@ -449,7 +458,7 @@ pub fn is_managed_schema(schema: &str, run_schema: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::AuthConfig;
+    use crate::{auth::ResolvedAuth, config::AuthConfig};
     use openssl::{rsa::Rsa, sign::Verifier};
 
     #[test]
@@ -477,6 +486,27 @@ mod tests {
         ));
         assert!(!is_managed_schema("EMBRASURE_CHECK_PROD", run));
         assert!(!is_managed_schema("EMBRASURE_CHECK_SHA_TIME_RANDOMLY", run));
+    }
+
+    #[test]
+    fn clone_seed_is_zero_copy_and_quotes_every_identifier() {
+        let source = Relation {
+            database: "PROD DB".into(),
+            schema: "ANALYTICS".into(),
+            identifier: "Order Facts".into(),
+        };
+        let target = Relation {
+            database: "CI DB".into(),
+            schema: "EMBRASURE_RUN_BASELINE".into(),
+            identifier: "MODEL_0".into(),
+        };
+        let sql = clone_table_statement(&source, &target);
+        assert_eq!(
+            sql,
+            r#"CREATE TABLE "CI DB"."EMBRASURE_RUN_BASELINE"."MODEL_0" CLONE "PROD DB"."ANALYTICS"."Order Facts""#
+        );
+        assert!(!sql.contains(" AS SELECT "));
+        assert!(!sql.contains("INSERT"));
     }
 
     #[test]
@@ -547,5 +577,114 @@ mod tests {
             body["parameters"],
             serde_json::json!({ "query_tag": "check:1" })
         );
+    }
+
+    #[tokio::test]
+    async fn snowflake_incremental_strategies_and_scale() {
+        if env::var("EMBRASURE_RUN_SNOWFLAKE_TESTS").as_deref() != Ok("1") {
+            return;
+        }
+        let required = |name: &str| {
+            env::var(name).unwrap_or_else(|_| {
+                panic!("{name} is required when EMBRASURE_RUN_SNOWFLAKE_TESTS=1")
+            })
+        };
+        let account = AccountConfig {
+            name: "integration".into(),
+            account: required("EMBRASURE_TEST_SNOWFLAKE_ACCOUNT"),
+            user: required("EMBRASURE_TEST_SNOWFLAKE_USER"),
+            role: required("EMBRASURE_TEST_SNOWFLAKE_ROLE"),
+            database: required("EMBRASURE_TEST_SNOWFLAKE_DATABASE"),
+            warehouse: required("EMBRASURE_TEST_SNOWFLAKE_WAREHOUSE"),
+            production_schema: "unused".into(),
+            selector: None,
+            auth: AuthConfig::ProgrammaticAccessToken {
+                token_env: "EMBRASURE_TEST_SNOWFLAKE_TOKEN".into(),
+            },
+        };
+        let auth = ResolvedAuth::ProgrammaticAccessToken {
+            token: required("EMBRASURE_TEST_SNOWFLAKE_TOKEN"),
+        };
+        let run_schema = format!("EMBRASURE_IT_{}", Uuid::new_v4().simple()).to_ascii_uppercase();
+        let second_schema = format!("{run_schema}_SECOND");
+        let client = SnowflakeClient::new(
+            &account,
+            &auth,
+            format!("embrasure:integration:{run_schema}"),
+            300,
+        )
+        .unwrap();
+        client
+            .create_schema(&account.database, &run_schema)
+            .await
+            .unwrap();
+        client
+            .create_schema(&account.database, &second_schema)
+            .await
+            .unwrap();
+
+        let source = Relation {
+            database: account.database.clone(),
+            schema: run_schema.clone(),
+            identifier: "SOURCE".into(),
+        };
+        let baseline = Relation {
+            database: account.database.clone(),
+            schema: second_schema.clone(),
+            identifier: "BASELINE".into(),
+        };
+        let candidate = Relation {
+            database: account.database.clone(),
+            schema: second_schema.clone(),
+            identifier: "CANDIDATE".into(),
+        };
+        let result = async {
+            client
+                .execute(&format!(
+                    "CREATE TABLE {} AS SELECT ID, MOD(ID, 100) AS SEGMENT FROM (SELECT ROW_NUMBER() OVER (ORDER BY SEQ4()) - 1 AS ID FROM TABLE(GENERATOR(ROWCOUNT => 100000)))",
+                    source.sql()
+                ))
+                .await?;
+            client.clone_table(&source, &baseline).await?;
+            client.clone_table(&baseline, &candidate).await?;
+            client
+                .execute(&format!(
+                    "MERGE INTO {} C USING (SELECT 100000 AS ID, 0 AS SEGMENT) N ON C.ID = N.ID WHEN NOT MATCHED THEN INSERT (ID, SEGMENT) VALUES (N.ID, N.SEGMENT)",
+                    candidate.sql()
+                ))
+                .await?;
+            let incremental = client
+                .execute(&format!("SELECT COUNT(*) FROM {}", candidate.sql()))
+                .await?;
+            assert_eq!(incremental.rows[0][0].as_deref(), Some("100001"));
+
+            client
+                .execute(&format!(
+                    "CREATE OR REPLACE TABLE {} AS SELECT * FROM {} WHERE ID < 50000 UNION ALL SELECT 1, 1",
+                    candidate.sql(), baseline.sql()
+                ))
+                .await?;
+            let integrity = client
+                .execute(&format!(
+                    "SELECT COUNT(*) AS ROWS, COUNT_IF(ID IS NULL) AS NULL_KEYS, COUNT(*) - COUNT(DISTINCT ID) AS DUPLICATE_ROWS FROM {}",
+                    candidate.sql()
+                ))
+                .await?;
+            assert_eq!(integrity.rows[0][0].as_deref(), Some("50001"));
+            assert_eq!(integrity.rows[0][1].as_deref(), Some("0"));
+            assert_eq!(integrity.rows[0][2].as_deref(), Some("1"));
+            Ok::<(), anyhow::Error>(())
+        }
+        .await;
+
+        let second_cleanup = client
+            .drop_schema(&account.database, &second_schema, &run_schema)
+            .await;
+        let first_cleanup = client
+            .drop_schema(&account.database, &run_schema, &run_schema)
+            .await;
+        result.unwrap();
+        second_cleanup.unwrap();
+        first_cleanup.unwrap();
     }
 }

--- a/src/snowflake.rs
+++ b/src/snowflake.rs
@@ -26,6 +26,7 @@ use crate::{
     config::AccountConfig,
 };
 
+#[derive(Clone)]
 pub struct SnowflakeClient {
     http: Client,
     endpoint: String,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -147,3 +147,15 @@ fn run_remains_an_alias_for_check() {
             "Build and compare changed dbt models",
         ));
 }
+
+#[test]
+fn check_exposes_quick_and_deep_modes() {
+    Command::cargo_bin("embrasure")
+        .unwrap()
+        .args(["check", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--mode <MODE>"))
+        .stdout(predicate::str::contains("quick"))
+        .stdout(predicate::str::contains("deep"));
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -159,3 +159,32 @@ fn check_exposes_quick_and_deep_modes() {
         .stdout(predicate::str::contains("quick"))
         .stdout(predicate::str::contains("deep"));
 }
+
+#[test]
+fn check_exposes_scope_incremental_and_report_controls() {
+    Command::cargo_bin("embrasure")
+        .unwrap()
+        .args(["check", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--downstream <DOWNSTREAM>"))
+        .stdout(predicate::str::contains("--critical-tag <CRITICAL_TAGS>"))
+        .stdout(predicate::str::contains(
+            "--incremental-mode <INCREMENTAL_MODE>",
+        ))
+        .stdout(predicate::str::contains(
+            "--report-version <REPORT_VERSION>",
+        ))
+        .stdout(predicate::str::contains("possible values: 1, 2"))
+        .stdout(predicate::str::contains("--verbose"));
+}
+
+#[test]
+fn legacy_report_version_requires_json_output() {
+    Command::cargo_bin("embrasure")
+        .unwrap()
+        .args(["check", "--report-version", "1"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("--json"));
+}


### PR DESCRIPTION
## Summary
- add critical-path downstream validation with complete blast-radius reporting
- detect duplicate and null keys with per-model thresholds and compact output
- add report v2 while preserving the v1 JSON contract
- validate incremental models from table-level Snowflake clones with safe cleanup
- document enterprise permissions, limits, and lineage boundaries

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --all-targets --locked` (56 passed)
- `cargo build --release --locked`
- strict JSON Schema contract tests for report v1 and v2

The live Snowflake suite remains environment-gated and is not required by CI.