### PR TITLE
Add exact arbitrary SQL query diffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Local checks connect directly to Snowflake. They require no Embrasure account or
 - Shifts in row counts, null rates, cardinality, ranges, averages, and percentiles
 - Primary-key values that appear or disappear
 - Duplicate or null primary keys introduced by a branch
+- Exact differences between arbitrary candidate and production SQL results
 - Existing dbt test failures
 - Affected dbt models and exposures
 - Declared cross-account dependencies
@@ -86,7 +87,7 @@ embrasure check --dry-run
 embrasure check --dry-run --json
 ```
 
-Dry runs still resolve credentials and run local dbt parsing. `--dry-run` cannot be combined with `--cloud`.
+Dry runs use local dbt parsing but do not resolve credentials, create Snowflake schemas, or query warehouse data. `--dry-run` cannot be combined with `--cloud`.
 
 ## Reports and exit codes
 
@@ -98,7 +99,7 @@ embrasure check --json --markdown embrasure-check.md
 embrasure check --json --report-version 1
 ```
 
-Published contracts: [report v1](schemas/report-v1.schema.json) and [report v2](schemas/report-v2.schema.json).
+Published contracts: [report v1](schemas/report-v1.schema.json), [report v2](schemas/report-v2.schema.json), and [report v3](schemas/report-v3.schema.json). V3 is the default; v1 and v2 remain explicit compatibility projections.
 
 | Exit code | Meaning |
 |---:|---|
@@ -118,6 +119,26 @@ Request review only after exit 0.
 ```
 
 For a faster first pass on large tables, add `--mode quick`. Quick mode estimates cardinality and skips percentiles. Deep mode is the default. Primary-key integrity stays exact in both modes.
+
+### Arbitrary SQL checks
+
+Query-diff checks compare any two read-only query results exactly. `production_sql` defaults to `sql`, and each dbt `ref()` is rendered against the candidate or production-state manifest. Checks with no refs, or definitions changed since `--base`, run even when no model changed.
+
+```yaml
+checks:
+  - type: query_diff
+    name: paid order totals
+    sql: |
+      select customer_id, sum(amount) as paid_amount
+      from {{ ref('orders') }}
+      where status = 'paid'
+      group by customer_id
+    primary_key: [customer_id]
+```
+
+With a primary key, Embrasure reports added, removed, and changed rows plus per-column mismatch counts. Null or duplicate keys block the value join. Without a key, grouped rows and their multiplicities preserve duplicate-only differences. Query examples are bounded by the configured sample, column, and value limits.
+
+Only persisted dbt models are supported in `ref()`. Query checks accept one `SELECT`, `WITH`, or `VALUES` expression; other Jinja and multi-statement SQL are rejected. Removed checks are reported as incomplete coverage instead of silently passing.
 
 ## GitHub Actions
 
@@ -203,7 +224,7 @@ The validation role needs `SELECT` on the production source and `CREATE TABLE` i
 
 See the [example configuration](embrasure-check.example.yml) and [enterprise setup guide](docs/enterprise.md) for service credentials, multiple accounts, model policies, filters, thresholds, concurrency, external changes, cross-account dependencies, Metabase, and grants.
 
-Every temporary schema has a unique name and ownership marker. Embrasure checks both before removal and treats cleanup failures as execution failures. Use a dedicated role that can read and clone only the production tables under test and create temporary schemas in the required databases.
+Every temporary schema has a unique name and ownership marker. Query results are materialized in a dedicated run-owned schema so they cannot collide with dbt model aliases. Embrasure checks ownership before removal and treats cleanup failures as execution failures. Use a dedicated role that can read and clone only the production tables under test and create temporary schemas in the required databases. SQL validation is not a side-effect sandbox, so the role must not be able to call unsafe procedures, functions, or external integrations.
 
 [Security and data flow](docs/security-and-data-flow.md) documents network connections, local files, returned data, credentials, cleanup, updates, and release verification.
 
@@ -223,6 +244,6 @@ cargo clippy --all-targets --all-features -- -D warnings
 cargo test --locked
 ```
 
-The opt-in Snowflake suite uses `EMBRASURE_RUN_SNOWFLAKE_TESTS=1` and the `EMBRASURE_TEST_SNOWFLAKE_*` account, user, role, database, warehouse, and token variables.
+The opt-in Snowflake suite uses `EMBRASURE_RUN_SNOWFLAKE_TESTS=1` and the `EMBRASURE_TEST_SNOWFLAKE_*` account, user, role, database, warehouse, and token variables. It covers exact keyed passes and changes, duplicate-only unkeyed differences, incremental cloning, cleanup, and 100,000 synthetic rows.
 
 Contributions are welcome under the [Apache 2.0 license](LICENSE).

--- a/docs/enterprise.md
+++ b/docs/enterprise.md
@@ -134,7 +134,7 @@ embrasure check --base origin/main --json --markdown embrasure-check.md
 
 Exit `0` is ready for review, `1` is a finding, `2` is missing evidence, and `3` is a setup or execution failure.
 
-Report v2 is the default JSON contract. It includes validation scope, skipped models, notices, duplicate and null-key metrics, build strategy, and dbt topology changes. Legacy consumers can request v1 with `--json --report-version 1`.
+Report v3 is the default JSON contract and adds query-diff evidence. V1 and v2 remain unchanged compatibility projections and can be requested with `--json --report-version 1` or `--json --report-version 2`.
 
 ## Reference
 
@@ -151,7 +151,9 @@ validation:
 
 Override policy with `--downstream` and repeatable `--critical-tag`. Use repeatable `--select` to intersect the resulting validation set. Excluded models remain visible as not validated.
 
-If selection exceeds `safety.max_models`, Embrasure exits `2` before dbt builds or comparisons. It does not truncate the set. Independent comparisons run concurrently up to `comparison.concurrency`.
+If selection exceeds `safety.max_models`, Embrasure exits `2` before dbt model builds. It does not truncate the set. Ref-free and production-only query checks can still run because they need no candidate build. Independent comparisons run concurrently up to `comparison.concurrency`.
+
+Query checks are activated when referenced models are impacted or when the check definition changed since the base revision. Checks removed from the configuration produce an explicit coverage gap. Each side is materialized once in a dedicated run-owned schema before exact keyed or bag-semantic comparison.
 
 Quick mode is the inexpensive first pass:
 

--- a/docs/security-and-data-flow.md
+++ b/docs/security-and-data-flow.md
@@ -54,8 +54,11 @@ Snowflake returns the comparison evidence used in the local report:
 - Row counts, null rates, cardinality, min/max values, averages, and percentiles
 - Counts of primary-key values found on only one side, duplicate rows, and null-key rows
 - Optional stably ordered primary-key and duplicate-key examples, up to `safety.primary_key_sample_limit`
+- Optional deterministic query-diff row values, bounded by `safety.primary_key_sample_limit`, `safety.max_columns_per_model`, and `safety.max_example_value_chars`
 
-Set `primary_key_sample_limit: 0` when key values must not appear in process memory or JSON output. Reports are written to stdout unless `--markdown <path>` is provided.
+Set `primary_key_sample_limit: 0` when key or query-diff example values must not appear in process memory or JSON output. Reports are written to stdout unless `--markdown <path>` is provided.
+
+Query checks accept a single read-only query expression, but syntax validation is not a side-effect sandbox for functions invoked by that query. Use a least-privilege Snowflake role that cannot call unsafe procedures, user-defined functions, or external integrations. Query materializations use a dedicated run-owned schema and follow the same ownership-checked cleanup path as model schemas.
 
 ## Credentials and local files
 

--- a/embrasure-check.example.yml
+++ b/embrasure-check.example.yml
@@ -15,6 +15,8 @@ safety:
   max_models: 25
   max_columns_per_model: 100
   primary_key_sample_limit: 20
+  max_query_checks: 20
+  max_example_value_chars: 512
 
 comparison:
   # quick estimates cardinality and skips percentiles.
@@ -78,6 +80,25 @@ models:
     # where: "order_date >= DATEADD(day, -30, CURRENT_DATE)"
     # Set this only for an intentional deletion after checking reported impact.
     # allow_removal: true
+
+# Optional exact comparisons for arbitrary read-only query results. production_sql
+# defaults to sql. ref()-free checks run on every invocation; checks with refs run
+# when any referenced model is impacted.
+checks:
+  - type: query_diff
+    name: paid order totals
+    sql: |
+      select customer_id, sum(amount) as paid_amount
+      from {{ ref('orders') }}
+      where status = 'paid'
+      group by customer_id
+    primary_key: [customer_id]
+    # account: primary # Required with multiple accounts.
+    # production_sql: |
+    #   select customer_id, sum(amount) as paid_amount
+    #   from {{ ref('legacy_orders') }}
+    #   where status = 'paid'
+    #   group by customer_id
 
 # Optional non-dbt changes that should invalidate dbt models.
 external_changes:

--- a/schemas/report-v1.schema.json
+++ b/schemas/report-v1.schema.json
@@ -77,7 +77,7 @@
         "account": { "type": "string" },
         "ci_relation": { "type": "string" },
         "production_relation": { "type": ["string", "null"] },
-        "dbt_build": { "enum": ["pending", "passed", "failed"] },
+        "dbt_build": { "enum": ["planned", "pending", "passed", "failed"] },
         "comparison": {
           "anyOf": [
             { "$ref": "#/$defs/model_comparison" },

--- a/schemas/report-v3.schema.json
+++ b/schemas/report-v3.schema.json
@@ -1,16 +1,16 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/EmbrasureAI/embrasure-cli/schemas/report-v2.schema.json",
-  "title": "Embrasure check report v2",
+  "$id": "https://github.com/EmbrasureAI/embrasure-cli/schemas/report-v3.schema.json",
+  "title": "Embrasure check report v3",
   "type": "object",
   "additionalProperties": false,
   "required": [
     "schema_version", "status", "exit_code", "base", "ci_schemas", "thresholds",
-    "summary", "validation_scope", "models", "impact", "findings", "coverage_gaps",
-    "notices", "execution_errors"
+    "summary", "validation_scope", "models", "query_checks", "impact", "findings",
+    "coverage_gaps", "notices", "execution_errors"
   ],
   "properties": {
-    "schema_version": { "const": 2 },
+    "schema_version": { "const": 3 },
     "status": { "enum": ["pass", "findings", "incomplete", "execution_failure"] },
     "exit_code": { "enum": [0, 1, 2, 3] },
     "base": { "type": "string" },
@@ -19,6 +19,7 @@
     "summary": { "$ref": "#/$defs/summary" },
     "validation_scope": { "$ref": "#/$defs/validation_scope" },
     "models": { "type": "array", "items": { "$ref": "#/$defs/model" } },
+    "query_checks": { "type": "array", "items": { "$ref": "#/$defs/query_check" } },
     "impact": { "$ref": "#/$defs/impact" },
     "findings": { "type": "array", "items": { "$ref": "#/$defs/finding" } },
     "coverage_gaps": { "type": "array", "items": { "$ref": "#/$defs/coverage_gap" } },
@@ -46,11 +47,17 @@
     },
     "summary": {
       "type": "object", "additionalProperties": false,
-      "required": ["models_selected", "models_built", "models_compared", "findings", "coverage_gaps"],
+      "required": [
+        "models_selected", "models_built", "models_compared", "query_checks_configured",
+        "query_checks_run", "query_checks_passed", "findings", "coverage_gaps"
+      ],
       "properties": {
         "models_selected": { "type": "integer", "minimum": 0 },
         "models_built": { "type": "integer", "minimum": 0 },
         "models_compared": { "type": "integer", "minimum": 0 },
+        "query_checks_configured": { "type": "integer", "minimum": 0 },
+        "query_checks_run": { "type": "integer", "minimum": 0 },
+        "query_checks_passed": { "type": "integer", "minimum": 0 },
         "findings": { "type": "integer", "minimum": 0 },
         "coverage_gaps": { "type": "integer", "minimum": 0 }
       }
@@ -121,8 +128,8 @@
       "required": [
         "columns", "ci_only_count", "production_only_count", "ci_only_examples",
         "production_only_examples", "ci_duplicate_key_count", "production_duplicate_key_count",
-        "ci_duplicate_rows", "production_duplicate_rows",
-        "ci_null_key_rows", "production_null_key_rows", "ci_duplicate_examples"
+        "ci_duplicate_rows", "production_duplicate_rows", "ci_null_key_rows",
+        "production_null_key_rows", "ci_duplicate_examples"
       ],
       "properties": {
         "columns": { "type": "array", "minItems": 1, "items": { "type": "string" } },
@@ -141,6 +148,83 @@
     },
     "key_examples": {
       "type": "array", "items": { "type": "array", "items": { "type": ["string", "null"] } }
+    },
+    "query_check": {
+      "type": "object", "additionalProperties": false,
+      "required": [
+        "name", "account", "status", "current_refs", "production_refs", "primary_key",
+        "candidate_relation", "production_relation", "candidate_row_count",
+        "production_row_count", "columns", "comparison", "reason", "invalid_primary_key_reason",
+        "examples_truncated"
+      ],
+      "properties": {
+        "name": { "type": "string" }, "account": { "type": "string" },
+        "status": { "enum": ["planned", "pass", "findings", "incomplete", "skipped", "execution_failure"] },
+        "current_refs": { "type": "array", "items": { "type": "string" } },
+        "production_refs": { "type": "array", "items": { "type": "string" } },
+        "primary_key": { "type": "array", "items": { "type": "string" } },
+        "candidate_relation": { "type": ["string", "null"] },
+        "production_relation": { "type": ["string", "null"] },
+        "candidate_row_count": { "type": ["integer", "null"], "minimum": 0 },
+        "production_row_count": { "type": ["integer", "null"], "minimum": 0 },
+        "columns": { "type": "array", "items": { "$ref": "#/$defs/query_column" } },
+        "comparison": { "anyOf": [{ "$ref": "#/$defs/query_comparison" }, { "type": "null" }] },
+        "reason": { "type": ["string", "null"] },
+        "invalid_primary_key_reason": { "type": ["string", "null"] },
+        "examples_truncated": { "type": "boolean" }
+      }
+    },
+    "query_column": {
+      "type": "object", "additionalProperties": false,
+      "required": ["name", "candidate_type", "production_type"],
+      "properties": {
+        "name": { "type": "string" },
+        "candidate_type": { "type": ["string", "null"] },
+        "production_type": { "type": ["string", "null"] }
+      }
+    },
+    "query_comparison": {
+      "type": "object", "additionalProperties": false,
+      "required": [
+        "candidate_only_rows", "production_only_rows", "changed_rows",
+        "candidate_duplicate_keys", "production_duplicate_keys", "candidate_duplicate_rows",
+        "production_duplicate_rows", "candidate_null_key_rows", "production_null_key_rows",
+        "column_mismatches", "examples"
+      ],
+      "properties": {
+        "candidate_only_rows": { "type": "integer", "minimum": 0 },
+        "production_only_rows": { "type": "integer", "minimum": 0 },
+        "changed_rows": { "type": "integer", "minimum": 0 },
+        "candidate_duplicate_keys": { "type": "integer", "minimum": 0 },
+        "production_duplicate_keys": { "type": "integer", "minimum": 0 },
+        "candidate_duplicate_rows": { "type": "integer", "minimum": 0 },
+        "production_duplicate_rows": { "type": "integer", "minimum": 0 },
+        "candidate_null_key_rows": { "type": "integer", "minimum": 0 },
+        "production_null_key_rows": { "type": "integer", "minimum": 0 },
+        "column_mismatches": { "type": "array", "items": { "$ref": "#/$defs/query_column_mismatch" } },
+        "examples": { "type": "array", "items": { "$ref": "#/$defs/query_example" } }
+      }
+    },
+    "query_column_mismatch": {
+      "type": "object", "additionalProperties": false,
+      "required": ["column", "rows"],
+      "properties": {
+        "column": { "type": "string" }, "rows": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "query_example": {
+      "type": "object", "additionalProperties": false,
+      "required": ["key", "candidate", "production", "candidate_multiplicity", "production_multiplicity"],
+      "properties": {
+        "key": { "$ref": "#/$defs/query_example_values" },
+        "candidate": { "$ref": "#/$defs/query_example_values" },
+        "production": { "$ref": "#/$defs/query_example_values" },
+        "candidate_multiplicity": { "type": ["integer", "null"], "minimum": 0 },
+        "production_multiplicity": { "type": ["integer", "null"], "minimum": 0 }
+      }
+    },
+    "query_example_values": {
+      "type": "array", "items": { "type": ["string", "null"] }
     },
     "finding": {
       "type": "object", "additionalProperties": false, "required": ["model", "check", "message"],

--- a/src/cloud.rs
+++ b/src/cloud.rs
@@ -310,10 +310,24 @@ pub fn cached_review(snapshot: &PreparedSnapshot) -> Result<Option<Report>> {
             return Err(error).with_context(|| format!("could not read {}", path.display()));
         }
     };
-    Ok(
-        (cache.fingerprint == snapshot.fingerprint && cache_is_fresh(&cache.saved_at))
-            .then_some(cache.report),
+    Ok(cache_is_reusable(
+        &cache.fingerprint,
+        &snapshot.fingerprint,
+        &cache.saved_at,
+        cache.report.schema_version,
     )
+    .then_some(cache.report))
+}
+
+fn cache_is_reusable(
+    cached_fingerprint: &str,
+    snapshot_fingerprint: &str,
+    saved_at: &str,
+    report_schema_version: u8,
+) -> bool {
+    cached_fingerprint == snapshot_fingerprint
+        && cache_is_fresh(saved_at)
+        && report_schema_version == 3
 }
 
 pub fn save_review(snapshot: &PreparedSnapshot, report: &Report) -> Result<()> {
@@ -953,5 +967,8 @@ mod tests {
             &(Utc::now() - chrono::Duration::hours(2)).to_rfc3339()
         ));
         assert!(!cache_is_fresh("not-a-timestamp"));
+        let now = Utc::now().to_rfc3339();
+        assert!(cache_is_reusable("same", "same", &now, 3));
+        assert!(!cache_is_reusable("same", "same", &now, 2));
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,6 +10,8 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Config {
+    #[serde(skip)]
+    pub source_path: Option<PathBuf>,
     pub version: u8,
     #[serde(default)]
     pub dbt: DbtConfig,
@@ -24,6 +26,8 @@ pub struct Config {
     pub accounts: Vec<AccountConfig>,
     #[serde(default)]
     pub models: BTreeMap<String, ModelConfig>,
+    #[serde(default)]
+    pub checks: Vec<CheckConfig>,
     #[serde(default)]
     pub external_changes: Vec<ExternalChange>,
     #[serde(default)]
@@ -70,6 +74,10 @@ pub struct SafetyConfig {
     pub max_columns_per_model: usize,
     #[serde(default = "default_pk_limit")]
     pub primary_key_sample_limit: usize,
+    #[serde(default = "default_max_query_checks")]
+    pub max_query_checks: usize,
+    #[serde(default = "default_max_example_value_chars")]
+    pub max_example_value_chars: usize,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -147,6 +155,33 @@ impl Default for SafetyConfig {
             max_models: default_max_models(),
             max_columns_per_model: default_max_columns(),
             primary_key_sample_limit: default_pk_limit(),
+            max_query_checks: default_max_query_checks(),
+            max_example_value_chars: default_max_example_value_chars(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+pub enum CheckConfig {
+    QueryDiff(QueryDiffConfig),
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct QueryDiffConfig {
+    pub name: String,
+    pub account: Option<String>,
+    pub sql: String,
+    pub production_sql: Option<String>,
+    #[serde(default)]
+    pub primary_key: Vec<String>,
+}
+
+impl CheckConfig {
+    pub fn query_diff(&self) -> &QueryDiffConfig {
+        match self {
+            Self::QueryDiff(check) => check,
         }
     }
 }
@@ -288,8 +323,12 @@ impl Config {
     pub fn load(path: &Path) -> Result<Self> {
         let bytes =
             fs::read(path).with_context(|| format!("could not read config {}", path.display()))?;
-        let config: Self = serde_yaml::from_slice(&bytes)
+        let mut config: Self = serde_yaml::from_slice(&bytes)
             .with_context(|| format!("invalid config {}", path.display()))?;
+        config.source_path = Some(
+            path.canonicalize()
+                .with_context(|| format!("could not resolve config {}", path.display()))?,
+        );
         config.validate()?;
         Ok(config)
     }
@@ -315,8 +354,21 @@ impl Config {
         {
             bail!("every account needs a dbt selector when multiple accounts are configured");
         }
-        if self.safety.max_models == 0 || self.safety.max_columns_per_model == 0 {
-            bail!("safety model and column limits must be greater than zero");
+        if self.safety.max_models == 0
+            || self.safety.max_columns_per_model == 0
+            || self.safety.max_query_checks == 0
+            || self.safety.max_example_value_chars == 0
+        {
+            bail!(
+                "safety model, column, query-check, and example limits must be greater than zero"
+            );
+        }
+        if self.checks.len() > self.safety.max_query_checks {
+            bail!(
+                "{} checks exceed safety.max_query_checks {}",
+                self.checks.len(),
+                self.safety.max_query_checks
+            );
         }
         if self.safety.statement_timeout_seconds == 0 {
             bail!("statement timeout must be greater than zero");
@@ -432,6 +484,55 @@ impl Config {
                 }
             }
         }
+        let mut check_names = BTreeSet::new();
+        for check in &self.checks {
+            let check = check.query_diff();
+            if check.name.trim().is_empty() {
+                bail!("query-diff check names must not be empty");
+            }
+            if !check_names.insert(check.name.to_ascii_lowercase()) {
+                bail!("query-diff check names must be unique (case-insensitive)");
+            }
+            if self.accounts.len() > 1 && check.account.is_none() {
+                bail!(
+                    "check {} needs an account when multiple accounts are configured",
+                    check.name
+                );
+            }
+            if let Some(account) = &check.account {
+                if !self
+                    .accounts
+                    .iter()
+                    .any(|candidate| candidate.name == *account)
+                {
+                    bail!("check {} references unknown account {account}", check.name);
+                }
+            }
+            crate::query::QueryTemplate::parse(&check.sql)
+                .with_context(|| format!("invalid SQL template for check {}", check.name))?;
+            if let Some(sql) = &check.production_sql {
+                crate::query::QueryTemplate::parse(sql).with_context(|| {
+                    format!("invalid production_sql template for check {}", check.name)
+                })?;
+            }
+            if check.primary_key.iter().any(|key| key.trim().is_empty()) {
+                bail!(
+                    "check {} primary_key must not contain empty columns",
+                    check.name
+                );
+            }
+            let distinct_keys = check
+                .primary_key
+                .iter()
+                .map(|key| key.to_ascii_lowercase())
+                .collect::<BTreeSet<_>>();
+            if distinct_keys.len() != check.primary_key.len() {
+                bail!(
+                    "check {} primary_key columns must be unique (case-insensitive)",
+                    check.name
+                );
+            }
+        }
         if let Some(metabase) = &self.metabase {
             let url = url::Url::parse(&metabase.url).context("metabase.url is invalid")?;
             if !matches!(url.scheme(), "http" | "https") || url.host_str().is_none() {
@@ -539,6 +640,12 @@ fn default_max_columns() -> usize {
 fn default_pk_limit() -> usize {
     20
 }
+fn default_max_query_checks() -> usize {
+    20
+}
+fn default_max_example_value_chars() -> usize {
+    512
+}
 fn default_comparison_concurrency() -> usize {
     4
 }
@@ -604,6 +711,59 @@ accounts:
     fn example_config_stays_valid() {
         let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("embrasure-check.example.yml");
         Config::load(&path).unwrap();
+    }
+
+    #[test]
+    fn arbitrary_query_checks_are_validated_at_config_load() {
+        let valid = r#"
+version: 1
+accounts:
+  - name: primary
+    account: org-one
+    user: ci
+    role: ci
+    database: analytics
+    warehouse: ci
+    production_schema: prod
+    auth: { type: oauth, token_env: TOKEN }
+checks:
+  - type: query_diff
+    name: paid orders
+    sql: select id, amount from {{ ref('orders') }} where status = 'paid'
+    production_sql: select id, amount from {{ ref('legacy_orders') }} where status = 'paid'
+    primary_key: [id]
+"#;
+        let config: Config = serde_yaml::from_str(valid).unwrap();
+        config.validate().unwrap();
+
+        let unsafe_sql = valid.replace(
+            "select id, amount from {{ ref('orders') }} where status = 'paid'",
+            "delete from orders",
+        );
+        let config: Config = serde_yaml::from_str(&unsafe_sql).unwrap();
+        assert!(format!("{:#}", config.validate().unwrap_err()).contains("SELECT"));
+    }
+
+    #[test]
+    fn query_check_budget_and_names_are_enforced() {
+        let yaml = r#"
+version: 1
+safety: { max_query_checks: 1 }
+accounts:
+  - name: primary
+    account: org-one
+    user: ci
+    role: ci
+    database: analytics
+    warehouse: ci
+    production_schema: prod
+    auth: { type: oauth, token_env: TOKEN }
+checks:
+  - { type: query_diff, name: same, sql: "select 1" }
+  - { type: query_diff, name: SAME, sql: "select 1" }
+"#;
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        assert!(config.validate().is_err());
     }
 
     #[test]

--- a/src/dbt.rs
+++ b/src/dbt.rs
@@ -599,6 +599,32 @@ pub fn prepare(
 }
 
 impl DbtContext {
+    #[cfg(test)]
+    pub fn for_test(
+        repo_root: PathBuf,
+        manifests: BTreeMap<String, Manifest>,
+        production_manifests: BTreeMap<String, Manifest>,
+    ) -> Result<Self> {
+        let scratch = tempfile::tempdir()?;
+        let profiles_dir = scratch.path().join("profiles");
+        fs::create_dir_all(&profiles_dir)?;
+        let mut state_dirs = BTreeMap::new();
+        for account in manifests.keys() {
+            let state = scratch.path().join("state").join(account);
+            fs::create_dir_all(&state)?;
+            state_dirs.insert(account.clone(), state);
+        }
+        Ok(Self {
+            scratch,
+            repo_root,
+            profiles_dir,
+            state_dirs,
+            manifests,
+            production_manifests,
+            base_worktree: None,
+        })
+    }
+
     pub fn manifest(&self, account: &str) -> Result<&Manifest> {
         self.manifests
             .get(account)

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod git;
 mod init;
 mod loopback;
 mod metabase;
+mod query;
 mod report;
 mod run;
 mod snowflake;
@@ -112,7 +113,7 @@ enum Command {
         #[arg(long, hide = true)]
         production_schema: Option<String>,
     },
-    /// Build and compare changed dbt models.
+    /// Build and compare changed dbt models, then run configured query checks.
     #[command(alias = "run")]
     Check {
         /// Git revision used as the production comparison base.
@@ -359,7 +360,7 @@ async fn main() -> ExitCode {
                     report.finalize();
                 }
             }
-            let report_version = report_version.unwrap_or(report::ReportVersion::V2);
+            let report_version = report_version.unwrap_or(report::ReportVersion::V3);
             if use_cloud {
                 if report.exit_code == report::EXIT_EXECUTION {
                     if json {

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,0 +1,1799 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    future::Future,
+    pin::Pin,
+};
+
+use anyhow::{Context, Result, bail};
+
+use crate::{
+    config::SafetyConfig,
+    report::{
+        QueryCheckReport, QueryCheckStatus, QueryColumnComparison, QueryColumnMismatch,
+        QueryComparison, QueryDiffExample,
+    },
+    snowflake::{QueryResult, Relation, ResultColumn, SnowflakeClient, quote_identifier},
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct RefTarget {
+    pub package: Option<String>,
+    pub name: String,
+}
+
+impl RefTarget {
+    pub fn display(&self) -> String {
+        self.package.as_ref().map_or_else(
+            || self.name.clone(),
+            |package| format!("{package}.{}", self.name),
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+enum TemplatePart {
+    Sql(String),
+    Ref(RefTarget),
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct QueryTemplate {
+    parts: Vec<TemplatePart>,
+    refs: Vec<RefTarget>,
+}
+
+impl QueryTemplate {
+    pub fn parse(sql: &str) -> Result<Self> {
+        let normalized = normalize_statement(sql)?;
+        let first = first_keyword(&normalized).context("SQL query is empty")?;
+        if !matches!(first.as_str(), "SELECT" | "WITH" | "VALUES") {
+            bail!("SQL must be one SELECT, WITH, or VALUES query expression");
+        }
+        let mut parts = Vec::new();
+        let mut refs = Vec::new();
+        let mut literal_start = 0;
+        let mut index = 0;
+        let bytes = normalized.as_bytes();
+        let mut state = LexState::Normal;
+        while index < bytes.len() {
+            match state {
+                LexState::Normal => {
+                    if starts(bytes, index, b"--") {
+                        state = LexState::LineComment;
+                        index += 2;
+                    } else if starts(bytes, index, b"/*") {
+                        state = LexState::BlockComment;
+                        index += 2;
+                    } else if starts(bytes, index, b"$$") {
+                        state = LexState::DollarString;
+                        index += 2;
+                    } else if bytes[index] == b'\'' {
+                        state = LexState::SingleQuote;
+                        index += 1;
+                    } else if bytes[index] == b'"' {
+                        state = LexState::DoubleQuote;
+                        index += 1;
+                    } else if starts(bytes, index, b"{{") {
+                        if literal_start < index {
+                            parts.push(TemplatePart::Sql(normalized[literal_start..index].into()));
+                        }
+                        let end = normalized[index + 2..]
+                            .find("}}")
+                            .map(|offset| index + 2 + offset)
+                            .context("unterminated Jinja expression")?;
+                        let target = parse_ref(&normalized[index + 2..end])?;
+                        refs.push(target.clone());
+                        parts.push(TemplatePart::Ref(target));
+                        index = end + 2;
+                        literal_start = index;
+                    } else if starts(bytes, index, b"{%") || starts(bytes, index, b"{#") {
+                        bail!("only dbt ref() expressions are supported in query checks");
+                    } else {
+                        index += 1;
+                    }
+                }
+                LexState::SingleQuote => {
+                    if bytes[index] == b'\'' {
+                        if bytes.get(index + 1) == Some(&b'\'') {
+                            index += 2;
+                        } else {
+                            state = LexState::Normal;
+                            index += 1;
+                        }
+                    } else {
+                        index += 1;
+                    }
+                }
+                LexState::DoubleQuote => {
+                    if bytes[index] == b'"' {
+                        if bytes.get(index + 1) == Some(&b'"') {
+                            index += 2;
+                        } else {
+                            state = LexState::Normal;
+                            index += 1;
+                        }
+                    } else {
+                        index += 1;
+                    }
+                }
+                LexState::LineComment => {
+                    if bytes[index] == b'\n' {
+                        state = LexState::Normal;
+                    }
+                    index += 1;
+                }
+                LexState::BlockComment => {
+                    if starts(bytes, index, b"*/") {
+                        state = LexState::Normal;
+                        index += 2;
+                    } else {
+                        index += 1;
+                    }
+                }
+                LexState::DollarString => {
+                    if starts(bytes, index, b"$$") {
+                        state = LexState::Normal;
+                        index += 2;
+                    } else {
+                        index += 1;
+                    }
+                }
+            }
+        }
+        ensure_terminated(state)?;
+        if literal_start < normalized.len() {
+            parts.push(TemplatePart::Sql(normalized[literal_start..].into()));
+        }
+        refs.sort();
+        refs.dedup();
+        Ok(Self { parts, refs })
+    }
+
+    pub fn refs(&self) -> &[RefTarget] {
+        &self.refs
+    }
+
+    pub fn render(&self, mut resolve: impl FnMut(&RefTarget) -> Result<String>) -> Result<String> {
+        let mut sql = String::new();
+        for part in &self.parts {
+            match part {
+                TemplatePart::Sql(value) => sql.push_str(value),
+                TemplatePart::Ref(target) => sql.push_str(&resolve(target)?),
+            }
+        }
+        Ok(sql)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LexState {
+    Normal,
+    SingleQuote,
+    DoubleQuote,
+    LineComment,
+    BlockComment,
+    DollarString,
+}
+
+fn normalize_statement(sql: &str) -> Result<String> {
+    if sql.trim().is_empty() {
+        bail!("SQL query is empty");
+    }
+    let bytes = sql.as_bytes();
+    let mut state = LexState::Normal;
+    let mut semicolons = Vec::new();
+    let mut index = 0;
+    while index < bytes.len() {
+        match state {
+            LexState::Normal => {
+                if starts(bytes, index, b"--") {
+                    state = LexState::LineComment;
+                    index += 2;
+                } else if starts(bytes, index, b"/*") {
+                    state = LexState::BlockComment;
+                    index += 2;
+                } else if starts(bytes, index, b"$$") {
+                    state = LexState::DollarString;
+                    index += 2;
+                } else if bytes[index] == b'\'' {
+                    state = LexState::SingleQuote;
+                    index += 1;
+                } else if bytes[index] == b'"' {
+                    state = LexState::DoubleQuote;
+                    index += 1;
+                } else {
+                    if bytes[index] == b';' {
+                        semicolons.push(index);
+                    }
+                    index += 1;
+                }
+            }
+            LexState::SingleQuote => {
+                if bytes[index] == b'\'' {
+                    if bytes.get(index + 1) == Some(&b'\'') {
+                        index += 2;
+                    } else {
+                        state = LexState::Normal;
+                        index += 1;
+                    }
+                } else {
+                    index += 1;
+                }
+            }
+            LexState::DoubleQuote => {
+                if bytes[index] == b'"' {
+                    if bytes.get(index + 1) == Some(&b'"') {
+                        index += 2;
+                    } else {
+                        state = LexState::Normal;
+                        index += 1;
+                    }
+                } else {
+                    index += 1;
+                }
+            }
+            LexState::LineComment => {
+                if bytes[index] == b'\n' {
+                    state = LexState::Normal;
+                }
+                index += 1;
+            }
+            LexState::BlockComment => {
+                if starts(bytes, index, b"*/") {
+                    state = LexState::Normal;
+                    index += 2;
+                } else {
+                    index += 1;
+                }
+            }
+            LexState::DollarString => {
+                if starts(bytes, index, b"$$") {
+                    state = LexState::Normal;
+                    index += 2;
+                } else {
+                    index += 1;
+                }
+            }
+        }
+    }
+    ensure_terminated(state)?;
+    match semicolons.as_slice() {
+        [] => Ok(sql.trim().into()),
+        [semicolon] if comment_or_whitespace_tail(&sql[semicolon + 1..])? => {
+            let mut normalized = String::with_capacity(sql.len() - 1);
+            normalized.push_str(&sql[..*semicolon]);
+            normalized.push_str(&sql[semicolon + 1..]);
+            Ok(normalized.trim().into())
+        }
+        _ => bail!("SQL must contain one query expression, not multiple statements"),
+    }
+}
+
+fn comment_or_whitespace_tail(tail: &str) -> Result<bool> {
+    let bytes = tail.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index].is_ascii_whitespace() {
+            index += 1;
+        } else if starts(bytes, index, b"--") {
+            index = bytes[index + 2..]
+                .iter()
+                .position(|byte| *byte == b'\n')
+                .map_or(bytes.len(), |offset| index + 3 + offset);
+        } else if starts(bytes, index, b"/*") {
+            let Some(offset) = tail[index + 2..].find("*/") else {
+                bail!("unterminated block comment");
+            };
+            index += offset + 4;
+        } else {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+fn first_keyword(sql: &str) -> Option<String> {
+    let bytes = sql.as_bytes();
+    let mut index = 0;
+    loop {
+        while bytes.get(index).is_some_and(u8::is_ascii_whitespace) {
+            index += 1;
+        }
+        if starts(bytes, index, b"--") {
+            index = bytes[index + 2..]
+                .iter()
+                .position(|byte| *byte == b'\n')
+                .map_or(bytes.len(), |offset| index + 3 + offset);
+        } else if starts(bytes, index, b"/*") {
+            let offset = sql[index + 2..].find("*/")?;
+            index += offset + 4;
+        } else {
+            break;
+        }
+    }
+    let start = index;
+    while bytes
+        .get(index)
+        .is_some_and(|byte| byte.is_ascii_alphabetic())
+    {
+        index += 1;
+    }
+    (index > start).then(|| sql[start..index].to_ascii_uppercase())
+}
+
+fn ensure_terminated(state: LexState) -> Result<()> {
+    match state {
+        LexState::Normal | LexState::LineComment => Ok(()),
+        LexState::SingleQuote => bail!("unterminated single-quoted string"),
+        LexState::DoubleQuote => bail!("unterminated quoted identifier"),
+        LexState::BlockComment => bail!("unterminated block comment"),
+        LexState::DollarString => bail!("unterminated dollar-quoted string"),
+    }
+}
+
+fn parse_ref(expression: &str) -> Result<RefTarget> {
+    let expression = expression.trim();
+    let arguments = expression
+        .strip_prefix("ref")
+        .and_then(|rest| {
+            let rest = rest.trim();
+            rest.strip_prefix('(')?.strip_suffix(')')
+        })
+        .context("only dbt ref() expressions are supported in query checks")?;
+    let arguments = split_ref_arguments(arguments)?;
+    match arguments.as_slice() {
+        [name] => Ok(RefTarget {
+            package: None,
+            name: name.clone(),
+        }),
+        [package, name] => Ok(RefTarget {
+            package: Some(package.clone()),
+            name: name.clone(),
+        }),
+        _ => bail!("ref() must have one model name or a package and model name"),
+    }
+}
+
+fn split_ref_arguments(input: &str) -> Result<Vec<String>> {
+    let mut values = Vec::new();
+    let mut index = 0;
+    let bytes = input.as_bytes();
+    while index < bytes.len() {
+        while bytes
+            .get(index)
+            .is_some_and(|byte| byte.is_ascii_whitespace())
+        {
+            index += 1;
+        }
+        let quote = *bytes
+            .get(index)
+            .context("ref() arguments must be quoted strings")?;
+        if !matches!(quote, b'\'' | b'"') {
+            bail!("ref() arguments must be quoted strings");
+        }
+        index += 1;
+        let start = index;
+        while bytes.get(index).is_some_and(|byte| *byte != quote) {
+            index += 1;
+        }
+        let end = index;
+        if bytes.get(index) != Some(&quote) {
+            bail!("unterminated ref() argument");
+        }
+        values.push(input[start..end].to_owned());
+        index += 1;
+        while bytes
+            .get(index)
+            .is_some_and(|byte| byte.is_ascii_whitespace())
+        {
+            index += 1;
+        }
+        if index == bytes.len() {
+            break;
+        }
+        if bytes[index] != b',' {
+            bail!("ref() arguments must be comma-separated quoted strings");
+        }
+        index += 1;
+    }
+    if values.iter().any(String::is_empty) {
+        bail!("ref() arguments must not be empty");
+    }
+    Ok(values)
+}
+
+fn starts(bytes: &[u8], index: usize, value: &[u8]) -> bool {
+    bytes.get(index..index + value.len()) == Some(value)
+}
+
+pub(crate) trait QueryExecutor: Send + Sync {
+    fn execute<'a>(
+        &'a self,
+        statement: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<QueryResult>> + Send + 'a>>;
+}
+
+impl QueryExecutor for SnowflakeClient {
+    fn execute<'a>(
+        &'a self,
+        statement: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<QueryResult>> + Send + 'a>> {
+        Box::pin(SnowflakeClient::execute(self, statement))
+    }
+}
+
+pub(crate) struct QueryDiffInput<'a> {
+    pub name: &'a str,
+    pub account: &'a str,
+    pub current_refs: Vec<String>,
+    pub production_refs: Vec<String>,
+    pub candidate_sql: &'a str,
+    pub production_sql: &'a str,
+    pub candidate: &'a Relation,
+    pub production: &'a Relation,
+    pub primary_key: &'a [String],
+    pub safety: &'a SafetyConfig,
+}
+
+#[derive(Clone, Copy)]
+struct ExampleLimits {
+    rows: usize,
+    value_chars: usize,
+}
+
+pub(crate) async fn run_query_diff<E: QueryExecutor>(
+    executor: &E,
+    input: QueryDiffInput<'_>,
+) -> Result<QueryCheckReport> {
+    let mut report = QueryCheckReport {
+        name: input.name.into(),
+        account: input.account.into(),
+        status: QueryCheckStatus::Incomplete,
+        current_refs: input.current_refs,
+        production_refs: input.production_refs,
+        primary_key: input.primary_key.to_vec(),
+        candidate_relation: Some(input.candidate.sql()),
+        production_relation: Some(input.production.sql()),
+        candidate_row_count: None,
+        production_row_count: None,
+        columns: vec![],
+        comparison: None,
+        reason: None,
+        invalid_primary_key_reason: None,
+        examples_truncated: false,
+    };
+    let candidate_columns = preflight(executor, input.candidate_sql).await?;
+    let production_columns = preflight(executor, input.production_sql).await?;
+    report.invalid_primary_key_reason =
+        primary_key_metadata_error(input.primary_key, &candidate_columns, &production_columns);
+    if let Some(failure) = validate_preflight(
+        &candidate_columns,
+        &production_columns,
+        input.safety.max_columns_per_model,
+    ) {
+        report.reason = Some(failure);
+        report.columns = schema_evidence(&candidate_columns, &production_columns);
+        return Ok(report);
+    }
+
+    executor
+        .execute(&format!(
+            "CREATE TRANSIENT TABLE {} AS SELECT * FROM (\n{}\n)",
+            input.candidate.sql(),
+            input.candidate_sql
+        ))
+        .await
+        .context("could not materialize candidate query")?;
+    executor
+        .execute(&format!(
+            "CREATE TRANSIENT TABLE {} AS SELECT * FROM (\n{}\n)",
+            input.production.sql(),
+            input.production_sql
+        ))
+        .await
+        .context("could not materialize production query")?;
+
+    report.columns = schema_evidence(&candidate_columns, &production_columns);
+    let (candidate_rows, production_rows) =
+        row_counts(executor, input.candidate, input.production).await?;
+    report.candidate_row_count = Some(candidate_rows);
+    report.production_row_count = Some(production_rows);
+    let Some(pairs) = paired_columns(&candidate_columns, &production_columns) else {
+        report.status = QueryCheckStatus::Findings;
+        report.reason = Some(
+            "candidate and production query schemas differ; value comparison was skipped".into(),
+        );
+        return Ok(report);
+    };
+    let comparison = if input.primary_key.is_empty() {
+        let limits = ExampleLimits {
+            rows: input.safety.primary_key_sample_limit,
+            value_chars: input.safety.max_example_value_chars,
+        };
+        compare_unkeyed(
+            executor,
+            input.candidate,
+            input.production,
+            &pairs,
+            limits,
+            &mut report.examples_truncated,
+        )
+        .await?
+    } else {
+        let keys = match resolve_keys(input.primary_key, &pairs) {
+            Ok(keys) => keys,
+            Err(reason) => {
+                report.invalid_primary_key_reason = Some(reason.clone());
+                report.reason = Some(reason);
+                return Ok(report);
+            }
+        };
+        let candidate_integrity = key_integrity(executor, input.candidate, &keys, true).await?;
+        let production_integrity = key_integrity(executor, input.production, &keys, false).await?;
+        if candidate_integrity.0 > 0
+            || candidate_integrity.2 > 0
+            || production_integrity.0 > 0
+            || production_integrity.2 > 0
+        {
+            let examples = key_integrity_examples(
+                executor,
+                input.candidate,
+                input.production,
+                &keys,
+                ExampleLimits {
+                    rows: input.safety.primary_key_sample_limit,
+                    value_chars: input.safety.max_example_value_chars,
+                },
+                &mut report.examples_truncated,
+            )
+            .await?;
+            report.status = QueryCheckStatus::Findings;
+            report.reason = Some(format!(
+                "key integrity blocks value comparison: candidate has {} duplicate keys and {} null-key rows; production has {} duplicate keys and {} null-key rows",
+                candidate_integrity.0,
+                candidate_integrity.2,
+                production_integrity.0,
+                production_integrity.2
+            ));
+            report.comparison = Some(QueryComparison {
+                candidate_only_rows: 0,
+                production_only_rows: 0,
+                changed_rows: 0,
+                candidate_duplicate_keys: candidate_integrity.0,
+                production_duplicate_keys: production_integrity.0,
+                candidate_duplicate_rows: candidate_integrity.1,
+                production_duplicate_rows: production_integrity.1,
+                candidate_null_key_rows: candidate_integrity.2,
+                production_null_key_rows: production_integrity.2,
+                column_mismatches: vec![],
+                examples,
+            });
+            return Ok(report);
+        }
+        compare_keyed(
+            executor,
+            input.candidate,
+            input.production,
+            &pairs,
+            &keys,
+            ExampleLimits {
+                rows: input.safety.primary_key_sample_limit,
+                value_chars: input.safety.max_example_value_chars,
+            },
+            &mut report.examples_truncated,
+        )
+        .await?
+    };
+    let differs = comparison.candidate_only_rows > 0
+        || comparison.production_only_rows > 0
+        || comparison.changed_rows > 0;
+    report.status = if differs {
+        QueryCheckStatus::Findings
+    } else {
+        QueryCheckStatus::Pass
+    };
+    if differs {
+        report.reason = Some(format!(
+            "{} candidate-only, {} production-only, and {} changed rows",
+            comparison.candidate_only_rows,
+            comparison.production_only_rows,
+            comparison.changed_rows
+        ));
+    }
+    report.comparison = Some(comparison);
+    Ok(report)
+}
+
+async fn preflight<E: QueryExecutor>(executor: &E, sql: &str) -> Result<Vec<ResultColumn>> {
+    Ok(executor
+        .execute(&format!("SELECT * FROM (\n{sql}\n) LIMIT 0"))
+        .await?
+        .columns)
+}
+
+fn validate_preflight(
+    candidate: &[ResultColumn],
+    production: &[ResultColumn],
+    max_columns: usize,
+) -> Option<String> {
+    for (side, columns) in [("candidate", candidate), ("production", production)] {
+        if columns.is_empty() {
+            return Some(format!("{side} query returned no columns"));
+        }
+        if columns.len() > max_columns {
+            return Some(format!(
+                "{side} query has {} columns, above safety.max_columns_per_model {max_columns}",
+                columns.len()
+            ));
+        }
+        let mut names = BTreeSet::new();
+        for column in columns {
+            if unsupported_type(&column.data_type) {
+                return Some(format!(
+                    "{side} query column {} has unsupported type {}; cast semi-structured, vector, or geospatial values to a scalar type",
+                    column.name, column.data_type
+                ));
+            }
+            if column.name.to_ascii_uppercase().starts_with("__EMBRASURE_") {
+                return Some(format!(
+                    "{side} query column {} uses the reserved __EMBRASURE_ prefix; add a different alias",
+                    column.name
+                ));
+            }
+            if !names.insert(column.name.to_ascii_lowercase()) {
+                return Some(format!(
+                    "{side} query returns duplicate column name {}; add unique aliases",
+                    column.name
+                ));
+            }
+        }
+    }
+    None
+}
+
+fn primary_key_metadata_error(
+    configured: &[String],
+    candidate: &[ResultColumn],
+    production: &[ResultColumn],
+) -> Option<String> {
+    configured.iter().find_map(|key| {
+        let candidate_matches = candidate
+            .iter()
+            .filter(|column| column.name.eq_ignore_ascii_case(key))
+            .collect::<Vec<_>>();
+        let production_matches = production
+            .iter()
+            .filter(|column| column.name.eq_ignore_ascii_case(key))
+            .collect::<Vec<_>>();
+        match (candidate_matches.as_slice(), production_matches.as_slice()) {
+            ([candidate], [production]) => {
+                if !candidate
+                    .data_type
+                    .eq_ignore_ascii_case(&production.data_type)
+                {
+                    Some(format!(
+                        "primary-key column {key} has incompatible types {} and {}",
+                        candidate.data_type, production.data_type
+                    ))
+                } else if unsupported_type(&candidate.data_type)
+                    || unsupported_type(&production.data_type)
+                {
+                    Some(format!(
+                        "primary-key column {key} has unsupported type {}",
+                        candidate.data_type
+                    ))
+                } else {
+                    None
+                }
+            }
+            ([], _) | (_, []) => Some(format!(
+                "primary-key column {key} is missing from one or both query results"
+            )),
+            _ => Some(format!("primary-key column {key} is ambiguous")),
+        }
+    })
+}
+
+fn schema_evidence(
+    candidate: &[ResultColumn],
+    production: &[ResultColumn],
+) -> Vec<QueryColumnComparison> {
+    let candidate = column_map(candidate);
+    let production = column_map(production);
+    candidate
+        .keys()
+        .chain(production.keys())
+        .cloned()
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .map(|name| QueryColumnComparison {
+            name: candidate
+                .get(&name)
+                .or_else(|| production.get(&name))
+                .map(|column| column.name.clone())
+                .unwrap_or(name.clone()),
+            candidate_type: candidate.get(&name).map(|column| column.data_type.clone()),
+            production_type: production.get(&name).map(|column| column.data_type.clone()),
+        })
+        .collect()
+}
+
+fn paired_columns<'a>(
+    candidate: &'a [ResultColumn],
+    production: &'a [ResultColumn],
+) -> Option<Vec<(&'a ResultColumn, &'a ResultColumn)>> {
+    let candidate_map = column_map(candidate);
+    let production_map = column_map(production);
+    if candidate_map.len() != production_map.len() || candidate_map.keys().ne(production_map.keys())
+    {
+        return None;
+    }
+    candidate_map
+        .into_iter()
+        .map(|(name, candidate)| {
+            let production = production_map.get(&name)?;
+            candidate
+                .data_type
+                .eq_ignore_ascii_case(&production.data_type)
+                .then_some((candidate, *production))
+        })
+        .collect()
+}
+
+fn column_map(columns: &[ResultColumn]) -> BTreeMap<String, &ResultColumn> {
+    columns
+        .iter()
+        .map(|column| (column.name.to_ascii_lowercase(), column))
+        .collect()
+}
+
+fn unsupported_type(data_type: &str) -> bool {
+    matches!(
+        data_type
+            .split(['(', ' '])
+            .next()
+            .unwrap_or(data_type)
+            .to_ascii_uppercase()
+            .as_str(),
+        "ARRAY" | "OBJECT" | "VARIANT" | "GEOGRAPHY" | "GEOMETRY" | "MAP" | "VECTOR"
+    )
+}
+
+async fn row_counts<E: QueryExecutor>(
+    executor: &E,
+    candidate: &Relation,
+    production: &Relation,
+) -> Result<(u64, u64)> {
+    let result = executor
+        .execute(&format!(
+            "SELECT (SELECT COUNT(*) FROM {}), (SELECT COUNT(*) FROM {})",
+            candidate.sql(),
+            production.sql()
+        ))
+        .await?;
+    let row = result
+        .rows
+        .first()
+        .context("row-count query returned no row")?;
+    Ok((parse_u64(row.first())?, parse_u64(row.get(1))?))
+}
+
+type ColumnPair<'a> = (&'a ResultColumn, &'a ResultColumn);
+
+fn resolve_keys<'a>(
+    configured: &[String],
+    pairs: &[ColumnPair<'a>],
+) -> Result<Vec<ColumnPair<'a>>, String> {
+    let mut resolved = Vec::new();
+    for key in configured {
+        let matches = pairs
+            .iter()
+            .filter(|(candidate, production)| {
+                candidate.name.eq_ignore_ascii_case(key)
+                    || production.name.eq_ignore_ascii_case(key)
+            })
+            .copied()
+            .collect::<Vec<_>>();
+        match matches.as_slice() {
+            [pair] => resolved.push(*pair),
+            [] => {
+                return Err(format!(
+                    "primary-key column {key} is missing from one or both query results"
+                ));
+            }
+            _ => return Err(format!("primary-key column {key} is ambiguous")),
+        }
+    }
+    Ok(resolved)
+}
+
+async fn key_integrity<E: QueryExecutor>(
+    executor: &E,
+    relation: &Relation,
+    keys: &[ColumnPair<'_>],
+    candidate_side: bool,
+) -> Result<(u64, u64, u64)> {
+    let names = keys
+        .iter()
+        .map(|pair| {
+            quote_identifier(if candidate_side {
+                &pair.0.name
+            } else {
+                &pair.1.name
+            })
+        })
+        .collect::<Vec<_>>();
+    let nulls = names
+        .iter()
+        .map(|name| format!("{name} IS NULL"))
+        .collect::<Vec<_>>()
+        .join(" OR ");
+    let result = executor
+        .execute(&format!(
+            "SELECT COALESCE(SUM(IFF(NOT ({nulls}) AND __EMBRASURE_N > 1, 1, 0)), 0), \
+             COALESCE(SUM(IFF(NOT ({nulls}) AND __EMBRASURE_N > 1, __EMBRASURE_N - 1, 0)), 0), \
+             COALESCE(SUM(IFF(({nulls}), __EMBRASURE_N, 0)), 0) \
+             FROM (SELECT {}, COUNT(*) AS __EMBRASURE_N FROM {} GROUP BY {})",
+            names.join(", "),
+            relation.sql(),
+            names.join(", ")
+        ))
+        .await?;
+    let row = result
+        .rows
+        .first()
+        .context("key-integrity query returned no row")?;
+    Ok((
+        parse_u64(row.first())?,
+        parse_u64(row.get(1))?,
+        parse_u64(row.get(2))?,
+    ))
+}
+
+async fn key_integrity_examples<E: QueryExecutor>(
+    executor: &E,
+    candidate: &Relation,
+    production: &Relation,
+    keys: &[ColumnPair<'_>],
+    limits: ExampleLimits,
+    examples_truncated: &mut bool,
+) -> Result<Vec<QueryDiffExample>> {
+    if limits.rows == 0 {
+        return Ok(vec![]);
+    }
+    let canonical = keys
+        .iter()
+        .map(|pair| quote_identifier(&pair.0.name))
+        .collect::<Vec<_>>();
+    let candidate_keys = keys
+        .iter()
+        .map(|pair| {
+            format!(
+                "{} AS {}",
+                quote_identifier(&pair.0.name),
+                quote_identifier(&pair.0.name)
+            )
+        })
+        .collect::<Vec<_>>();
+    let production_keys = keys
+        .iter()
+        .map(|pair| {
+            format!(
+                "{} AS {}",
+                quote_identifier(&pair.1.name),
+                quote_identifier(&pair.0.name)
+            )
+        })
+        .collect::<Vec<_>>();
+    let nulls = canonical
+        .iter()
+        .map(|name| format!("{name} IS NULL"))
+        .collect::<Vec<_>>()
+        .join(" OR ");
+    let values = keys
+        .iter()
+        .map(|pair| bounded_value("X", &pair.0.name, limits.value_chars))
+        .collect::<Vec<_>>();
+    let ordering = canonical
+        .iter()
+        .map(|name| format!("X.{name} NULLS FIRST"))
+        .chain(std::iter::once("X.__EMBRASURE_SIDE".into()))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let result = executor
+        .execute(&format!(
+            "WITH C_KEYS AS (SELECT {}, COUNT(*) AS __EMBRASURE_N FROM {} GROUP BY {}), \
+             P_KEYS AS (SELECT {}, COUNT(*) AS __EMBRASURE_N FROM {} GROUP BY {}), \
+             ISSUES AS (\
+               SELECT 'candidate' AS __EMBRASURE_SIDE, * FROM C_KEYS WHERE __EMBRASURE_N > 1 OR ({nulls}) \
+               UNION ALL \
+               SELECT 'production' AS __EMBRASURE_SIDE, * FROM P_KEYS WHERE __EMBRASURE_N > 1 OR ({nulls})\
+             ) \
+             SELECT X.__EMBRASURE_SIDE, {}, X.__EMBRASURE_N::VARCHAR FROM ISSUES X \
+             ORDER BY {ordering} LIMIT {}",
+            candidate_keys.join(", "),
+            candidate.sql(),
+            canonical.join(", "),
+            production_keys.join(", "),
+            production.sql(),
+            canonical.join(", "),
+            values.join(", "),
+            limits.rows
+        ))
+        .await?;
+    result
+        .rows
+        .into_iter()
+        .map(|mut row| {
+            let side = row
+                .first()
+                .and_then(Option::as_deref)
+                .context("key-integrity example omitted its side")?
+                .to_owned();
+            let end = 1 + keys.len();
+            let multiplicity = parse_u64(row.get(end))?;
+            truncate_row(&mut row[1..end], limits.value_chars, examples_truncated);
+            Ok(QueryDiffExample {
+                key: row[1..end].to_vec(),
+                candidate: vec![],
+                production: vec![],
+                candidate_multiplicity: (side == "candidate").then_some(multiplicity),
+                production_multiplicity: (side == "production").then_some(multiplicity),
+            })
+        })
+        .collect()
+}
+
+async fn compare_keyed<E: QueryExecutor>(
+    executor: &E,
+    candidate: &Relation,
+    production: &Relation,
+    pairs: &[ColumnPair<'_>],
+    keys: &[ColumnPair<'_>],
+    limits: ExampleLimits,
+    examples_truncated: &mut bool,
+) -> Result<QueryComparison> {
+    let join = keys
+        .iter()
+        .map(|pair| {
+            format!(
+                "EQUAL_NULL(C.{}, P.{})",
+                quote_identifier(&pair.0.name),
+                quote_identifier(&pair.1.name)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(" AND ");
+    let value_pairs = pairs
+        .iter()
+        .filter(|pair| {
+            !keys
+                .iter()
+                .any(|key| key.0.name.eq_ignore_ascii_case(&pair.0.name))
+        })
+        .copied()
+        .collect::<Vec<_>>();
+    let changed = if value_pairs.is_empty() {
+        "FALSE".into()
+    } else {
+        value_pairs
+            .iter()
+            .map(|pair| {
+                format!(
+                    "NOT EQUAL_NULL(C.{}, P.{})",
+                    quote_identifier(&pair.0.name),
+                    quote_identifier(&pair.1.name)
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(" OR ")
+    };
+    let candidate_present = format!("C.{} IS NOT NULL", quote_identifier(&keys[0].0.name));
+    let production_present = format!("P.{} IS NOT NULL", quote_identifier(&keys[0].1.name));
+    let mut metrics = vec![
+        format!("COALESCE(COUNT_IF(NOT ({production_present})), 0)"),
+        format!("COALESCE(COUNT_IF(NOT ({candidate_present})), 0)"),
+        format!(
+            "COALESCE(COUNT_IF(({candidate_present}) AND ({production_present}) AND ({changed})), 0)"
+        ),
+    ];
+    metrics.extend(value_pairs.iter().map(|pair| {
+        format!(
+            "COALESCE(COUNT_IF(({candidate_present}) AND ({production_present}) AND NOT EQUAL_NULL(C.{}, P.{})), 0)",
+            quote_identifier(&pair.0.name), quote_identifier(&pair.1.name)
+        )
+    }));
+    let counts = executor
+        .execute(&format!(
+            "SELECT {} FROM {} C FULL OUTER JOIN {} P ON {join}",
+            metrics.join(", "),
+            candidate.sql(),
+            production.sql()
+        ))
+        .await?;
+    let row = counts
+        .rows
+        .first()
+        .context("keyed comparison returned no row")?;
+    let candidate_only_rows = parse_u64(row.first())?;
+    let production_only_rows = parse_u64(row.get(1))?;
+    let changed_rows = parse_u64(row.get(2))?;
+    let column_mismatches = value_pairs
+        .iter()
+        .enumerate()
+        .map(|(index, pair)| {
+            Ok(QueryColumnMismatch {
+                column: pair.0.name.clone(),
+                rows: parse_u64(row.get(index + 3))?,
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let examples = if candidate_only_rows + production_only_rows + changed_rows == 0 {
+        vec![]
+    } else {
+        keyed_examples(
+            executor,
+            candidate,
+            production,
+            pairs,
+            keys,
+            &join,
+            &changed,
+            &candidate_present,
+            &production_present,
+            limits.rows,
+            limits.value_chars,
+            examples_truncated,
+        )
+        .await?
+    };
+    Ok(QueryComparison {
+        candidate_only_rows,
+        production_only_rows,
+        changed_rows,
+        candidate_duplicate_keys: 0,
+        production_duplicate_keys: 0,
+        candidate_duplicate_rows: 0,
+        production_duplicate_rows: 0,
+        candidate_null_key_rows: 0,
+        production_null_key_rows: 0,
+        column_mismatches,
+        examples,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn keyed_examples<E: QueryExecutor>(
+    executor: &E,
+    candidate: &Relation,
+    production: &Relation,
+    pairs: &[ColumnPair<'_>],
+    keys: &[ColumnPair<'_>],
+    join: &str,
+    changed: &str,
+    candidate_present: &str,
+    production_present: &str,
+    sample_limit: usize,
+    value_limit: usize,
+    examples_truncated: &mut bool,
+) -> Result<Vec<QueryDiffExample>> {
+    let key_values = keys
+        .iter()
+        .map(|pair| bounded_coalesce("C", &pair.0.name, "P", &pair.1.name, value_limit))
+        .collect::<Vec<_>>();
+    let candidate_values = pairs
+        .iter()
+        .map(|pair| bounded_value("C", &pair.0.name, value_limit))
+        .collect::<Vec<_>>();
+    let production_values = pairs
+        .iter()
+        .map(|pair| bounded_value("P", &pair.1.name, value_limit))
+        .collect::<Vec<_>>();
+    let selected = key_values
+        .iter()
+        .chain(&candidate_values)
+        .chain(&production_values)
+        .cloned()
+        .collect::<Vec<_>>();
+    let ordering = keys
+        .iter()
+        .map(|pair| {
+            format!(
+                "COALESCE(C.{}, P.{}) NULLS FIRST",
+                quote_identifier(&pair.0.name),
+                quote_identifier(&pair.1.name)
+            )
+        })
+        .chain(pairs.iter().flat_map(|pair| {
+            [
+                format!("C.{} NULLS FIRST", quote_identifier(&pair.0.name)),
+                format!("P.{} NULLS FIRST", quote_identifier(&pair.1.name)),
+            ]
+        }))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let result = executor
+        .execute(&format!(
+            "SELECT {} FROM {} C FULL OUTER JOIN {} P ON {join} \
+             WHERE NOT ({candidate_present}) OR NOT ({production_present}) OR ({changed}) \
+             ORDER BY {ordering} LIMIT {sample_limit}",
+            selected.join(", "),
+            candidate.sql(),
+            production.sql()
+        ))
+        .await?;
+    Ok(result
+        .rows
+        .into_iter()
+        .map(|row| {
+            let key_end = keys.len();
+            let candidate_end = key_end + pairs.len();
+            let production_end = candidate_end + pairs.len();
+            let mut values = row;
+            truncate_row(&mut values, value_limit, examples_truncated);
+            QueryDiffExample {
+                key: values[..key_end].to_vec(),
+                candidate: values[key_end..candidate_end].to_vec(),
+                production: values[candidate_end..production_end].to_vec(),
+                candidate_multiplicity: None,
+                production_multiplicity: None,
+            }
+        })
+        .collect())
+}
+
+async fn compare_unkeyed<E: QueryExecutor>(
+    executor: &E,
+    candidate: &Relation,
+    production: &Relation,
+    pairs: &[ColumnPair<'_>],
+    limits: ExampleLimits,
+    examples_truncated: &mut bool,
+) -> Result<QueryComparison> {
+    let candidate_columns = pairs
+        .iter()
+        .map(|pair| {
+            format!(
+                "{} AS {}",
+                quote_identifier(&pair.0.name),
+                quote_identifier(&pair.0.name)
+            )
+        })
+        .collect::<Vec<_>>();
+    let production_columns = pairs
+        .iter()
+        .map(|pair| {
+            format!(
+                "{} AS {}",
+                quote_identifier(&pair.1.name),
+                quote_identifier(&pair.0.name)
+            )
+        })
+        .collect::<Vec<_>>();
+    let canonical = pairs
+        .iter()
+        .map(|pair| quote_identifier(&pair.0.name))
+        .collect::<Vec<_>>();
+    let join = canonical
+        .iter()
+        .map(|name| format!("EQUAL_NULL(C.{name}, P.{name})"))
+        .collect::<Vec<_>>()
+        .join(" AND ");
+    let cte = format!(
+        "C AS (SELECT {}, COUNT(*) AS __EMBRASURE_N FROM {} GROUP BY {}), \
+         P AS (SELECT {}, COUNT(*) AS __EMBRASURE_N FROM {} GROUP BY {})",
+        candidate_columns.join(", "),
+        candidate.sql(),
+        canonical.join(", "),
+        production_columns.join(", "),
+        production.sql(),
+        canonical.join(", ")
+    );
+    let counts = executor
+        .execute(&format!(
+            "WITH {cte} SELECT \
+             COALESCE(SUM(GREATEST(COALESCE(C.__EMBRASURE_N, 0) - COALESCE(P.__EMBRASURE_N, 0), 0)), 0), \
+             COALESCE(SUM(GREATEST(COALESCE(P.__EMBRASURE_N, 0) - COALESCE(C.__EMBRASURE_N, 0), 0)), 0) \
+             FROM C FULL OUTER JOIN P ON {join}"
+        ))
+        .await?;
+    let row = counts
+        .rows
+        .first()
+        .context("unkeyed comparison returned no row")?;
+    let candidate_only_rows = parse_u64(row.first())?;
+    let production_only_rows = parse_u64(row.get(1))?;
+    let examples = if candidate_only_rows + production_only_rows == 0 {
+        vec![]
+    } else {
+        let candidate_values = pairs
+            .iter()
+            .map(|pair| bounded_value("C", &pair.0.name, limits.value_chars))
+            .collect::<Vec<_>>();
+        let production_values = pairs
+            .iter()
+            .map(|pair| bounded_value("P", &pair.0.name, limits.value_chars))
+            .collect::<Vec<_>>();
+        let row_values = pairs
+            .iter()
+            .map(|pair| format!("COALESCE(C.{0}, P.{0})", quote_identifier(&pair.0.name)))
+            .collect::<Vec<_>>();
+        let ordering = std::iter::once(format!("HASH({})", row_values.join(", ")))
+            .chain(
+                row_values
+                    .iter()
+                    .map(|value| format!("{value} NULLS FIRST")),
+            )
+            .chain([
+                "COALESCE(C.__EMBRASURE_N, 0)".into(),
+                "COALESCE(P.__EMBRASURE_N, 0)".into(),
+            ])
+            .collect::<Vec<_>>()
+            .join(", ");
+        let selected = candidate_values
+            .iter()
+            .chain(&production_values)
+            .cloned()
+            .chain([
+                "COALESCE(C.__EMBRASURE_N, 0)::VARCHAR".into(),
+                "COALESCE(P.__EMBRASURE_N, 0)::VARCHAR".into(),
+            ])
+            .collect::<Vec<_>>();
+        let result = executor
+            .execute(&format!(
+                "WITH {cte} SELECT {} FROM C FULL OUTER JOIN P ON {join} \
+                 WHERE COALESCE(C.__EMBRASURE_N, 0) != COALESCE(P.__EMBRASURE_N, 0) \
+                 ORDER BY {ordering} LIMIT {sample_limit}",
+                selected.join(", "),
+                sample_limit = limits.rows
+            ))
+            .await?;
+        result
+            .rows
+            .into_iter()
+            .map(|mut row| {
+                let candidate_end = pairs.len();
+                let production_end = candidate_end + pairs.len();
+                let candidate_multiplicity = parse_u64(row.get(production_end))?;
+                let production_multiplicity = parse_u64(row.get(production_end + 1))?;
+                truncate_row(
+                    &mut row[..production_end],
+                    limits.value_chars,
+                    examples_truncated,
+                );
+                Ok(QueryDiffExample {
+                    key: vec![],
+                    candidate: row[..candidate_end].to_vec(),
+                    production: row[candidate_end..production_end].to_vec(),
+                    candidate_multiplicity: Some(candidate_multiplicity),
+                    production_multiplicity: Some(production_multiplicity),
+                })
+            })
+            .collect::<Result<Vec<_>>>()?
+    };
+    Ok(QueryComparison {
+        candidate_only_rows,
+        production_only_rows,
+        changed_rows: 0,
+        candidate_duplicate_keys: 0,
+        production_duplicate_keys: 0,
+        candidate_duplicate_rows: 0,
+        production_duplicate_rows: 0,
+        candidate_null_key_rows: 0,
+        production_null_key_rows: 0,
+        column_mismatches: vec![],
+        examples,
+    })
+}
+
+fn bounded_value(alias: &str, column: &str, limit: usize) -> String {
+    let value = format!("TO_VARCHAR({alias}.{})", quote_identifier(column));
+    format!(
+        "IFF({alias}.{column} IS NULL, NULL, IFF(LENGTH({value}) > {limit}, CONCAT(LEFT({value}, {limit}), '<truncated>'), {value}))",
+        column = quote_identifier(column)
+    )
+}
+
+fn bounded_coalesce(
+    candidate_alias: &str,
+    candidate_column: &str,
+    production_alias: &str,
+    production_column: &str,
+    limit: usize,
+) -> String {
+    let value = format!(
+        "COALESCE({}.{}, {}.{})",
+        candidate_alias,
+        quote_identifier(candidate_column),
+        production_alias,
+        quote_identifier(production_column)
+    );
+    let text = format!("TO_VARCHAR({value})");
+    format!(
+        "IFF({value} IS NULL, NULL, IFF(LENGTH({text}) > {limit}, CONCAT(LEFT({text}, {limit}), '<truncated>'), {text}))"
+    )
+}
+
+fn truncate_row(row: &mut [Option<String>], limit: usize, truncated: &mut bool) {
+    for value in row.iter_mut().flatten() {
+        let marked = value.ends_with("<truncated>");
+        if marked {
+            *truncated = true;
+        }
+        let allowed = limit + usize::from(marked) * "<truncated>".chars().count();
+        if value.chars().count() > allowed {
+            let mut shortened = value.chars().take(limit).collect::<String>();
+            shortened.push_str("<truncated>");
+            *value = shortened;
+            *truncated = true;
+        }
+    }
+}
+
+fn parse_u64(value: Option<&Option<String>>) -> Result<u64> {
+    value
+        .and_then(Option::as_deref)
+        .context("Snowflake metric was null")?
+        .parse()
+        .context("Snowflake metric was not an unsigned integer")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{collections::VecDeque, sync::Mutex};
+
+    struct FakeExecutor {
+        responses: Mutex<VecDeque<QueryResult>>,
+        statements: Mutex<Vec<String>>,
+    }
+
+    impl FakeExecutor {
+        fn new(responses: Vec<QueryResult>) -> Self {
+            Self {
+                responses: Mutex::new(responses.into()),
+                statements: Mutex::new(vec![]),
+            }
+        }
+    }
+
+    impl QueryExecutor for FakeExecutor {
+        fn execute<'a>(
+            &'a self,
+            statement: &'a str,
+        ) -> Pin<Box<dyn Future<Output = Result<QueryResult>> + Send + 'a>> {
+            Box::pin(async move {
+                self.statements.lock().unwrap().push(statement.into());
+                self.responses
+                    .lock()
+                    .unwrap()
+                    .pop_front()
+                    .context("fake executor ran out of responses")
+            })
+        }
+    }
+
+    fn columns() -> Vec<ResultColumn> {
+        vec![
+            ResultColumn {
+                name: "ID".into(),
+                data_type: "NUMBER(38,0)".into(),
+            },
+            ResultColumn {
+                name: "VALUE".into(),
+                data_type: "VARCHAR(100)".into(),
+            },
+        ]
+    }
+
+    fn rows(values: &[&[Option<&str>]]) -> QueryResult {
+        QueryResult {
+            columns: vec![],
+            rows: values
+                .iter()
+                .map(|row| {
+                    row.iter()
+                        .map(|value| value.map(ToOwned::to_owned))
+                        .collect()
+                })
+                .collect(),
+        }
+    }
+
+    fn relation(identifier: &str) -> Relation {
+        Relation {
+            database: "DB".into(),
+            schema: "RUN".into(),
+            identifier: identifier.into(),
+        }
+    }
+
+    #[test]
+    fn parses_and_renders_refs_without_touching_literals_or_comments() {
+        let template = QueryTemplate::parse(
+            "SELECT '{{ ref('ignored') }}', $$; {{ nope() }}$$ FROM {{ ref('pkg', 'orders') }}; -- ok",
+        )
+        .unwrap();
+        assert_eq!(template.refs()[0].display(), "pkg.orders");
+        let rendered = template
+            .render(|target| Ok(format!("RELATION_{}", target.name)))
+            .unwrap();
+        assert!(rendered.contains("FROM RELATION_orders"));
+        assert!(rendered.contains("'{{ ref('ignored') }}'"));
+        assert!(rendered.contains("$$; {{ nope() }}$$"));
+    }
+
+    #[test]
+    fn rejects_multiple_statements_and_unsupported_jinja() {
+        assert!(QueryTemplate::parse("SELECT 1; DROP TABLE X").is_err());
+        assert!(QueryTemplate::parse("DELETE FROM X").is_err());
+        assert!(QueryTemplate::parse("TABLE(GENERATOR(ROWCOUNT => 1))").is_err());
+        assert!(QueryTemplate::parse("SELECT {{ var('x') }}").is_err());
+    }
+
+    #[test]
+    fn trailing_comments_and_semicolons_inside_strings_are_valid() {
+        QueryTemplate::parse("SELECT ';' AS X; /* trailing */ -- done").unwrap();
+        QueryTemplate::parse("SELECT $$;$$ AS X").unwrap();
+    }
+
+    #[test]
+    fn duplicate_columns_and_width_are_rejected_before_materialization() {
+        let duplicate = vec![
+            ResultColumn {
+                name: "ID".into(),
+                data_type: "NUMBER".into(),
+            },
+            ResultColumn {
+                name: "id".into(),
+                data_type: "NUMBER".into(),
+            },
+        ];
+        assert!(
+            validate_preflight(&duplicate, &[], 10)
+                .unwrap()
+                .contains("duplicate")
+        );
+        assert!(
+            validate_preflight(&duplicate[..1], &[], 0)
+                .unwrap()
+                .contains("above")
+        );
+
+        let punctuation = vec![
+            ResultColumn {
+                name: "order;id".into(),
+                data_type: "NUMBER".into(),
+            },
+            ResultColumn {
+                name: "ORDER;ID".into(),
+                data_type: "NUMBER".into(),
+            },
+        ];
+        assert_eq!(
+            primary_key_metadata_error(&["order;id".into()], &punctuation, &punctuation[..1])
+                .as_deref(),
+            Some("primary-key column order;id is ambiguous")
+        );
+
+        let unrelated_then_key = vec![
+            ResultColumn {
+                name: "amount".into(),
+                data_type: "NUMBER".into(),
+            },
+            ResultColumn {
+                name: "AMOUNT".into(),
+                data_type: "NUMBER".into(),
+            },
+            ResultColumn {
+                name: "order;id".into(),
+                data_type: "NUMBER".into(),
+            },
+            ResultColumn {
+                name: "ORDER;ID".into(),
+                data_type: "NUMBER".into(),
+            },
+        ];
+        assert!(
+            validate_preflight(&unrelated_then_key, &[], 10)
+                .unwrap()
+                .contains("AMOUNT")
+        );
+        assert_eq!(
+            primary_key_metadata_error(
+                &["order;id".into()],
+                &unrelated_then_key,
+                &punctuation[..1]
+            )
+            .as_deref(),
+            Some("primary-key column order;id is ambiguous")
+        );
+
+        let typed_key = |data_type: &str| {
+            vec![ResultColumn {
+                name: "id".into(),
+                data_type: data_type.into(),
+            }]
+        };
+        assert!(
+            primary_key_metadata_error(&["id".into()], &typed_key("NUMBER"), &typed_key("VARCHAR"))
+                .unwrap()
+                .contains("incompatible types")
+        );
+    }
+
+    #[test]
+    fn unsupported_values_require_explicit_casts() {
+        assert!(unsupported_type("VARIANT"));
+        assert!(unsupported_type("GEOGRAPHY"));
+        assert!(!unsupported_type("VARCHAR(100)"));
+    }
+
+    #[test]
+    fn report_values_are_defensively_bounded() {
+        let mut row = vec![Some("abcdefgh".into()), Some("ok".into())];
+        let mut truncated = false;
+        truncate_row(&mut row, 4, &mut truncated);
+        assert_eq!(row[0].as_deref(), Some("abcd<truncated>"));
+        assert_eq!(row[1].as_deref(), Some("ok"));
+        assert!(truncated);
+    }
+
+    #[tokio::test]
+    async fn unsupported_types_stop_before_materialization() {
+        let metadata = |data_type: &str| QueryResult {
+            columns: vec![ResultColumn {
+                name: "VALUE".into(),
+                data_type: data_type.into(),
+            }],
+            rows: vec![],
+        };
+        let executor = FakeExecutor::new(vec![metadata("VARIANT"), metadata("VARIANT")]);
+        let candidate = relation("CANDIDATE");
+        let production = relation("PRODUCTION");
+        let report = run_query_diff(
+            &executor,
+            QueryDiffInput {
+                name: "unsupported",
+                account: "primary",
+                current_refs: vec![],
+                production_refs: vec![],
+                candidate_sql: "SELECT PARSE_JSON('{}') AS VALUE",
+                production_sql: "SELECT PARSE_JSON('{}') AS VALUE",
+                candidate: &candidate,
+                production: &production,
+                primary_key: &[],
+                safety: &SafetyConfig::default(),
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(report.status, QueryCheckStatus::Incomplete);
+        let statements = executor.statements.lock().unwrap();
+        assert_eq!(statements.len(), 2);
+        assert!(!statements.iter().any(|sql| sql.starts_with("CREATE")));
+    }
+
+    #[tokio::test]
+    async fn schema_mismatch_materializes_counts_but_skips_value_sql() {
+        let executor = FakeExecutor::new(vec![
+            QueryResult {
+                columns: vec![ResultColumn {
+                    name: "ID".into(),
+                    data_type: "NUMBER(38,0)".into(),
+                }],
+                rows: vec![],
+            },
+            QueryResult {
+                columns: columns(),
+                rows: vec![],
+            },
+            QueryResult::default(),
+            QueryResult::default(),
+            rows(&[&[Some("1"), Some("1")]]),
+        ]);
+        let candidate = relation("CANDIDATE");
+        let production = relation("PRODUCTION");
+        let report = run_query_diff(
+            &executor,
+            QueryDiffInput {
+                name: "schema",
+                account: "primary",
+                current_refs: vec![],
+                production_refs: vec![],
+                candidate_sql: "SELECT ID FROM C",
+                production_sql: "SELECT ID, VALUE FROM P",
+                candidate: &candidate,
+                production: &production,
+                primary_key: &[],
+                safety: &SafetyConfig::default(),
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(report.status, QueryCheckStatus::Findings);
+        assert!(report.comparison.is_none());
+        let statements = executor.statements.lock().unwrap();
+        assert_eq!(statements.len(), 5);
+        assert!(!statements.iter().any(|sql| sql.contains("FULL OUTER JOIN")));
+    }
+
+    #[tokio::test]
+    async fn key_integrity_blocks_join_and_returns_ordered_bounded_examples() {
+        let metadata = || QueryResult {
+            columns: columns(),
+            rows: vec![],
+        };
+        let executor = FakeExecutor::new(vec![
+            metadata(),
+            metadata(),
+            QueryResult::default(),
+            QueryResult::default(),
+            rows(&[&[Some("3"), Some("1")]]),
+            rows(&[&[Some("1"), Some("1"), Some("1")]]),
+            rows(&[&[Some("0"), Some("0"), Some("0")]]),
+            rows(&[
+                &[Some("candidate"), None, Some("1")],
+                &[Some("candidate"), Some("1"), Some("2")],
+            ]),
+        ]);
+        let candidate = relation("CANDIDATE");
+        let production = relation("PRODUCTION");
+        let report = run_query_diff(
+            &executor,
+            QueryDiffInput {
+                name: "integrity",
+                account: "primary",
+                current_refs: vec![],
+                production_refs: vec![],
+                candidate_sql: "SELECT ID, VALUE FROM C",
+                production_sql: "SELECT ID, VALUE FROM P",
+                candidate: &candidate,
+                production: &production,
+                primary_key: &["ID".into()],
+                safety: &SafetyConfig::default(),
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(report.status, QueryCheckStatus::Findings);
+        let comparison = report.comparison.unwrap();
+        assert_eq!(comparison.candidate_duplicate_keys, 1);
+        assert_eq!(comparison.candidate_null_key_rows, 1);
+        assert_eq!(comparison.examples.len(), 2);
+        assert_eq!(comparison.examples[0].key, vec![None]);
+        assert_eq!(comparison.examples[1].candidate_multiplicity, Some(2));
+        let statements = executor.statements.lock().unwrap();
+        assert!(!statements.iter().any(|sql| sql.contains("FULL OUTER JOIN")));
+        assert!(
+            statements
+                .last()
+                .unwrap()
+                .contains("ORDER BY X.\"ID\" NULLS FIRST")
+        );
+    }
+
+    #[tokio::test]
+    async fn unkeyed_diff_preserves_duplicate_multiplicity_end_to_end() {
+        let metadata = || QueryResult {
+            columns: columns(),
+            rows: vec![],
+        };
+        let executor = FakeExecutor::new(vec![
+            metadata(),
+            metadata(),
+            QueryResult::default(),
+            QueryResult::default(),
+            rows(&[&[Some("123"), Some("1")]]),
+            rows(&[&[Some("122"), Some("0")]]),
+            rows(&[&[
+                Some("1"),
+                Some("same"),
+                Some("1"),
+                Some("same"),
+                Some("123"),
+                Some("1"),
+            ]]),
+        ]);
+        let safety = SafetyConfig {
+            max_example_value_chars: 1,
+            ..SafetyConfig::default()
+        };
+        let candidate = relation("CANDIDATE");
+        let production = relation("PRODUCTION");
+        let report = run_query_diff(
+            &executor,
+            QueryDiffInput {
+                name: "duplicate_only",
+                account: "primary",
+                current_refs: vec![],
+                production_refs: vec![],
+                candidate_sql: "SELECT ID, VALUE FROM SOURCE",
+                production_sql: "SELECT ID, VALUE FROM SOURCE",
+                candidate: &candidate,
+                production: &production,
+                primary_key: &[],
+                safety: &safety,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(report.status, QueryCheckStatus::Findings);
+        let comparison = report.comparison.unwrap();
+        assert_eq!(comparison.candidate_only_rows, 122);
+        assert_eq!(comparison.production_only_rows, 0);
+        assert_eq!(comparison.examples[0].candidate_multiplicity, Some(123));
+        assert_eq!(comparison.examples[0].production_multiplicity, Some(1));
+        let statements = executor.statements.lock().unwrap();
+        assert_eq!(
+            statements
+                .iter()
+                .filter(|sql| sql.starts_with("CREATE TRANSIENT TABLE"))
+                .count(),
+            2
+        );
+        assert!(
+            statements
+                .iter()
+                .any(|sql| sql.contains("COUNT(*) AS __EMBRASURE_N"))
+        );
+        assert!(!statements.iter().any(|sql| sql.contains(" MINUS ")));
+    }
+
+    #[tokio::test]
+    async fn keyed_diff_reports_changed_rows_and_columns_end_to_end() {
+        let metadata = || QueryResult {
+            columns: columns(),
+            rows: vec![],
+        };
+        let executor = FakeExecutor::new(vec![
+            metadata(),
+            metadata(),
+            QueryResult::default(),
+            QueryResult::default(),
+            rows(&[&[Some("2"), Some("2")]]),
+            rows(&[&[Some("0"), Some("0"), Some("0")]]),
+            rows(&[&[Some("0"), Some("0"), Some("0")]]),
+            rows(&[&[Some("0"), Some("0"), Some("1"), Some("1")]]),
+            rows(&[&[Some("2"), Some("2"), Some("new"), Some("2"), Some("old")]]),
+        ]);
+        let safety = SafetyConfig::default();
+        let candidate = relation("CANDIDATE");
+        let production = relation("PRODUCTION");
+        let report = run_query_diff(
+            &executor,
+            QueryDiffInput {
+                name: "keyed",
+                account: "primary",
+                current_refs: vec!["orders".into()],
+                production_refs: vec!["orders".into()],
+                candidate_sql: "SELECT ID, VALUE FROM CANDIDATE_SOURCE",
+                production_sql: "SELECT ID, VALUE FROM PRODUCTION_SOURCE",
+                candidate: &candidate,
+                production: &production,
+                primary_key: &["id".into()],
+                safety: &safety,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(report.status, QueryCheckStatus::Findings);
+        let comparison = report.comparison.unwrap();
+        assert_eq!(comparison.changed_rows, 1);
+        assert_eq!(comparison.column_mismatches[0].column, "VALUE");
+        assert_eq!(comparison.column_mismatches[0].rows, 1);
+        assert_eq!(comparison.examples[0].key, vec![Some("2".into())]);
+        assert_eq!(comparison.examples[0].candidate[1], Some("new".into()));
+        assert_eq!(comparison.examples[0].production[1], Some("old".into()));
+        assert!(
+            executor
+                .statements
+                .lock()
+                .unwrap()
+                .iter()
+                .any(|sql| sql.contains("COALESCE(COUNT_IF") && sql.contains("FULL OUTER JOIN"))
+        );
+    }
+}

--- a/src/report.rs
+++ b/src/report.rs
@@ -19,6 +19,8 @@ pub enum ReportVersion {
     V1,
     #[value(name = "2")]
     V2,
+    #[value(name = "3")]
+    V3,
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
@@ -41,6 +43,8 @@ pub struct Report {
     pub summary: Summary,
     pub validation_scope: ValidationScope,
     pub models: Vec<ModelReport>,
+    #[serde(default)]
+    pub query_checks: Vec<QueryCheckReport>,
     pub impact: ImpactReport,
     pub findings: Vec<Finding>,
     pub coverage_gaps: Vec<CoverageGap>,
@@ -61,8 +65,81 @@ pub struct Summary {
     pub models_selected: usize,
     pub models_built: usize,
     pub models_compared: usize,
+    #[serde(default)]
+    pub query_checks_configured: usize,
+    #[serde(default)]
+    pub query_checks_run: usize,
+    #[serde(default)]
+    pub query_checks_passed: usize,
     pub findings: usize,
     pub coverage_gaps: usize,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum QueryCheckStatus {
+    Planned,
+    Pass,
+    Findings,
+    Incomplete,
+    Skipped,
+    ExecutionFailure,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct QueryCheckReport {
+    pub name: String,
+    pub account: String,
+    pub status: QueryCheckStatus,
+    pub current_refs: Vec<String>,
+    pub production_refs: Vec<String>,
+    pub primary_key: Vec<String>,
+    pub candidate_relation: Option<String>,
+    pub production_relation: Option<String>,
+    pub candidate_row_count: Option<u64>,
+    pub production_row_count: Option<u64>,
+    pub columns: Vec<QueryColumnComparison>,
+    pub comparison: Option<QueryComparison>,
+    pub reason: Option<String>,
+    pub invalid_primary_key_reason: Option<String>,
+    pub examples_truncated: bool,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct QueryColumnComparison {
+    pub name: String,
+    pub candidate_type: Option<String>,
+    pub production_type: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct QueryComparison {
+    pub candidate_only_rows: u64,
+    pub production_only_rows: u64,
+    pub changed_rows: u64,
+    pub candidate_duplicate_keys: u64,
+    pub production_duplicate_keys: u64,
+    pub candidate_duplicate_rows: u64,
+    pub production_duplicate_rows: u64,
+    pub candidate_null_key_rows: u64,
+    pub production_null_key_rows: u64,
+    pub column_mismatches: Vec<QueryColumnMismatch>,
+    pub examples: Vec<QueryDiffExample>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct QueryColumnMismatch {
+    pub column: String,
+    pub rows: u64,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct QueryDiffExample {
+    pub key: Vec<Option<String>>,
+    pub candidate: Vec<Option<String>>,
+    pub production: Vec<Option<String>>,
+    pub candidate_multiplicity: Option<u64>,
+    pub production_multiplicity: Option<u64>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -208,7 +285,7 @@ pub struct LineageChange {
 impl Report {
     pub fn empty(base: String, thresholds: Thresholds) -> Self {
         Self {
-            schema_version: 2,
+            schema_version: 3,
             status: Status::Pass,
             exit_code: EXIT_PASS,
             base,
@@ -217,6 +294,7 @@ impl Report {
             summary: Summary::default(),
             validation_scope: ValidationScope::default(),
             models: vec![],
+            query_checks: vec![],
             impact: ImpactReport::default(),
             findings: vec![],
             coverage_gaps: vec![],
@@ -231,6 +309,8 @@ impl Report {
                 .cmp(&b.unique_id)
                 .then(a.account.cmp(&b.account))
         });
+        self.query_checks
+            .sort_by(|a, b| a.name.cmp(&b.name).then(a.account.cmp(&b.account)));
         self.findings.sort();
         self.findings.dedup();
         self.coverage_gaps.sort();
@@ -277,6 +357,22 @@ impl Report {
             .iter()
             .filter(|m| m.comparison.is_some())
             .count();
+        self.summary.query_checks_configured = self.query_checks.len();
+        self.summary.query_checks_run = self
+            .query_checks
+            .iter()
+            .filter(|check| {
+                !matches!(
+                    check.status,
+                    QueryCheckStatus::Planned | QueryCheckStatus::Skipped
+                )
+            })
+            .count();
+        self.summary.query_checks_passed = self
+            .query_checks
+            .iter()
+            .filter(|check| check.status == QueryCheckStatus::Pass)
+            .count();
         self.summary.findings = self.findings.len();
         self.summary.coverage_gaps = self.coverage_gaps.len();
 
@@ -309,10 +405,11 @@ impl Report {
             Status::ExecutionFailure => style.bad("EXECUTION FAILURE"),
         };
         let mut output = format!(
-            "embrasure: {label}\n{} selected · {} built · {} compared · {} findings · {} coverage gaps\n{} impacted · {} validated · {} not validated\n",
+            "embrasure: {label}\n{} selected · {} built · {} compared · {} query checks run · {} findings · {} coverage gaps\n{} impacted · {} validated · {} not validated\n",
             self.summary.models_selected,
             self.summary.models_built,
             self.summary.models_compared,
+            self.summary.query_checks_run,
             self.summary.findings,
             self.summary.coverage_gaps,
             self.validation_scope.impacted_models,
@@ -329,6 +426,16 @@ impl Report {
         }
         for error in &self.execution_errors {
             let _ = writeln!(output, "- [error] {error}");
+        }
+        for check in &self.query_checks {
+            let _ = writeln!(
+                output,
+                "- [query:{:?}] {} ({}): {}",
+                check.status,
+                check.name,
+                check.account,
+                check.reason.as_deref().unwrap_or("comparison complete")
+            );
         }
         let visible_notices = if verbose { self.notices.len() } else { 3 };
         for notice in self.notices.iter().take(visible_notices) {
@@ -399,7 +506,8 @@ impl Report {
     pub fn json_value(&self, version: ReportVersion) -> serde_json::Result<serde_json::Value> {
         match version {
             ReportVersion::V1 => serde_json::to_value(ReportV1::from(self)),
-            ReportVersion::V2 => serde_json::to_value(self),
+            ReportVersion::V2 => serde_json::to_value(ReportV2::from(self)),
+            ReportVersion::V3 => serde_json::to_value(self),
         }
     }
 
@@ -414,10 +522,11 @@ impl Report {
         let _ = writeln!(output, "**Exit code:** `{}`\n", self.exit_code);
         let _ = writeln!(
             output,
-            "| Selected | Built | Compared | Findings | Coverage gaps |\n|---:|---:|---:|---:|---:|\n| {} | {} | {} | {} | {} |\n",
+            "| Selected | Built | Compared | Query checks | Findings | Coverage gaps |\n|---:|---:|---:|---:|---:|---:|\n| {} | {} | {} | {} | {} | {} |\n",
             self.summary.models_selected,
             self.summary.models_built,
             self.summary.models_compared,
+            self.summary.query_checks_run,
             self.summary.findings,
             self.summary.coverage_gaps,
         );
@@ -482,6 +591,35 @@ impl Report {
                 "- **{} · {}:** {}",
                 notice.scope, notice.code, notice.message
             );
+        }
+        output.push_str("\n## Query-diff evidence\n\n");
+        if self.query_checks.is_empty() {
+            output.push_str("No query-diff checks configured.\n\n");
+        }
+        for check in &self.query_checks {
+            let _ = writeln!(output, "### `{}` ({})\n", check.name, check.account);
+            let _ = writeln!(output, "- Status: `{:?}`", check.status);
+            if let (Some(candidate), Some(production)) =
+                (check.candidate_row_count, check.production_row_count)
+            {
+                let _ = writeln!(
+                    output,
+                    "- Rows: candidate `{candidate}` · production `{production}`"
+                );
+            }
+            if let Some(comparison) = &check.comparison {
+                let _ = writeln!(
+                    output,
+                    "- Difference: `{}` candidate-only · `{}` production-only · `{}` changed",
+                    comparison.candidate_only_rows,
+                    comparison.production_only_rows,
+                    comparison.changed_rows
+                );
+            }
+            if let Some(reason) = &check.reason {
+                let _ = writeln!(output, "- {reason}");
+            }
+            output.push('\n');
         }
         output.push_str("\n## Model evidence\n\n");
         if self.models.is_empty() {
@@ -763,6 +901,66 @@ fn write_lineage_node<'a>(
 }
 
 #[derive(Serialize)]
+struct ReportV2<'a> {
+    schema_version: u8,
+    status: Status,
+    exit_code: u8,
+    base: &'a str,
+    ci_schemas: &'a [CiSchema],
+    thresholds: Thresholds,
+    summary: SummaryV2,
+    validation_scope: &'a ValidationScope,
+    models: &'a [ModelReport],
+    impact: &'a ImpactReport,
+    findings: &'a [Finding],
+    coverage_gaps: &'a [CoverageGap],
+    notices: &'a [Notice],
+    execution_errors: &'a [String],
+}
+
+#[derive(Serialize)]
+struct SummaryV2 {
+    models_selected: usize,
+    models_built: usize,
+    models_compared: usize,
+    findings: usize,
+    coverage_gaps: usize,
+}
+
+impl From<&Summary> for SummaryV2 {
+    fn from(summary: &Summary) -> Self {
+        Self {
+            models_selected: summary.models_selected,
+            models_built: summary.models_built,
+            models_compared: summary.models_compared,
+            findings: summary.findings,
+            coverage_gaps: summary.coverage_gaps,
+        }
+    }
+}
+
+impl<'a> From<&'a Report> for ReportV2<'a> {
+    fn from(report: &'a Report) -> Self {
+        Self {
+            schema_version: 2,
+            status: report.status,
+            exit_code: report.exit_code,
+            base: &report.base,
+            ci_schemas: &report.ci_schemas,
+            thresholds: report.thresholds,
+            summary: SummaryV2::from(&report.summary),
+            validation_scope: &report.validation_scope,
+            models: &report.models,
+            impact: &report.impact,
+            findings: &report.findings,
+            coverage_gaps: &report.coverage_gaps,
+            notices: &report.notices,
+            execution_errors: &report.execution_errors,
+        }
+    }
+}
+
+#[derive(Serialize)]
 struct ReportV1<'a> {
     schema_version: u8,
     status: Status,
@@ -770,7 +968,7 @@ struct ReportV1<'a> {
     base: &'a str,
     ci_schemas: &'a [CiSchema],
     thresholds: Thresholds,
-    summary: &'a Summary,
+    summary: SummaryV2,
     models: Vec<ModelReportV1<'a>>,
     impact: ImpactReportV1<'a>,
     findings: &'a [Finding],
@@ -824,7 +1022,7 @@ impl<'a> From<&'a Report> for ReportV1<'a> {
             base: &report.base,
             ci_schemas: &report.ci_schemas,
             thresholds: report.thresholds,
-            summary: &report.summary,
+            summary: SummaryV2::from(&report.summary),
             models: report.models.iter().map(ModelReportV1::from).collect(),
             impact: ImpactReportV1 {
                 dbt_models: &report.impact.dbt_models,
@@ -938,6 +1136,45 @@ mod tests {
             code: "incremental_history_not_recomputed".into(),
             message: "historical rows were not recomputed".into(),
         });
+        report.query_checks.push(QueryCheckReport {
+            name: "paid_orders_match".into(),
+            account: "primary".into(),
+            status: QueryCheckStatus::Findings,
+            current_refs: vec!["orders".into()],
+            production_refs: vec!["orders".into()],
+            primary_key: vec!["ID".into()],
+            candidate_relation: Some(r#""DB"."CI"."QUERY_C""#.into()),
+            production_relation: Some(r#""DB"."CI"."QUERY_P""#.into()),
+            candidate_row_count: Some(10),
+            production_row_count: Some(9),
+            columns: vec![QueryColumnComparison {
+                name: "ID".into(),
+                candidate_type: Some("NUMBER".into()),
+                production_type: Some("NUMBER".into()),
+            }],
+            comparison: Some(QueryComparison {
+                candidate_only_rows: 1,
+                production_only_rows: 0,
+                changed_rows: 0,
+                candidate_duplicate_keys: 0,
+                production_duplicate_keys: 0,
+                candidate_duplicate_rows: 0,
+                production_duplicate_rows: 0,
+                candidate_null_key_rows: 0,
+                production_null_key_rows: 0,
+                column_mismatches: vec![],
+                examples: vec![QueryDiffExample {
+                    key: vec![Some("10".into())],
+                    candidate: vec![Some("10".into())],
+                    production: vec![None],
+                    candidate_multiplicity: None,
+                    production_multiplicity: None,
+                }],
+            }),
+            reason: Some("1 candidate-only, 0 production-only, and 0 changed rows".into()),
+            invalid_primary_key_reason: None,
+            examples_truncated: false,
+        });
         report.finalize();
         report
     }
@@ -1017,6 +1254,29 @@ mod tests {
             ReportVersion::V2,
             include_str!("../schemas/report-v2.schema.json"),
         );
+        assert_matches_schema(
+            &report,
+            ReportVersion::V3,
+            include_str!("../schemas/report-v3.schema.json"),
+        );
+        let mut planned = report.clone();
+        planned.models[0].dbt_build = "planned".into();
+        planned.models[0].comparison = None;
+        assert_matches_schema(
+            &planned,
+            ReportVersion::V1,
+            include_str!("../schemas/report-v1.schema.json"),
+        );
+        assert_matches_schema(
+            &planned,
+            ReportVersion::V2,
+            include_str!("../schemas/report-v2.schema.json"),
+        );
+        assert_matches_schema(
+            &planned,
+            ReportVersion::V3,
+            include_str!("../schemas/report-v3.schema.json"),
+        );
 
         let v1: serde_json::Value =
             serde_json::from_str(&report.json(ReportVersion::V1).unwrap()).unwrap();
@@ -1027,6 +1287,18 @@ mod tests {
                 .get("ci_duplicate_rows")
                 .is_none()
         );
+        let v2: serde_json::Value =
+            serde_json::from_str(&report.json(ReportVersion::V2).unwrap()).unwrap();
+        assert!(v2.get("query_checks").is_none());
+        assert!(v2["summary"].get("query_checks_run").is_none());
+
+        let schema: serde_json::Value =
+            serde_json::from_str(include_str!("../schemas/report-v3.schema.json")).unwrap();
+        let validator = jsonschema::validator_for(&schema).unwrap();
+        let mut malformed: serde_json::Value =
+            serde_json::from_str(&report.json(ReportVersion::V3).unwrap()).unwrap();
+        malformed["models"][0]["unexpected"] = serde_json::json!(true);
+        assert!(validator.validate(&malformed).is_err());
     }
 
     #[test]

--- a/src/run.rs
+++ b/src/run.rs
@@ -12,12 +12,16 @@ use crate::{
     auth,
     compare::{CompareOptions, compare_model},
     config::{
-        ComparisonMode, Config, DownstreamPolicy, IncrementalMode, ModelConfig, SafetyConfig,
-        Thresholds,
+        ComparisonMode, Config, DownstreamPolicy, IncrementalMode, ModelConfig, QueryDiffConfig,
+        SafetyConfig, Thresholds,
     },
-    dbt::{self, DbtContext, ManifestNode},
-    metabase,
-    report::{CiSchema, CoverageGap, Finding, ModelReport, Notice, Report, SkippedModel},
+    dbt::{self, DbtContext, Manifest, ManifestNode},
+    git, metabase,
+    query::{QueryDiffInput, QueryTemplate, RefTarget, run_query_diff},
+    report::{
+        CiSchema, CoverageGap, Finding, ModelReport, Notice, QueryCheckReport, QueryCheckStatus,
+        Report, SkippedModel,
+    },
     snowflake::{Relation, SnowflakeClient, is_managed_schema},
 };
 
@@ -99,9 +103,24 @@ async fn execute(
     dry_run: bool,
     report: &mut Report,
 ) -> Result<()> {
-    let resolved_auth = auth::resolve_all(config)
-        .await
-        .context("could not resolve Snowflake credentials")?;
+    let resolved_auth = if dry_run {
+        config
+            .accounts
+            .iter()
+            .map(|account| {
+                (
+                    account.name.clone(),
+                    auth::ResolvedAuth::ProgrammaticAccessToken {
+                        token: "dry-run-not-used".into(),
+                    },
+                )
+            })
+            .collect()
+    } else {
+        auth::resolve_all(config)
+            .await
+            .context("could not resolve Snowflake credentials")?
+    };
     let schema = dbt::ci_schema_name(&config.safety.schema_prefix, &config.dbt.project_dir)?;
     let query_tag = format!("embrasure:{}:{}", env!("CARGO_PKG_VERSION"), Uuid::new_v4());
     let mut clients = Vec::new();
@@ -138,7 +157,10 @@ async fn execute(
             }
 
             let mut context = dbt::prepare(config, &resolved_auth, base, &schema, &query_tag)?;
-            let selections = plan_selections(config, &context, options, report)?;
+            let query_check_changes =
+                query_check_changes(config, base, &context.repo_root, report)?;
+            let selections =
+                plan_selections(config, &context, options, &query_check_changes, report)?;
             if dry_run {
                 report.notices.push(Notice {
                     scope: "validation".into(),
@@ -151,6 +173,7 @@ async fn execute(
             let result = if let Some(selections) = selections {
                 if dry_run {
                     plan_model_reports(config, &context, &selections, "planned", report)?;
+                    plan_query_reports(config, &context, &selections, report);
                     Ok(())
                 } else {
                     execute_with_dbt(config, &mut context, &clients, &schema, &selections, report)
@@ -187,6 +210,130 @@ async fn execute(
 struct AccountSelection {
     selected: BTreeSet<String>,
     removed: BTreeSet<String>,
+    query_checks: Vec<PlannedQueryCheck>,
+}
+
+#[derive(Debug, Clone)]
+struct PlannedQueryCheck {
+    config: QueryDiffConfig,
+    current: QueryTemplate,
+    production: QueryTemplate,
+    current_refs: Vec<ResolvedRef>,
+    production_refs: Vec<ResolvedRef>,
+}
+
+#[derive(Debug, Clone)]
+struct ResolvedRef {
+    target: RefTarget,
+    node_id: Option<String>,
+    error: Option<String>,
+}
+
+#[derive(Debug, Default)]
+struct QueryCheckChanges {
+    changed: BTreeSet<String>,
+}
+
+fn query_check_changes(
+    config: &Config,
+    base: &str,
+    repo_root: &Path,
+    report: &mut Report,
+) -> Result<QueryCheckChanges> {
+    let all_current_changed = || QueryCheckChanges {
+        changed: config
+            .checks
+            .iter()
+            .map(|check| check.query_diff().name.to_ascii_lowercase())
+            .collect(),
+    };
+    let Some(source_path) = config.source_path.as_deref() else {
+        return Ok(all_current_changed());
+    };
+    let Ok(relative) = source_path.strip_prefix(repo_root) else {
+        if !config.checks.is_empty() {
+            report.notices.push(Notice {
+                scope: "query_checks".into(),
+                code: "query_check_base_unavailable".into(),
+                message: format!(
+                    "config {} is outside the Git repository; current query checks will run, but removed checks cannot be compared with {base}",
+                    source_path.display()
+                ),
+            });
+        }
+        return Ok(all_current_changed());
+    };
+    let relative = relative.to_string_lossy().replace('\\', "/");
+    let object = format!("{base}:{relative}");
+    let exists = git::output(repo_root, &["cat-file", "-e", &object])?;
+    if !exists.status.success() {
+        return Ok(all_current_changed());
+    }
+    let yaml = git::text(repo_root, &["show", &object])?;
+    let base_config: Config =
+        serde_yaml::from_str(&yaml).with_context(|| format!("invalid config at {object}"))?;
+    base_config
+        .validate()
+        .with_context(|| format!("invalid config at {object}"))?;
+    Ok(compare_query_check_definitions(
+        config,
+        &base_config,
+        base,
+        report,
+    ))
+}
+
+fn compare_query_check_definitions(
+    config: &Config,
+    base_config: &Config,
+    base: &str,
+    report: &mut Report,
+) -> QueryCheckChanges {
+    let current = config
+        .checks
+        .iter()
+        .map(|check| {
+            (
+                check.query_diff().name.to_ascii_lowercase(),
+                check.query_diff(),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    let previous = base_config
+        .checks
+        .iter()
+        .map(|check| {
+            (
+                check.query_diff().name.to_ascii_lowercase(),
+                check.query_diff(),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    let changed = current
+        .iter()
+        .filter(|(name, check)| previous.get(*name).copied() != Some(**check))
+        .map(|(name, _)| name.clone())
+        .collect();
+    for (name, check) in previous {
+        if current.contains_key(&name) {
+            continue;
+        }
+        let account = check
+            .account
+            .clone()
+            .or_else(|| {
+                (base_config.accounts.len() == 1).then(|| base_config.accounts[0].name.clone())
+            })
+            .unwrap_or_else(|| "unassigned".into());
+        report.coverage_gaps.push(CoverageGap {
+            scope: query_scope(&check.name),
+            check: "query_diff_removed".into(),
+            reason: format!(
+                "query check was present at {base} for account {account} but is absent from the current configuration"
+            ),
+        });
+    }
+    QueryCheckChanges { changed }
 }
 
 fn resolve_selected_models(
@@ -235,6 +382,7 @@ fn plan_selections(
     config: &Config,
     context: &DbtContext,
     options: &CheckOptions,
+    query_check_changes: &QueryCheckChanges,
     report: &mut Report,
 ) -> Result<Option<Vec<AccountSelection>>> {
     let changed_paths = context.changed_paths(&report.base)?;
@@ -343,6 +491,19 @@ fn plan_selections(
             }
             selected.retain(|id| chosen[account_index].contains(id));
         }
+        let query_checks = plan_query_checks_for_account(
+            config,
+            &account.name,
+            manifest,
+            production,
+            &changed,
+            &removed,
+            &current_impacted,
+            &surviving_removed_impact,
+            query_check_changes,
+            &mut selected,
+            report,
+        )?;
         let impacted = current_impacted
             .union(&removed_impacted)
             .cloned()
@@ -363,7 +524,11 @@ fn plan_selections(
             });
         }
         selected_count += selected.len();
-        selections.push(AccountSelection { selected, removed });
+        selections.push(AccountSelection {
+            selected,
+            removed,
+            query_checks,
+        });
     }
     if !report.impact.dbt_models.is_empty() {
         report.notices.push(Notice {
@@ -373,13 +538,50 @@ fn plan_selections(
         });
     }
     if selected_count > config.safety.max_models {
-        for (account, selection) in config.accounts.iter().zip(&selections) {
+        let mut has_runnable_query = false;
+        for (account, selection) in config.accounts.iter().zip(&mut selections) {
             for id in &selection.selected {
                 report.validation_scope.skipped_models.push(SkippedModel {
                     id: format!("{}:{id}", account.name),
                     reason: "validation stopped because the requested model count exceeded safety.max_models".into(),
                 });
             }
+            let selected = selection.selected.clone();
+            let mut runnable = Vec::new();
+            for check in std::mem::take(&mut selection.query_checks) {
+                let needs_build = check.current_refs.iter().any(|resolved| {
+                    resolved
+                        .node_id
+                        .as_ref()
+                        .is_some_and(|id| selected.contains(id))
+                });
+                if needs_build {
+                    let current_refs = check
+                        .current_refs
+                        .iter()
+                        .map(|resolved| resolved.target.display())
+                        .collect();
+                    let production_refs = check
+                        .production_refs
+                        .iter()
+                        .map(|resolved| resolved.target.display())
+                        .collect();
+                    push_incomplete_query(
+                        report,
+                        &check,
+                        &account.name,
+                        current_refs,
+                        production_refs,
+                        "query check requires candidate models, but safety.max_models stopped the build"
+                            .into(),
+                    );
+                } else {
+                    runnable.push(check);
+                }
+            }
+            selection.query_checks = runnable;
+            selection.selected.clear();
+            has_runnable_query |= !selection.query_checks.is_empty();
         }
         report.coverage_gaps.push(CoverageGap {
             scope: "validation".into(),
@@ -389,7 +591,7 @@ fn plan_selections(
                 config.safety.max_models
             ),
         });
-        return Ok(None);
+        return Ok(has_runnable_query.then_some(selections));
     }
     Ok(Some(selections))
 }
@@ -479,6 +681,68 @@ fn plan_model_reports(
     Ok(production_relations)
 }
 
+fn plan_query_reports(
+    config: &Config,
+    context: &DbtContext,
+    selections: &[AccountSelection],
+    report: &mut Report,
+) {
+    for (account, selection) in config.accounts.iter().zip(selections) {
+        let Ok(current_manifest) = context.manifest(&account.name) else {
+            continue;
+        };
+        let Ok(production_manifest) = context.production_manifest(&account.name) else {
+            continue;
+        };
+        for check in &selection.query_checks {
+            let current_refs = check
+                .current_refs
+                .iter()
+                .map(|resolved| resolved.target.display())
+                .collect::<Vec<_>>();
+            let production_refs = check
+                .production_refs
+                .iter()
+                .map(|resolved| resolved.target.display())
+                .collect::<Vec<_>>();
+            let invalid = check
+                .current_refs
+                .iter()
+                .chain(&check.production_refs)
+                .find_map(|resolved| resolved.error.clone())
+                .or_else(|| ephemeral_ref_reason(check, current_manifest, production_manifest));
+            if let Some(reason) = invalid {
+                push_incomplete_query(
+                    report,
+                    check,
+                    &account.name,
+                    current_refs,
+                    production_refs,
+                    reason,
+                );
+                continue;
+            }
+            report.query_checks.push(QueryCheckReport {
+                name: check.config.name.clone(),
+                account: account.name.clone(),
+                status: QueryCheckStatus::Planned,
+                current_refs,
+                production_refs,
+                primary_key: check.config.primary_key.clone(),
+                candidate_relation: None,
+                production_relation: None,
+                candidate_row_count: None,
+                production_row_count: None,
+                columns: vec![],
+                comparison: None,
+                reason: Some("planned by --dry-run; query was not executed".into()),
+                invalid_primary_key_reason: None,
+                examples_truncated: false,
+            });
+        }
+    }
+}
+
 async fn execute_with_dbt(
     config: &Config,
     context: &mut DbtContext,
@@ -541,6 +805,33 @@ async fn execute_with_dbt(
                     )
                 })?;
         }
+    }
+
+    let occupied_schemas = report
+        .ci_schemas
+        .iter()
+        .map(|item| item.schema.to_ascii_uppercase())
+        .collect::<BTreeSet<_>>();
+    let query_schema = unique_query_schema(ci_schema, &occupied_schemas);
+    for (index, (account, selection)) in config.accounts.iter().zip(selections).enumerate() {
+        if selection.query_checks.is_empty() {
+            continue;
+        }
+        clients[index]
+            .create_schema(&account.database, &query_schema)
+            .await
+            .with_context(|| {
+                format!(
+                    "could not create query-check schema for account {}",
+                    account.name
+                )
+            })?;
+        report.ci_schemas.push(CiSchema {
+            account: account.name.clone(),
+            database: account.database.clone(),
+            schema: query_schema.clone(),
+            cleaned_up: false,
+        });
     }
 
     let mut baseline_relations = BTreeMap::<(String, String), Relation>::new();
@@ -731,14 +1022,28 @@ async fn execute_with_dbt(
         }
     }
 
-    let completed = timeout(
+    let query_jobs = prepare_query_jobs(
+        config,
+        context,
+        clients,
+        &query_schema,
+        selections,
+        &baseline_relations,
+        report,
+    );
+    let (completed, completed_queries) = timeout(
         Duration::from_secs(config.comparison.timeout_seconds),
-        run_comparisons(
-            comparison_jobs,
-            config.comparison.concurrency,
-            config.comparison.mode,
-            config.safety.clone(),
-        ),
+        async {
+            let models = run_comparisons(
+                comparison_jobs,
+                config.comparison.concurrency,
+                config.comparison.mode,
+                config.safety.clone(),
+            )
+            .await?;
+            let queries = run_query_comparisons(query_jobs, config.comparison.concurrency).await?;
+            Ok::<_, anyhow::Error>((models, queries))
+        },
     )
     .await
     .with_context(|| {
@@ -756,6 +1061,38 @@ async fn execute_with_dbt(
                 report.findings.extend(findings);
             }
             Err(error) => report.execution_errors.push(format!("{error:#}")),
+        }
+    }
+    for item in completed_queries {
+        match item.result {
+            Ok(check) => {
+                record_query_outcome(report, &check);
+                report.query_checks.push(check);
+            }
+            Err(error) => {
+                let message = format!("{error:#}");
+                report.execution_errors.push(format!(
+                    "query-diff check {} in account {} failed: {message}",
+                    item.name, item.account
+                ));
+                report.query_checks.push(QueryCheckReport {
+                    name: item.name,
+                    account: item.account,
+                    status: QueryCheckStatus::ExecutionFailure,
+                    current_refs: item.current_refs,
+                    production_refs: item.production_refs,
+                    primary_key: item.primary_key,
+                    candidate_relation: Some(item.candidate.sql()),
+                    production_relation: Some(item.production.sql()),
+                    candidate_row_count: None,
+                    production_row_count: None,
+                    columns: vec![],
+                    comparison: None,
+                    reason: Some(message),
+                    invalid_primary_key_reason: None,
+                    examples_truncated: false,
+                });
+            }
         }
     }
 
@@ -791,6 +1128,359 @@ struct CompletedComparison {
     model_id: String,
     account: String,
     result: Result<(crate::report::ModelComparison, Vec<Finding>)>,
+}
+
+struct QueryComparisonJob {
+    client: SnowflakeClient,
+    name: String,
+    account: String,
+    current_refs: Vec<String>,
+    production_refs: Vec<String>,
+    candidate_sql: String,
+    production_sql: String,
+    candidate: Relation,
+    production: Relation,
+    primary_key: Vec<String>,
+    safety: SafetyConfig,
+}
+
+struct CompletedQueryComparison {
+    name: String,
+    account: String,
+    current_refs: Vec<String>,
+    production_refs: Vec<String>,
+    primary_key: Vec<String>,
+    candidate: Relation,
+    production: Relation,
+    result: Result<QueryCheckReport>,
+}
+
+fn prepare_query_jobs(
+    config: &Config,
+    context: &DbtContext,
+    clients: &[SnowflakeClient],
+    ci_schema: &str,
+    selections: &[AccountSelection],
+    baseline_relations: &BTreeMap<(String, String), Relation>,
+    report: &mut Report,
+) -> Vec<QueryComparisonJob> {
+    let mut jobs = Vec::new();
+    for (account_index, (account, selection)) in config.accounts.iter().zip(selections).enumerate()
+    {
+        let Ok(current_manifest) = context.manifest(&account.name) else {
+            continue;
+        };
+        let Ok(production_manifest) = context.production_manifest(&account.name) else {
+            continue;
+        };
+        for (check_index, check) in selection.query_checks.iter().enumerate() {
+            let current_refs = check
+                .current_refs
+                .iter()
+                .map(|resolved| resolved.target.display())
+                .collect::<Vec<_>>();
+            let production_refs = check
+                .production_refs
+                .iter()
+                .map(|resolved| resolved.target.display())
+                .collect::<Vec<_>>();
+            let resolution_error = check
+                .current_refs
+                .iter()
+                .chain(&check.production_refs)
+                .find_map(|resolved| resolved.error.clone());
+            if let Some(reason) = resolution_error {
+                push_incomplete_query(
+                    report,
+                    check,
+                    &account.name,
+                    current_refs,
+                    production_refs,
+                    reason,
+                );
+                continue;
+            }
+            let ephemeral = ephemeral_ref_reason(check, current_manifest, production_manifest);
+            if let Some(reason) = ephemeral {
+                push_incomplete_query(
+                    report,
+                    check,
+                    &account.name,
+                    current_refs,
+                    production_refs,
+                    reason,
+                );
+                continue;
+            }
+            let candidate_sql = check.current.render(|target| {
+                let id = resolved_id(&check.current_refs, target)?;
+                if selection.selected.contains(id) {
+                    let built = report.models.iter().any(|model| {
+                        model.account == account.name
+                            && model.unique_id == id
+                            && model.dbt_build == "passed"
+                    });
+                    if !built {
+                        bail!(
+                            "current ref {} was not built successfully",
+                            target.display()
+                        );
+                    }
+                    let node = current_manifest
+                        .nodes
+                        .get(id)
+                        .context("resolved current ref disappeared from manifest")?;
+                    Ok(relation_for(node, &account.database, &node.schema).sql())
+                } else {
+                    let node = production_manifest.nodes.get(id).with_context(|| {
+                        format!(
+                            "unchanged current ref {} has no production-state relation",
+                            target.display()
+                        )
+                    })?;
+                    Ok(baseline_relations
+                        .get(&(account.name.clone(), id.to_owned()))
+                        .cloned()
+                        .unwrap_or_else(|| relation_for(node, &account.database, &node.schema))
+                        .sql())
+                }
+            });
+            let production_sql = check.production.render(|target| {
+                let id = resolved_id(&check.production_refs, target)?;
+                let node = production_manifest
+                    .nodes
+                    .get(id)
+                    .context("resolved production ref disappeared from manifest")?;
+                Ok(baseline_relations
+                    .get(&(account.name.clone(), id.to_owned()))
+                    .cloned()
+                    .unwrap_or_else(|| relation_for(node, &account.database, &node.schema))
+                    .sql())
+            });
+            let (candidate_sql, production_sql) = match (candidate_sql, production_sql) {
+                (Ok(candidate_sql), Ok(production_sql)) => (candidate_sql, production_sql),
+                (Err(error), _) | (_, Err(error)) => {
+                    push_incomplete_query(
+                        report,
+                        check,
+                        &account.name,
+                        current_refs,
+                        production_refs,
+                        error.to_string(),
+                    );
+                    continue;
+                }
+            };
+            jobs.push(QueryComparisonJob {
+                client: clients[account_index].clone(),
+                name: check.config.name.clone(),
+                account: account.name.clone(),
+                current_refs,
+                production_refs,
+                candidate_sql,
+                production_sql,
+                candidate: Relation {
+                    database: account.database.clone(),
+                    schema: ci_schema.into(),
+                    identifier: format!("EMBRASURE_QUERY_{check_index}_CANDIDATE"),
+                },
+                production: Relation {
+                    database: account.database.clone(),
+                    schema: ci_schema.into(),
+                    identifier: format!("EMBRASURE_QUERY_{check_index}_PRODUCTION"),
+                },
+                primary_key: check.config.primary_key.clone(),
+                safety: config.safety.clone(),
+            });
+        }
+    }
+    jobs
+}
+
+fn resolved_id<'a>(resolved: &'a [ResolvedRef], target: &RefTarget) -> Result<&'a str> {
+    resolved
+        .iter()
+        .find(|item| item.target == *target)
+        .and_then(|item| item.node_id.as_deref())
+        .with_context(|| format!("ref {} could not be resolved", target.display()))
+}
+
+fn ephemeral_ref_reason(
+    check: &PlannedQueryCheck,
+    current_manifest: &Manifest,
+    production_manifest: &Manifest,
+) -> Option<String> {
+    check
+        .current_refs
+        .iter()
+        .filter_map(|resolved| resolved.node_id.as_ref())
+        .find_map(|id| {
+            current_manifest.nodes.get(id).and_then(|node| {
+                node.config
+                    .materialized
+                    .eq_ignore_ascii_case("ephemeral")
+                    .then(|| format!(
+                        "current ref {} is ephemeral; reference a persisted model or inline equivalent SQL",
+                        node.name
+                    ))
+            })
+        })
+        .or_else(|| {
+            check
+                .production_refs
+                .iter()
+                .filter_map(|resolved| resolved.node_id.as_ref())
+                .find_map(|id| {
+                    production_manifest.nodes.get(id).and_then(|node| {
+                        node.config
+                            .materialized
+                            .eq_ignore_ascii_case("ephemeral")
+                            .then(|| format!(
+                                "production ref {} is ephemeral; reference a persisted model or inline equivalent SQL",
+                                node.name
+                            ))
+                    })
+                })
+        })
+}
+
+fn push_incomplete_query(
+    report: &mut Report,
+    check: &PlannedQueryCheck,
+    account: &str,
+    current_refs: Vec<String>,
+    production_refs: Vec<String>,
+    reason: String,
+) {
+    report.coverage_gaps.push(CoverageGap {
+        scope: query_scope(&check.config.name),
+        check: "query_diff".into(),
+        reason: reason.clone(),
+    });
+    report.query_checks.push(QueryCheckReport {
+        name: check.config.name.clone(),
+        account: account.into(),
+        status: QueryCheckStatus::Incomplete,
+        current_refs,
+        production_refs,
+        primary_key: check.config.primary_key.clone(),
+        candidate_relation: None,
+        production_relation: None,
+        candidate_row_count: None,
+        production_row_count: None,
+        columns: vec![],
+        comparison: None,
+        reason: Some(reason),
+        invalid_primary_key_reason: None,
+        examples_truncated: false,
+    });
+}
+
+fn record_query_outcome(report: &mut Report, check: &QueryCheckReport) {
+    let scope = query_scope(&check.name);
+    if let Some(key_reason) = &check.invalid_primary_key_reason {
+        report.findings.push(Finding {
+            model: scope.clone(),
+            check: "query_diff_primary_key".into(),
+            message: key_reason.clone(),
+        });
+    }
+    match check.status {
+        QueryCheckStatus::Findings => {
+            report.findings.push(Finding {
+                model: scope.clone(),
+                check: "query_diff".into(),
+                message: check
+                    .reason
+                    .clone()
+                    .unwrap_or_else(|| "query results differ".into()),
+            });
+            if check
+                .reason
+                .as_deref()
+                .is_some_and(|reason| reason.starts_with("key integrity"))
+            {
+                report.coverage_gaps.push(CoverageGap {
+                    scope: scope.clone(),
+                    check: "query_diff_values".into(),
+                    reason: "value comparison was blocked by null or duplicate primary keys".into(),
+                });
+            }
+        }
+        QueryCheckStatus::Incomplete => {
+            let reason = check
+                .reason
+                .clone()
+                .unwrap_or_else(|| "query comparison was incomplete".into());
+            report.coverage_gaps.push(CoverageGap {
+                scope,
+                check: "query_diff".into(),
+                reason,
+            });
+        }
+        QueryCheckStatus::Planned
+        | QueryCheckStatus::Pass
+        | QueryCheckStatus::Skipped
+        | QueryCheckStatus::ExecutionFailure => {}
+    }
+}
+
+fn query_scope(name: &str) -> String {
+    format!("query:{name}")
+}
+
+async fn run_query_comparisons(
+    jobs: Vec<QueryComparisonJob>,
+    concurrency: usize,
+) -> Result<Vec<CompletedQueryComparison>> {
+    let mut pending = jobs.into_iter();
+    let mut running = JoinSet::new();
+    let mut completed = Vec::new();
+    for _ in 0..concurrency {
+        let Some(job) = pending.next() else { break };
+        spawn_query_comparison(&mut running, job);
+    }
+    while let Some(result) = running.join_next().await {
+        completed.push(result.context("query-comparison worker stopped unexpectedly")?);
+        if let Some(job) = pending.next() {
+            spawn_query_comparison(&mut running, job);
+        }
+    }
+    Ok(completed)
+}
+
+fn spawn_query_comparison(
+    running: &mut JoinSet<CompletedQueryComparison>,
+    job: QueryComparisonJob,
+) {
+    running.spawn(async move {
+        let result = run_query_diff(
+            &job.client,
+            QueryDiffInput {
+                name: &job.name,
+                account: &job.account,
+                current_refs: job.current_refs.clone(),
+                production_refs: job.production_refs.clone(),
+                candidate_sql: &job.candidate_sql,
+                production_sql: &job.production_sql,
+                candidate: &job.candidate,
+                production: &job.production,
+                primary_key: &job.primary_key,
+                safety: &job.safety,
+            },
+        )
+        .await;
+        CompletedQueryComparison {
+            name: job.name,
+            account: job.account,
+            current_refs: job.current_refs,
+            production_refs: job.production_refs,
+            primary_key: job.primary_key,
+            candidate: job.candidate,
+            production: job.production,
+            result,
+        }
+    });
 }
 
 async fn run_comparisons(
@@ -918,12 +1608,211 @@ fn snowflake_identifier(value: &str, quoted: Option<bool>) -> String {
     }
 }
 
+fn unique_query_schema(ci_schema: &str, occupied: &BTreeSet<String>) -> String {
+    loop {
+        let random = Uuid::new_v4().simple().to_string()[..8].to_ascii_uppercase();
+        let candidate = format!("{ci_schema}_Q_{random}");
+        if !occupied.contains(&candidate.to_ascii_uppercase()) {
+            return candidate;
+        }
+    }
+}
+
 fn model_config<'a>(config: &'a Config, id: &str, name: &str) -> &'a ModelConfig {
     config
         .models
         .get(id)
         .or_else(|| config.models.get(name))
         .unwrap_or(&EMPTY_MODEL_CONFIG)
+}
+
+fn query_configs_for_account<'a>(config: &'a Config, account: &str) -> Vec<&'a QueryDiffConfig> {
+    config
+        .checks
+        .iter()
+        .map(|check| check.query_diff())
+        .filter(|check| {
+            check.account.as_deref() == Some(account)
+                || (check.account.is_none() && config.accounts.len() == 1)
+        })
+        .collect()
+}
+
+#[allow(clippy::too_many_arguments)]
+fn plan_query_checks_for_account(
+    config: &Config,
+    account: &str,
+    current_manifest: &Manifest,
+    production_manifest: &Manifest,
+    changed: &BTreeSet<String>,
+    removed: &BTreeSet<String>,
+    current_impacted: &BTreeSet<String>,
+    surviving_removed_impact: &BTreeSet<String>,
+    changes: &QueryCheckChanges,
+    selected: &mut BTreeSet<String>,
+    report: &mut Report,
+) -> Result<Vec<PlannedQueryCheck>> {
+    let current_query_impacted = current_impacted
+        .union(surviving_removed_impact)
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let production_roots = changed
+        .iter()
+        .filter(|id| production_manifest.nodes.contains_key(*id))
+        .cloned()
+        .chain(removed.iter().cloned())
+        .collect::<BTreeSet<_>>();
+    let production_query_impacted = production_manifest.model_descendants(&production_roots);
+    let mut planned = Vec::new();
+    for check in query_configs_for_account(config, account) {
+        let current = QueryTemplate::parse(&check.sql)?;
+        let production =
+            QueryTemplate::parse(check.production_sql.as_deref().unwrap_or(&check.sql))?;
+        let current_refs = resolve_refs(current_manifest, current.refs());
+        let production_refs = resolve_refs(production_manifest, production.refs());
+        let mut targets = current.refs().iter().cloned().collect::<BTreeSet<_>>();
+        targets.extend(production.refs().iter().cloned());
+        let exists_on_one_side = targets.iter().any(|target| {
+            resolve_ref(current_manifest, target)
+                .ok()
+                .flatten()
+                .is_some()
+                != resolve_ref(production_manifest, target)
+                    .ok()
+                    .flatten()
+                    .is_some()
+        });
+        let has_resolution_error = current_refs
+            .iter()
+            .chain(&production_refs)
+            .any(|resolved| resolved.node_id.is_none());
+        let active = (current.refs().is_empty() && production.refs().is_empty())
+            || changes.changed.contains(&check.name.to_ascii_lowercase())
+            || current_refs.iter().any(|resolved| {
+                resolved
+                    .node_id
+                    .as_ref()
+                    .is_some_and(|id| current_query_impacted.contains(id))
+            })
+            || production_refs.iter().any(|resolved| {
+                resolved
+                    .node_id
+                    .as_ref()
+                    .is_some_and(|id| production_query_impacted.contains(id))
+            })
+            || exists_on_one_side
+            || has_resolution_error;
+        if !active {
+            report.query_checks.push(skipped_query_check(
+                check,
+                account,
+                &current_refs,
+                &production_refs,
+                "none of the referenced dbt models are impacted",
+            ));
+            continue;
+        }
+        let query_targets = current_refs
+            .iter()
+            .filter_map(|resolved| resolved.node_id.as_ref())
+            .filter(|id| current_query_impacted.contains(*id))
+            .filter(|id| {
+                current_manifest
+                    .nodes
+                    .get(*id)
+                    .is_some_and(|node| !node.config.materialized.eq_ignore_ascii_case("ephemeral"))
+            })
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        selected.extend(current_manifest.paths_between(changed, &query_targets));
+        selected.extend(query_targets);
+        planned.push(PlannedQueryCheck {
+            config: check.clone(),
+            current,
+            production,
+            current_refs,
+            production_refs,
+        });
+    }
+    Ok(planned)
+}
+
+fn resolve_ref(manifest: &Manifest, target: &RefTarget) -> Result<Option<String>> {
+    let mut matches = manifest.nodes.values().filter(|node| {
+        node.resource_type == "model"
+            && node.name == target.name
+            && target.package.as_ref().is_none_or(|package| {
+                node.unique_id
+                    .split('.')
+                    .nth(1)
+                    .is_some_and(|node_package| node_package == package)
+            })
+    });
+    let Some(node) = matches.next() else {
+        return Ok(None);
+    };
+    if matches.next().is_some() {
+        bail!("ref {} is ambiguous in the dbt manifest", target.display());
+    }
+    Ok(Some(node.unique_id.clone()))
+}
+
+fn resolve_refs(manifest: &Manifest, targets: &[RefTarget]) -> Vec<ResolvedRef> {
+    targets
+        .iter()
+        .map(|target| match resolve_ref(manifest, target) {
+            Ok(Some(node_id)) => ResolvedRef {
+                target: target.clone(),
+                node_id: Some(node_id),
+                error: None,
+            },
+            Ok(None) => ResolvedRef {
+                target: target.clone(),
+                node_id: None,
+                error: Some(format!(
+                    "ref {} does not resolve to a dbt model in this manifest",
+                    target.display()
+                )),
+            },
+            Err(error) => ResolvedRef {
+                target: target.clone(),
+                node_id: None,
+                error: Some(error.to_string()),
+            },
+        })
+        .collect()
+}
+
+fn skipped_query_check(
+    check: &QueryDiffConfig,
+    account: &str,
+    current_refs: &[ResolvedRef],
+    production_refs: &[ResolvedRef],
+    reason: &str,
+) -> QueryCheckReport {
+    QueryCheckReport {
+        name: check.name.clone(),
+        account: account.into(),
+        status: QueryCheckStatus::Skipped,
+        current_refs: current_refs
+            .iter()
+            .map(|resolved| resolved.target.display())
+            .collect(),
+        production_refs: production_refs
+            .iter()
+            .map(|resolved| resolved.target.display())
+            .collect(),
+        primary_key: check.primary_key.clone(),
+        candidate_relation: None,
+        production_relation: None,
+        candidate_row_count: None,
+        production_row_count: None,
+        columns: vec![],
+        comparison: None,
+        reason: Some(reason.into()),
+        invalid_primary_key_reason: None,
+        examples_truncated: false,
+    }
 }
 
 static EMPTY_MODEL_CONFIG: ModelConfig = ModelConfig {
@@ -961,7 +1850,98 @@ fn error_report(base: &str, error: anyhow::Error) -> Report {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::dbt::{DependsOn, ManifestNode, NodeConfig, QuotePolicy};
+    use crate::{
+        auth::ResolvedAuth,
+        dbt::{DependsOn, ManifestNode, NodeConfig, QuotePolicy},
+        query::QueryExecutor,
+        snowflake::{QueryResult, ResultColumn},
+    };
+    use std::{collections::VecDeque, future::Future, path::PathBuf, pin::Pin, sync::Mutex};
+
+    struct FakeExecutor(Mutex<VecDeque<QueryResult>>);
+
+    impl QueryExecutor for FakeExecutor {
+        fn execute<'a>(
+            &'a self,
+            _statement: &'a str,
+        ) -> Pin<Box<dyn Future<Output = Result<QueryResult>> + Send + 'a>> {
+            Box::pin(async move {
+                self.0
+                    .lock()
+                    .unwrap()
+                    .pop_front()
+                    .context("fake executor ran out of responses")
+            })
+        }
+    }
+
+    fn manifest(nodes: impl IntoIterator<Item = ManifestNode>) -> Manifest {
+        let nodes = nodes
+            .into_iter()
+            .map(|node| (node.unique_id.clone(), node))
+            .collect();
+        Manifest {
+            nodes,
+            exposures: BTreeMap::new(),
+            child_map: BTreeMap::new(),
+        }
+    }
+
+    #[cfg(unix)]
+    fn fake_dbt(directory: &Path, changed_model: &str) -> PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+
+        let path = directory.join("fake-dbt");
+        std::fs::write(
+            &path,
+            format!(
+                "#!/bin/sh\ncase \" $* \" in\n  *\" --resource-type model \"*) echo '{{\"unique_id\":\"{changed_model}\"}}' ;;\nesac\n"
+            ),
+        )
+        .unwrap();
+        let mut permissions = std::fs::metadata(&path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&path, permissions).unwrap();
+        path
+    }
+
+    fn model(id: &str, materialized: &str) -> ManifestNode {
+        ManifestNode {
+            unique_id: id.into(),
+            name: id.rsplit('.').next().unwrap().into(),
+            resource_type: "model".into(),
+            database: Some("DB".into()),
+            schema: "PROD".into(),
+            alias: id.rsplit('.').next().unwrap().into(),
+            fqn: id.split('.').map(ToOwned::to_owned).collect(),
+            tags: vec![],
+            depends_on: DependsOn::default(),
+            config: NodeConfig {
+                materialized: materialized.into(),
+                ..NodeConfig::default()
+            },
+        }
+    }
+
+    fn query_config(check: &str) -> Config {
+        serde_yaml::from_str(&format!(
+            r#"
+version: 1
+accounts:
+  - name: primary
+    account: org-one
+    user: ci
+    role: ci
+    database: DB
+    warehouse: ci
+    production_schema: PROD
+    auth: {{ type: oauth, token_env: TOKEN }}
+checks:
+{check}
+"#
+        ))
+        .unwrap()
+    }
 
     #[test]
     fn ci_relation_never_uses_production_schema() {
@@ -978,6 +1958,22 @@ mod tests {
             config: NodeConfig::default(),
         };
         assert_eq!(relation_for(&node, "OTHER", "CHECK").schema, "CHECK");
+    }
+
+    #[test]
+    fn query_schema_cannot_reuse_a_dbt_custom_schema() {
+        let occupied = BTreeSet::from(["RUN_QUERY".into()]);
+        let schema = unique_query_schema("RUN", &occupied);
+        assert_ne!(schema, "RUN_QUERY");
+        assert!(schema.starts_with("RUN_Q_"));
+        assert!(is_managed_schema(&schema, "RUN"));
+        let longest_run_schema = "R".repeat(241);
+        let longest_query_schema = unique_query_schema(&longest_run_schema, &BTreeSet::new());
+        assert!(longest_query_schema.len() <= 255);
+        assert!(is_managed_schema(
+            &longest_query_schema,
+            &longest_run_schema
+        ));
     }
 
     #[tokio::test]
@@ -1035,5 +2031,586 @@ mod tests {
             relation_for(&node, "other", "CiSchema").sql(),
             "\"Analytics\".\"CiSchema\".\"OrderLines\""
         );
+    }
+
+    #[tokio::test]
+    async fn ref_free_query_runs_without_changed_models_and_controls_exit_status() {
+        let config =
+            query_config("  - { type: query_diff, name: always, sql: \"select 1 as id\" }");
+        config.validate().unwrap();
+        let current = manifest([]);
+        let production = manifest([]);
+        let mut selected = BTreeSet::new();
+        let mut report = Report::empty("main".into(), config.thresholds);
+        let planned = plan_query_checks_for_account(
+            &config,
+            "primary",
+            &current,
+            &production,
+            &BTreeSet::new(),
+            &BTreeSet::new(),
+            &BTreeSet::new(),
+            &BTreeSet::new(),
+            &QueryCheckChanges::default(),
+            &mut selected,
+            &mut report,
+        )
+        .unwrap();
+        assert!(selected.is_empty());
+        assert_eq!(planned.len(), 1);
+        let candidate_sql = planned[0].current.render(|_| unreachable!()).unwrap();
+        let production_sql = planned[0].production.render(|_| unreachable!()).unwrap();
+        let metadata = || QueryResult {
+            columns: vec![ResultColumn {
+                name: "ID".into(),
+                data_type: "NUMBER(38,0)".into(),
+            }],
+            rows: vec![],
+        };
+        let rows = |values: &[&str]| QueryResult {
+            columns: vec![],
+            rows: vec![values.iter().map(|value| Some((*value).into())).collect()],
+        };
+        let executor = FakeExecutor(Mutex::new(
+            vec![
+                metadata(),
+                metadata(),
+                QueryResult::default(),
+                QueryResult::default(),
+                rows(&["2", "1"]),
+                rows(&["1", "0"]),
+                rows(&["1", "1", "2", "1"]),
+            ]
+            .into(),
+        ));
+        let candidate = Relation {
+            database: "DB".into(),
+            schema: "RUN".into(),
+            identifier: "C".into(),
+        };
+        let production_relation = Relation {
+            database: "DB".into(),
+            schema: "RUN".into(),
+            identifier: "P".into(),
+        };
+        let outcome = run_query_diff(
+            &executor,
+            QueryDiffInput {
+                name: "always",
+                account: "primary",
+                current_refs: vec![],
+                production_refs: vec![],
+                candidate_sql: &candidate_sql,
+                production_sql: &production_sql,
+                candidate: &candidate,
+                production: &production_relation,
+                primary_key: &[],
+                safety: &config.safety,
+            },
+        )
+        .await
+        .unwrap();
+        record_query_outcome(&mut report, &outcome);
+        report.query_checks.push(outcome);
+        report.finalize();
+        assert_eq!(report.exit_code, crate::report::EXIT_FINDINGS);
+        assert_eq!(report.summary.query_checks_run, 1);
+    }
+
+    #[tokio::test]
+    async fn base_only_removed_ref_activates_renders_and_compares() {
+        let config = query_config(
+            r#"  - type: query_diff
+    name: removed model
+    sql: select 1 as id
+    production_sql: select id from {{ ref('removed') }}"#,
+        );
+        config.validate().unwrap();
+        let current = manifest([]);
+        let production = manifest([model("model.project.removed", "table")]);
+        let removed = BTreeSet::from(["model.project.removed".into()]);
+        let mut selected = BTreeSet::new();
+        let mut report = Report::empty("main".into(), config.thresholds);
+        let planned = plan_query_checks_for_account(
+            &config,
+            "primary",
+            &current,
+            &production,
+            &BTreeSet::new(),
+            &removed,
+            &BTreeSet::new(),
+            &BTreeSet::new(),
+            &QueryCheckChanges::default(),
+            &mut selected,
+            &mut report,
+        )
+        .unwrap();
+        assert_eq!(planned.len(), 1);
+        assert!(selected.is_empty());
+        let rendered = planned[0]
+            .production
+            .render(|target| {
+                let id = resolved_id(&planned[0].production_refs, target)?;
+                Ok(relation_for(&production.nodes[id], "DB", "PROD").sql())
+            })
+            .unwrap();
+        assert_eq!(rendered, r#"select id from "DB"."PROD"."REMOVED""#);
+        let candidate_sql = planned[0].current.render(|_| unreachable!()).unwrap();
+        let metadata = || QueryResult {
+            columns: vec![ResultColumn {
+                name: "ID".into(),
+                data_type: "NUMBER(38,0)".into(),
+            }],
+            rows: vec![],
+        };
+        let metrics = |values: &[&str]| QueryResult {
+            columns: vec![],
+            rows: vec![values.iter().map(|value| Some((*value).into())).collect()],
+        };
+        let executor = FakeExecutor(Mutex::new(
+            vec![
+                metadata(),
+                metadata(),
+                QueryResult::default(),
+                QueryResult::default(),
+                metrics(&["1", "1"]),
+                metrics(&["0", "0"]),
+            ]
+            .into(),
+        ));
+        let candidate = Relation {
+            database: "DB".into(),
+            schema: "RUN".into(),
+            identifier: "C".into(),
+        };
+        let production_relation = Relation {
+            database: "DB".into(),
+            schema: "RUN".into(),
+            identifier: "P".into(),
+        };
+        let outcome = run_query_diff(
+            &executor,
+            QueryDiffInput {
+                name: "removed model",
+                account: "primary",
+                current_refs: vec![],
+                production_refs: vec!["removed".into()],
+                candidate_sql: &candidate_sql,
+                production_sql: &rendered,
+                candidate: &candidate,
+                production: &production_relation,
+                primary_key: &[],
+                safety: &config.safety,
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(outcome.status, QueryCheckStatus::Pass);
+        assert!(outcome.comparison.is_some());
+    }
+
+    #[test]
+    fn modified_and_removed_query_checks_are_never_silent() {
+        let current = query_config(
+            r#"  - type: query_diff
+    name: orders check
+    sql: select id from {{ ref('orders') }} where id > 0"#,
+        );
+        let previous = query_config(
+            r#"  - type: query_diff
+    name: orders check
+    sql: select id from {{ ref('orders') }}
+  - type: query_diff
+    name: removed check
+    sql: select id from {{ ref('orders') }}"#,
+        );
+        let mut report = Report::empty("main".into(), current.thresholds);
+        let changes = compare_query_check_definitions(&current, &previous, "main", &mut report);
+        assert!(changes.changed.contains("orders check"));
+        assert!(report.coverage_gaps.iter().any(|gap| {
+            gap.scope == "query:removed check" && gap.check == "query_diff_removed"
+        }));
+
+        let current_manifest = manifest([model("model.project.orders", "table")]);
+        let production_manifest = current_manifest.clone();
+        let mut selected = BTreeSet::new();
+        let planned = plan_query_checks_for_account(
+            &current,
+            "primary",
+            &current_manifest,
+            &production_manifest,
+            &BTreeSet::new(),
+            &BTreeSet::new(),
+            &BTreeSet::new(),
+            &BTreeSet::new(),
+            &changes,
+            &mut selected,
+            &mut report,
+        )
+        .unwrap();
+        assert_eq!(planned.len(), 1);
+        assert!(selected.is_empty());
+
+        let selections = vec![AccountSelection {
+            selected,
+            removed: BTreeSet::new(),
+            query_checks: planned,
+        }];
+        let context = DbtContext::for_test(
+            PathBuf::new(),
+            BTreeMap::from([("primary".into(), current_manifest)]),
+            BTreeMap::from([("primary".into(), production_manifest)]),
+        )
+        .unwrap();
+        plan_query_reports(&current, &context, &selections, &mut report);
+        assert!(report.query_checks.iter().any(|check| {
+            check.name == "orders check" && check.status == QueryCheckStatus::Planned
+        }));
+    }
+
+    #[test]
+    fn config_outside_repo_runs_current_checks_without_base_comparison() {
+        let mut config =
+            query_config("  - { type: query_diff, name: outside, sql: \"select 1 as id\" }");
+        config.source_path = Some(PathBuf::from("/outside/embrasure-check.yml"));
+        let mut report = Report::empty("main".into(), config.thresholds);
+        let changes = query_check_changes(&config, "main", Path::new("/repo"), &mut report)
+            .expect("an unversioned config should not stop validation");
+        assert!(changes.changed.contains("outside"));
+        assert!(report.notices.iter().any(|notice| {
+            notice.code == "query_check_base_unavailable"
+                && notice.message.contains("removed checks cannot be compared")
+        }));
+
+        config.checks.clear();
+        report.notices.clear();
+        query_check_changes(&config, "main", Path::new("/repo"), &mut report).unwrap();
+        assert!(report.notices.is_empty());
+    }
+
+    #[test]
+    fn ephemeral_refs_are_incomplete_on_either_side() {
+        let config = query_config(
+            r#"  - type: query_diff
+    name: ephemeral
+    sql: select id from {{ ref('orders') }}"#,
+        );
+        let id = "model.project.orders";
+        for (current_kind, production_kind, expected) in [
+            ("ephemeral", "table", "current ref orders is ephemeral"),
+            ("table", "ephemeral", "production ref orders is ephemeral"),
+        ] {
+            let current = manifest([model(id, current_kind)]);
+            let production = manifest([model(id, production_kind)]);
+            let changed = BTreeSet::from([id.into()]);
+            let mut selected = BTreeSet::new();
+            let mut report = Report::empty("main".into(), config.thresholds);
+            let planned = plan_query_checks_for_account(
+                &config,
+                "primary",
+                &current,
+                &production,
+                &changed,
+                &BTreeSet::new(),
+                &changed,
+                &BTreeSet::new(),
+                &QueryCheckChanges::default(),
+                &mut selected,
+                &mut report,
+            )
+            .unwrap();
+            assert!(
+                ephemeral_ref_reason(&planned[0], &current, &production)
+                    .unwrap()
+                    .starts_with(expected)
+            );
+        }
+    }
+
+    #[test]
+    fn invalid_query_keys_are_findings_and_incomplete_with_namespaced_scope() {
+        let mut report = Report::empty("main".into(), Thresholds::default());
+        let check = QueryCheckReport {
+            name: "orders".into(),
+            account: "primary".into(),
+            status: QueryCheckStatus::Incomplete,
+            current_refs: vec![],
+            production_refs: vec![],
+            primary_key: vec!["missing_id".into()],
+            candidate_relation: None,
+            production_relation: None,
+            candidate_row_count: None,
+            production_row_count: None,
+            columns: vec![],
+            comparison: None,
+            reason: Some(
+                "primary-key column missing_id is missing from one or both query results".into(),
+            ),
+            invalid_primary_key_reason: Some(
+                "primary-key column missing_id is missing from one or both query results".into(),
+            ),
+            examples_truncated: false,
+        };
+        record_query_outcome(&mut report, &check);
+        assert_eq!(report.findings[0].model, "query:orders");
+        assert_eq!(report.coverage_gaps[0].scope, "query:orders");
+
+        let mut unrelated = Report::empty("main".into(), Thresholds::default());
+        let mut duplicate = check.clone();
+        duplicate.primary_key = vec!["id".into()];
+        duplicate.reason =
+            Some("candidate query returns duplicate column name amount; add unique aliases".into());
+        duplicate.invalid_primary_key_reason = None;
+        record_query_outcome(&mut unrelated, &duplicate);
+        assert!(unrelated.findings.is_empty());
+        duplicate.reason = Some(
+            "candidate query returns duplicate column name order;id; add unique aliases".into(),
+        );
+        duplicate.invalid_primary_key_reason =
+            Some("primary-key column order;id is ambiguous".into());
+        record_query_outcome(&mut unrelated, &duplicate);
+        assert_eq!(unrelated.findings[0].check, "query_diff_primary_key");
+        assert_eq!(
+            unrelated.findings[0].message,
+            "primary-key column order;id is ambiguous"
+        );
+        assert!(
+            unrelated.coverage_gaps[1]
+                .reason
+                .contains("duplicate column")
+        );
+    }
+
+    #[test]
+    fn key_integrity_is_a_finding_with_incomplete_value_evidence() {
+        let mut report = Report::empty("main".into(), Thresholds::default());
+        let check = QueryCheckReport {
+            name: "orders".into(),
+            account: "primary".into(),
+            status: QueryCheckStatus::Findings,
+            current_refs: vec![],
+            production_refs: vec![],
+            primary_key: vec!["id".into()],
+            candidate_relation: None,
+            production_relation: None,
+            candidate_row_count: Some(2),
+            production_row_count: Some(1),
+            columns: vec![],
+            comparison: None,
+            reason: Some(
+                "key integrity blocks value comparison: candidate has 1 duplicate keys and 0 null-key rows; production has 0 duplicate keys and 0 null-key rows".into(),
+            ),
+            invalid_primary_key_reason: None,
+            examples_truncated: false,
+        };
+        record_query_outcome(&mut report, &check);
+        assert_eq!(report.findings[0].model, "query:orders");
+        assert_eq!(report.coverage_gaps[0].check, "query_diff_values");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn orchestration_expands_selection_uses_baseline_and_records_build_and_ref_gaps() {
+        let changed_id = "model.project.changed";
+        let target_id = "model.project.target";
+        let mut changed = model(changed_id, "table");
+        changed.schema = "RUN".into();
+        let mut target = model(target_id, "incremental");
+        target.schema = "RUN".into();
+        target.depends_on.nodes.push(changed_id.into());
+        let mut current = manifest([changed.clone(), target.clone()]);
+        current
+            .child_map
+            .insert(changed_id.into(), vec![target_id.into()]);
+        let production = manifest([
+            model(changed_id, "table"),
+            model(target_id, "incremental"),
+            model("model.project.removed", "table"),
+        ]);
+        let harness = tempfile::tempdir().unwrap();
+        let repo_output = std::process::Command::new("git")
+            .args(["rev-parse", "--show-toplevel"])
+            .output()
+            .unwrap();
+        let repo = PathBuf::from(String::from_utf8(repo_output.stdout).unwrap().trim());
+        let mut config = query_config(
+            r#"  - type: query_diff
+    name: target check
+    sql: select id from {{ ref('target') }}
+  - type: query_diff
+    name: unresolved check
+    sql: select id from {{ ref('missing') }}
+  - type: query_diff
+    name: always check
+    sql: select 1 as id
+  - type: query_diff
+    name: removed check
+    sql: select 1 as id
+    production_sql: select id from {{ ref('removed') }}"#,
+        );
+        config.dbt.project_dir = repo.clone();
+        config.dbt.command = fake_dbt(harness.path(), changed_id)
+            .to_string_lossy()
+            .into_owned();
+        config.validation.downstream = DownstreamPolicy::None;
+        let context = DbtContext::for_test(
+            repo,
+            BTreeMap::from([("primary".into(), current)]),
+            BTreeMap::from([("primary".into(), production)]),
+        )
+        .unwrap();
+        let mut report = Report::empty("HEAD".into(), config.thresholds);
+        let selections = plan_selections(
+            &config,
+            &context,
+            &CheckOptions::default(),
+            &QueryCheckChanges::default(),
+            &mut report,
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(
+            selections[0].selected,
+            BTreeSet::from([changed_id.into(), target_id.into()])
+        );
+
+        report.models.push(ModelReport {
+            unique_id: target_id.into(),
+            name: "target".into(),
+            account: "primary".into(),
+            ci_relation: r#""DB"."RUN"."TARGET""#.into(),
+            production_relation: Some(r#""DB"."PROD"."TARGET""#.into()),
+            dbt_build: "passed".into(),
+            build_strategy: "incremental_clone".into(),
+            comparison: None,
+        });
+        let baseline = Relation {
+            database: "DB".into(),
+            schema: "RUN_BASELINE".into(),
+            identifier: "TARGET".into(),
+        };
+        let baselines = BTreeMap::from([(("primary".into(), target_id.into()), baseline.clone())]);
+        let client = SnowflakeClient::new(
+            &config.accounts[0],
+            &ResolvedAuth::ProgrammaticAccessToken {
+                token: "unused".into(),
+            },
+            "test".into(),
+            30,
+        )
+        .unwrap();
+        let jobs = prepare_query_jobs(
+            &config,
+            &context,
+            &[client],
+            "RUN_QUERY",
+            &selections,
+            &baselines,
+            &mut report,
+        );
+        assert_eq!(jobs.len(), 3);
+        assert!(jobs.iter().all(|job| {
+            job.candidate.schema == "RUN_QUERY" && job.production.schema == "RUN_QUERY"
+        }));
+        let target_job = jobs.iter().find(|job| job.name == "target check").unwrap();
+        assert!(target_job.candidate_sql.contains(r#""DB"."RUN"."TARGET""#));
+        assert!(target_job.production_sql.contains(&baseline.sql()));
+        assert!(jobs.iter().any(|job| {
+            job.name == "always check"
+                && job.current_refs.is_empty()
+                && job.production_refs.is_empty()
+        }));
+        assert!(jobs.iter().any(|job| {
+            job.name == "removed check" && job.production_sql.contains(r#""DB"."PROD"."REMOVED""#)
+        }));
+        assert!(report.query_checks.iter().any(|check| {
+            check.name == "unresolved check" && check.status == QueryCheckStatus::Incomplete
+        }));
+
+        let metadata = || QueryResult {
+            columns: vec![ResultColumn {
+                name: "ID".into(),
+                data_type: "NUMBER(38,0)".into(),
+            }],
+            rows: vec![],
+        };
+        let metrics = |values: &[&str]| QueryResult {
+            columns: vec![],
+            rows: vec![values.iter().map(|value| Some((*value).into())).collect()],
+        };
+        for job in &jobs {
+            let executor = FakeExecutor(Mutex::new(
+                vec![
+                    metadata(),
+                    metadata(),
+                    QueryResult::default(),
+                    QueryResult::default(),
+                    metrics(&["1", "1"]),
+                    metrics(&["0", "0"]),
+                ]
+                .into(),
+            ));
+            let outcome = run_query_diff(
+                &executor,
+                QueryDiffInput {
+                    name: &job.name,
+                    account: &job.account,
+                    current_refs: job.current_refs.clone(),
+                    production_refs: job.production_refs.clone(),
+                    candidate_sql: &job.candidate_sql,
+                    production_sql: &job.production_sql,
+                    candidate: &job.candidate,
+                    production: &job.production,
+                    primary_key: &job.primary_key,
+                    safety: &job.safety,
+                },
+            )
+            .await
+            .unwrap();
+            assert_eq!(outcome.status, QueryCheckStatus::Pass);
+            record_query_outcome(&mut report, &outcome);
+            report.query_checks.push(outcome);
+        }
+        report.finalize();
+        assert_eq!(report.exit_code, crate::report::EXIT_INCOMPLETE);
+
+        let mut failed = Report::empty("HEAD".into(), config.thresholds);
+        failed.models.push(ModelReport {
+            unique_id: target_id.into(),
+            name: "target".into(),
+            account: "primary".into(),
+            ci_relation: r#""DB"."RUN"."TARGET""#.into(),
+            production_relation: Some(r#""DB"."PROD"."TARGET""#.into()),
+            dbt_build: "failed".into(),
+            build_strategy: "incremental_clone".into(),
+            comparison: None,
+        });
+        let failed_jobs = prepare_query_jobs(
+            &config,
+            &context,
+            &[SnowflakeClient::new(
+                &config.accounts[0],
+                &ResolvedAuth::ProgrammaticAccessToken {
+                    token: "unused".into(),
+                },
+                "test".into(),
+                30,
+            )
+            .unwrap()],
+            "RUN_QUERY",
+            &selections,
+            &baselines,
+            &mut failed,
+        );
+        assert_eq!(failed_jobs.len(), 2);
+        assert!(!failed_jobs.iter().any(|job| job.name == "target check"));
+        assert!(failed.query_checks.iter().any(|check| {
+            check.name == "target check"
+                && check.status == QueryCheckStatus::Incomplete
+                && check
+                    .reason
+                    .as_deref()
+                    .is_some_and(|reason| reason.contains("not built"))
+        }));
     }
 }

--- a/src/snowflake.rs
+++ b/src/snowflake.rs
@@ -534,7 +534,12 @@ fn privilege_hint(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{auth::ResolvedAuth, config::AuthConfig};
+    use crate::{
+        auth::ResolvedAuth,
+        config::{AuthConfig, SafetyConfig},
+        query::{QueryDiffInput, run_query_diff},
+        report::QueryCheckStatus,
+    };
     use openssl::{rsa::Rsa, sign::Verifier};
 
     #[test]
@@ -789,6 +794,109 @@ mod tests {
             assert_eq!(integrity.rows[0][0].as_deref(), Some("50001"));
             assert_eq!(integrity.rows[0][1].as_deref(), Some("0"));
             assert_eq!(integrity.rows[0][2].as_deref(), Some("1"));
+
+            let query_candidate = Relation {
+                database: account.database.clone(),
+                schema: second_schema.clone(),
+                identifier: "QUERY_CANDIDATE".into(),
+            };
+            let query_production = Relation {
+                database: account.database.clone(),
+                schema: second_schema.clone(),
+                identifier: "QUERY_PRODUCTION".into(),
+            };
+            let candidate_sql = format!("SELECT ID, SEGMENT FROM {}", candidate.sql());
+            let production_sql = format!(
+                "SELECT ID, SEGMENT FROM {} WHERE ID < 50000",
+                baseline.sql()
+            );
+            let query_report = run_query_diff(
+                &client,
+                QueryDiffInput {
+                    name: "duplicate multiplicity",
+                    account: "integration",
+                    current_refs: vec![],
+                    production_refs: vec![],
+                    candidate_sql: &candidate_sql,
+                    production_sql: &production_sql,
+                    candidate: &query_candidate,
+                    production: &query_production,
+                    primary_key: &[],
+                    safety: &SafetyConfig::default(),
+                },
+            )
+            .await?;
+            assert_eq!(query_report.status, QueryCheckStatus::Findings);
+            let comparison = query_report.comparison.unwrap();
+            assert_eq!(comparison.candidate_only_rows, 1);
+            assert_eq!(comparison.production_only_rows, 0);
+            assert_eq!(comparison.examples[0].candidate_multiplicity, Some(2));
+            assert_eq!(comparison.examples[0].production_multiplicity, Some(1));
+
+            let pass_candidate = Relation {
+                database: account.database.clone(),
+                schema: second_schema.clone(),
+                identifier: "QUERY_PASS_CANDIDATE".into(),
+            };
+            let pass_production = Relation {
+                database: account.database.clone(),
+                schema: second_schema.clone(),
+                identifier: "QUERY_PASS_PRODUCTION".into(),
+            };
+            let pass_sql = format!("SELECT ID, SEGMENT FROM {}", baseline.sql());
+            let pass = run_query_diff(
+                &client,
+                QueryDiffInput {
+                    name: "exact keyed pass",
+                    account: "integration",
+                    current_refs: vec![],
+                    production_refs: vec![],
+                    candidate_sql: &pass_sql,
+                    production_sql: &pass_sql,
+                    candidate: &pass_candidate,
+                    production: &pass_production,
+                    primary_key: &["ID".into()],
+                    safety: &SafetyConfig::default(),
+                },
+            )
+            .await?;
+            assert_eq!(pass.status, QueryCheckStatus::Pass);
+
+            let keyed_candidate = Relation {
+                database: account.database.clone(),
+                schema: second_schema.clone(),
+                identifier: "QUERY_KEYED_CANDIDATE".into(),
+            };
+            let keyed_production = Relation {
+                database: account.database.clone(),
+                schema: second_schema.clone(),
+                identifier: "QUERY_KEYED_PRODUCTION".into(),
+            };
+            let candidate_sql = "SELECT COLUMN1::NUMBER(38,0) AS ID, COLUMN2::VARCHAR(20) AS VALUE FROM VALUES (1, 'same'), (2, 'new'), (4, 'added')";
+            let production_sql = "SELECT COLUMN1::NUMBER(38,0) AS ID, COLUMN2::VARCHAR(20) AS VALUE FROM VALUES (1, 'same'), (2, 'old'), (3, 'removed')";
+            let keyed = run_query_diff(
+                &client,
+                QueryDiffInput {
+                    name: "keyed changes",
+                    account: "integration",
+                    current_refs: vec![],
+                    production_refs: vec![],
+                    candidate_sql,
+                    production_sql,
+                    candidate: &keyed_candidate,
+                    production: &keyed_production,
+                    primary_key: &["ID".into()],
+                    safety: &SafetyConfig::default(),
+                },
+            )
+            .await?;
+            assert_eq!(keyed.status, QueryCheckStatus::Findings);
+            let comparison = keyed.comparison.unwrap();
+            assert_eq!(comparison.candidate_only_rows, 1);
+            assert_eq!(comparison.production_only_rows, 1);
+            assert_eq!(comparison.changed_rows, 1);
+            assert_eq!(comparison.column_mismatches[0].column, "VALUE");
+            assert_eq!(comparison.column_mismatches[0].rows, 1);
             Ok::<(), anyhow::Error>(())
         }
         .await;

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -184,7 +184,7 @@ fn check_exposes_scope_incremental_and_report_controls() {
         .stdout(predicate::str::contains(
             "--report-version <REPORT_VERSION>",
         ))
-        .stdout(predicate::str::contains("possible values: 1, 2"))
+        .stdout(predicate::str::contains("possible values: 1, 2, 3"))
         .stdout(predicate::str::contains("--verbose"));
 }
 


### PR DESCRIPTION
## Summary

- add first-class `query_diff` checks with safe `ref()` rendering, symmetric impact selection, ref-free execution, and stable incremental baselines
- materialize each side once and compare exact bag semantics, or keyed row/column changes with integrity checks and bounded examples
- add explicit report v3 output/schema while preserving v1/v2 projections, plus configuration and security documentation

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked` (75 passed)
- `cargo package --locked --allow-dirty`
- nontrivial orchestration harness from parsed YAML through manifests, build outcomes, ref rendering, fake execution, report finalization, and exit status
- exact unkeyed duplicate-multiplicity, keyed add/remove/change, key-integrity, and report-schema end-to-end tests

An opt-in live Snowflake suite exercises the same public primitive. It could not run locally because the required Snowflake integration credentials are not available in this environment.