### PR TITLE
Polish the standalone CLI and complete release tooling

### DIFF
--- a/.github/embrasure.rb.template
+++ b/.github/embrasure.rb.template
@@ -1,0 +1,34 @@
+class Embrasure < Formula
+  desc "Validate dbt changes against production Snowflake data"
+  homepage "https://embrasure.ai"
+  version "@VERSION@"
+  license "Apache-2.0"
+
+  on_macos do
+    if Hardware::CPU.arm?
+      url "https://github.com/EmbrasureAI/embrasure-cli/releases/download/v@VERSION@/embrasure-@VERSION@-aarch64-apple-darwin.tar.gz"
+      sha256 "@MAC_ARM@"
+    else
+      url "https://github.com/EmbrasureAI/embrasure-cli/releases/download/v@VERSION@/embrasure-@VERSION@-x86_64-apple-darwin.tar.gz"
+      sha256 "@MAC_INTEL@"
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.arm?
+      url "https://github.com/EmbrasureAI/embrasure-cli/releases/download/v@VERSION@/embrasure-@VERSION@-aarch64-unknown-linux-gnu.tar.gz"
+      sha256 "@LINUX_ARM@"
+    else
+      url "https://github.com/EmbrasureAI/embrasure-cli/releases/download/v@VERSION@/embrasure-@VERSION@-x86_64-unknown-linux-gnu.tar.gz"
+      sha256 "@LINUX_INTEL@"
+    end
+  end
+
+  def install
+    bin.install "embrasure"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/embrasure --version")
+  end
+end

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,4 +21,14 @@ jobs:
       - run: cargo fmt --check
       - run: cargo clippy --all-targets --all-features -- -D warnings
       - run: cargo test --locked
+      # Guard the release manifest and packaged file set; this project is not published to crates.io.
       - run: cargo package --locked
+
+  msrv:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install minimum supported Rust
+        run: rustup toolchain install 1.85 --profile minimal
+      - run: cargo +1.85 check --locked --all-targets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,8 @@ jobs:
           package="embrasure-${version}-${{ matrix.target }}"
           mkdir -p "dist/${package}"
           cp "target/${{ matrix.target }}/release/embrasure" "dist/${package}/embrasure"
-          cp LICENSE NOTICE README.md SECURITY.md "dist/${package}/"
+          cp LICENSE NOTICE README.md SECURITY.md embrasure-check.example.yml "dist/${package}/"
+          cp -R docs "dist/${package}/docs"
           "dist/${package}/embrasure" --version | grep "embrasure ${version}"
           tar -C dist -czf "dist/${package}.tar.gz" "${package}"
           rm -rf "dist/${package}"
@@ -119,3 +120,49 @@ jobs:
             --verify-tag \
             --title "Embrasure ${GITHUB_REF_NAME}" \
             --generate-notes
+      - name: Move the composite action major tag
+        shell: bash
+        run: |
+          git tag --force v1 "${GITHUB_SHA}"
+          git push origin refs/tags/v1 --force
+
+  tap:
+    needs: publish
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Download release checksums
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release download "${GITHUB_REF_NAME}" --pattern SHA256SUMS
+      - name: Check out Homebrew tap
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: EmbrasureAI/homebrew-tap
+          token: ${{ secrets.TAP_PUSH_TOKEN }}
+          path: tap
+      - name: Regenerate formula
+        shell: bash
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          checksum() { awk -v name="$1" '$2 == name { print $1 }' SHA256SUMS; }
+          mac_arm="$(checksum "embrasure-${version}-aarch64-apple-darwin.tar.gz")"
+          mac_intel="$(checksum "embrasure-${version}-x86_64-apple-darwin.tar.gz")"
+          linux_arm="$(checksum "embrasure-${version}-aarch64-unknown-linux-gnu.tar.gz")"
+          linux_intel="$(checksum "embrasure-${version}-x86_64-unknown-linux-gnu.tar.gz")"
+          test -n "${mac_arm}${mac_intel}${linux_arm}${linux_intel}"
+          mkdir -p tap/Formula
+          sed \
+            -e "s/@VERSION@/${version}/g" \
+            -e "s/@MAC_ARM@/${mac_arm}/g" \
+            -e "s/@MAC_INTEL@/${mac_intel}/g" \
+            -e "s/@LINUX_ARM@/${linux_arm}/g" \
+            -e "s/@LINUX_INTEL@/${linux_intel}/g" \
+            .github/embrasure.rb.template > tap/Formula/embrasure.rb
+          cd tap
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git add Formula/embrasure.rb
+          git diff --cached --quiet || git commit -m "Update Embrasure to ${version}"
+          git push

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,5 @@
 # Contributing
 
-Thanks for helping improve Embrasure.
+Open an issue before a large behavior or report-contract change. Never commit credentials, tokens, profiles, private keys, or query results.
 
-1. Open an issue before a large behavior or report-schema change.
-2. Keep Snowflake credentials in environment variables or local key files. Never add credentials, tokens, profiles, or query results to fixtures.
-3. Add deterministic tests for new selection, comparison, lineage, or output behavior.
-4. Run `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test --locked`.
-
-Pull requests must preserve the stable exit-code contract and must not weaken CI-schema cleanup safeguards.
+Development requirements and verification commands are in [README.md](README.md#development). Security boundaries and cleanup safeguards are in [Security and data flow](docs/security-and-data-flow.md).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,6 +262,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be2ad0423bdbbb0e25bc89add796f3559706d4a95e1bc98e4d9662a957b6a19"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -402,6 +411,7 @@ dependencies = [
  "base64 0.23.1",
  "chrono",
  "clap",
+ "clap_complete",
  "directories",
  "globset",
  "jsonschema",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,6 +343,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "dispatch2"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -381,8 +402,10 @@ dependencies = [
  "base64 0.23.1",
  "chrono",
  "clap",
+ "directories",
  "globset",
  "jsonschema",
+ "keyring",
  "openssl",
  "predicates",
  "rand 0.8.7",
@@ -936,6 +959,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "log",
+ "zeroize",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -946,6 +979,15 @@ name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "libredox"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1195,6 +1237,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1438,6 +1486,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ anyhow = "1.0"
 base64 = "0.23"
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
 clap = { version = "4.5", features = ["derive"] }
+clap_complete = "4.5"
 globset = "0.4"
 directories = "6.0"
 keyring = "3.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ base64 = "0.23"
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
 clap = { version = "4.5", features = ["derive"] }
 globset = "0.4"
+directories = "6.0"
+keyring = "3.6"
 openssl = { version = "0.10", features = ["vendored"] }
 rand = "0.8"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/README.md
+++ b/README.md
@@ -40,6 +40,16 @@ embrasure doctor
 embrasure check --base origin/main
 ```
 
+Hand the exact reviewed working state to a durable cloud agent only when you choose:
+
+```bash
+embrasure cloud login
+embrasure check --base origin/main --cloud \
+  --context "Preserve one row per order. Refunds reduce net revenue. Missing discounts are zero."
+```
+
+`--cloud` requires business intent, prints every eligible path before upload, and reuses the immediately preceding local review only when the repository, dbt root, base SHA, working-tree snapshot, CLI version, and check configuration all match. Local `embrasure check` remains private and account-free.
+
 Example result:
 
 ```text

--- a/README.md
+++ b/README.md
@@ -7,31 +7,47 @@
 
 <p align="center"><strong>Catch unexpected data changes before a dbt PR is reviewed.</strong></p>
 
-Embrasure builds the dbt models changed on your branch and the paths to critical downstream models in temporary Snowflake schemas. It compares them with production, runs your existing dbt tests, reports the full downstream impact, and removes the schemas when it finishes.
+Embrasure builds changed dbt models and paths to critical downstream models in temporary Snowflake schemas. It runs existing dbt tests, compares candidate data with production, reports downstream impact, and removes the schemas.
 
-Use it locally or in CI. It connects directly to Snowflake, so no Embrasure account or hosted service is required.
+Local checks connect directly to Snowflake. They require no Embrasure account or hosted service.
 
 ## What it catches
 
 - Columns added, removed, renamed, or changed to an incompatible type
-- Unexpected shifts in row counts, null rates, cardinality, ranges, averages, and percentiles
+- Shifts in row counts, null rates, cardinality, ranges, averages, and percentiles
 - Primary-key values that appear or disappear
-- Duplicate and null primary keys introduced by the branch
-- Failures in your existing dbt tests
-- Downstream dbt models, exposures, cross-account dependencies, and optional Metabase dashboards affected by the change
-- Models affected by non-dbt changes you map in the configuration
+- Duplicate or null primary keys introduced by a branch
+- Existing dbt test failures
+- Affected dbt models and exposures
+- Declared cross-account dependencies
+- Optional Metabase dashboards
+- Models mapped to non-dbt file changes
 
-## Run it locally
+## Install
 
-You need Git and dbt Core with the Snowflake adapter. You do not need Rust or an Embrasure account.
+You need Git, dbt Core 1.5 or newer, and dbt-snowflake 1.5 or newer. Embrasure uses `dbt parse --target-path`, state selection, JSON `--output-keys`, and deferred builds. These interfaces are present in dbt Core 1.5. You do not need Rust.
 
-Install the CLI on macOS or Linux:
+```sh
+python -m pip install "dbt-core>=1.5,<2" "dbt-snowflake>=1.5,<2"
+```
+
+Install Embrasure on macOS or Linux with Homebrew:
 
 ```sh
 brew install embrasureai/tap/embrasure
 ```
 
-From your dbt project, run the guided setup. It reads your existing dbt profile and only asks for anything it cannot find.
+Or use the verified installer:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/EmbrasureAI/embrasure-cli/main/install.sh | sh
+```
+
+The installer verifies `SHA256SUMS` and writes to `/usr/local/bin` when writable, otherwise `~/.local/bin`. Set `EMBRASURE_INSTALL_DIR` to choose another directory.
+
+## First check
+
+Run from the dbt project directory:
 
 ```sh
 embrasure init
@@ -40,15 +56,7 @@ embrasure doctor
 embrasure check --base origin/main
 ```
 
-Hand the exact reviewed working state to a durable cloud agent only when you choose:
-
-```bash
-embrasure cloud login
-embrasure check --base origin/main --cloud \
-  --context "Preserve one row per order. Refunds reduce net revenue. Missing discounts are zero."
-```
-
-`--cloud` requires business intent, prints every eligible path before upload, and reuses the immediately preceding local review only when the repository, dbt root, base SHA, working-tree snapshot, CLI version, and check configuration all match. Local `embrasure check` remains private and account-free.
+`init` reads the active dbt profile and asks only for missing values. Use `--config <path>` before or after any subcommand to choose another config file.
 
 Example result:
 
@@ -58,28 +66,39 @@ embrasure: PASS
 5 impacted · 2 validated · 3 not validated
 ```
 
-The default checks changed models plus every path to critical models: models tagged `critical`, marked critical in Embrasure, or directly used by a dbt exposure. Use `--downstream all` for every downstream model or `--downstream none` for changed models only. The complete impact is reported in every mode.
+The default validates changed models and every path to a critical model. Critical targets are tagged `critical`, configured with `critical: true`, or used directly by a dbt exposure. Use `--downstream all` for every downstream model or `--downstream none` for changed models only. Impact is always computed from the full changed set.
 
-## Use it with an agent or CI
+## Focus and preview
 
-JSON output is versioned and deterministic. Progress goes to stderr so stdout contains one JSON document.
+Intersect the changed set with one or more explicit models:
 
 ```sh
-embrasure check --base origin/main --json
-embrasure check --base origin/main --json --markdown embrasure-check.md
+embrasure check --select orders --select order_items
+embrasure check --select orders --downstream none
 ```
 
-For a faster first pass on large tables, add `--mode quick`. Deep mode remains the default and includes exact cardinality plus numeric percentiles. Primary-key integrity remains exact in both modes.
+An unknown, ambiguous, unchanged, or out-of-scope selection fails instead of returning a misleading pass.
 
-The intended agent loop is simple:
+Preview the plan without creating schemas or querying warehouse data:
 
-```text
-Run `embrasure check --base origin/main --json`.
-Exit 1: fix every finding and rerun.
-Exit 2: resolve or explain every coverage gap.
-Exit 3: fix the setup or execution failure.
-Do not request review until it exits 0.
+```sh
+embrasure check --dry-run
+embrasure check --dry-run --json
 ```
+
+Dry runs still resolve credentials and run local dbt parsing. `--dry-run` cannot be combined with `--cloud`.
+
+## Reports and exit codes
+
+JSON output is versioned and stably ordered. Progress goes to stderr, so stdout contains one JSON document.
+
+```sh
+embrasure check --json
+embrasure check --json --markdown embrasure-check.md
+embrasure check --json --report-version 1
+```
+
+Published contracts: [report v1](schemas/report-v1.schema.json) and [report v2](schemas/report-v2.schema.json).
 
 | Exit code | Meaning |
 |---:|---|
@@ -88,33 +107,115 @@ Do not request review until it exits 0.
 | `2` | A requested check could not be completed |
 | `3` | Setup, execution, or cleanup failed |
 
-## Advanced setup
+Agent loop:
 
-The guided setup creates the smallest configuration needed for one Snowflake account. For service credentials, multiple accounts, critical-model policies, primary keys, large-table filters, per-model thresholds, concurrency and time limits, non-dbt changes, cross-account dependencies, or Metabase, use the [example configuration](embrasure-check.example.yml) and [enterprise setup guide](docs/enterprise.md).
+```text
+Run `embrasure check --base origin/main --json`.
+Exit 1: fix every finding and rerun.
+Exit 2: resolve or explain every coverage gap.
+Exit 3: fix the setup or execution failure.
+Request review only after exit 0.
+```
 
-## Safety
+For a faster first pass on large tables, add `--mode quick`. Quick mode estimates cardinality and skips percentiles. Deep mode is the default. Primary-key integrity stays exact in both modes.
 
-Embrasure uses a dedicated warehouse, query tags, statement timeouts, and a configurable model limit. Every temporary schema has a unique name and ownership marker. The CLI checks both before dropping it and treats cleanup failures as execution failures.
+## GitHub Actions
 
-Use a Snowflake role that can read and clone production tables under test and create temporary schemas in each relevant database. Credentials are never written to reports or normal terminal output.
+The composite action installs the CLI. Keep the check in a visible `run` step so exit codes and secrets remain explicit.
 
-See [Security and data flow](docs/security-and-data-flow.md) for the exact network connections, local files, data returned from Snowflake, credential handling, cleanup behavior, and release-verification steps.
+```yaml
+jobs:
+  embrasure:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python -m pip install "dbt-core>=1.5,<2" "dbt-snowflake>=1.5,<2"
+      - uses: EmbrasureAI/embrasure-cli@v1
+      - run: embrasure check --base origin/main --json
+        env:
+          SNOWFLAKE_PROGRAMMATIC_ACCESS_TOKEN: ${{ secrets.SNOWFLAKE_PROGRAMMATIC_ACCESS_TOKEN }}
+```
 
-## Releases
+`fetch-depth: 0` is required because selection compares the working tree with the base revision.
 
-Intel and ARM downloads for macOS and Linux are available on the [releases page](https://github.com/EmbrasureAI/embrasure-cli/releases). Each release includes SHA-256 checksums, an SPDX software bill of materials, and GitHub-signed build-provenance attestations.
+## Cloud handoff
 
-If you previously installed `@embrasure/cli` with npm, uninstall it first with `npm uninstall -g @embrasure/cli` so the two executables do not conflict.
+Cloud handoff is optional. It sends the exact reviewed state and local evidence to a durable agent:
+
+```sh
+embrasure cloud login
+embrasure cloud whoami
+embrasure check --cloud \
+  --context "Preserve one row per order. Refunds reduce net revenue. Missing discounts are zero."
+embrasure cloud status
+```
+
+`--cloud` requires business intent and prints every eligible path before upload. A plain `check` primes the local review cache. The next `check --cloud` reuses it only when the repository, dbt root, base SHA, snapshot, CLI version, and check configuration match. Run `embrasure auth status` or `embrasure cloud whoami` to inspect session readiness without printing secrets.
+
+## Maintenance
+
+List managed temporary schemas older than six hours:
+
+```sh
+embrasure clean
+embrasure clean --older-than 24 --yes
+```
+
+`clean` searches only configured account databases and verifies the prefix and ownership marker before removal.
+
+Check for or install an update:
+
+```sh
+embrasure update --check
+embrasure update
+```
+
+Generate shell completion scripts:
+
+```sh
+embrasure completion bash
+embrasure completion zsh
+embrasure completion fish
+```
+
+## Troubleshooting
+
+### Generated schema is outside the run namespace
+
+Your `generate_schema_name` macro must preserve the complete target schema. Make custom schemas children of `target.schema`; do not replace it.
+
+### Incremental relation cannot be cloned
+
+Snowflake zero-copy `CREATE TABLE ... CLONE` supports tables, not every relation type. Use `--incremental-mode full-refresh` when a full rebuild is acceptable, or exclude the model from this validation path.
+
+### Incremental candidate seeding fails
+
+The validation role needs `SELECT` on the production source and `CREATE TABLE` in the target schema. Run `embrasure doctor`. If the relation should not use clone mode, rerun with `--incremental-mode full-refresh`.
+
+## Configuration and safety
+
+See the [example configuration](embrasure-check.example.yml) and [enterprise setup guide](docs/enterprise.md) for service credentials, multiple accounts, model policies, filters, thresholds, concurrency, external changes, cross-account dependencies, Metabase, and grants.
+
+Every temporary schema has a unique name and ownership marker. Embrasure checks both before removal and treats cleanup failures as execution failures. Use a dedicated role that can read and clone only the production tables under test and create temporary schemas in the required databases.
+
+[Security and data flow](docs/security-and-data-flow.md) documents network connections, local files, returned data, credentials, cleanup, updates, and release verification.
 
 ## Current limits
 
 - Snowflake is the only supported warehouse.
-- dbt model lineage and exposures are authoritative. dbt artifacts alone cannot provide authoritative warehouse-to-dashboard column lineage; the CLI states this as an informational limit.
-- Metabase matching covers native SQL cards that reference fully qualified production relations. Unsupported or inaccessible metadata is reported as a coverage gap.
+- dbt artifacts provide model lineage and exposures, not authoritative warehouse-to-dashboard column lineage.
+- Metabase matching covers native SQL cards that reference fully qualified production relations. Unsupported or inaccessible metadata becomes a coverage gap.
 
 ## Development
 
-Rust 1.85 or newer is required only when building from source.
+Rust 1.85 or newer is required when building from source.
 
 ```sh
 cargo fmt --check
@@ -122,6 +223,6 @@ cargo clippy --all-targets --all-features -- -D warnings
 cargo test --locked
 ```
 
-The opt-in Snowflake suite is gated by `EMBRASURE_RUN_SNOWFLAKE_TESTS=1` and the `EMBRASURE_TEST_SNOWFLAKE_*` account, user, role, database, warehouse, and token variables. It exercises two schemas, zero-copy incremental seeding, full refresh, duplicate detection, cleanup, and 100,000 synthetic rows.
+The opt-in Snowflake suite uses `EMBRASURE_RUN_SNOWFLAKE_TESTS=1` and the `EMBRASURE_TEST_SNOWFLAKE_*` account, user, role, database, warehouse, and token variables.
 
 Contributions are welcome under the [Apache 2.0 license](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,7 +1,5 @@
 # Security
 
-Please do not open a public issue for a vulnerability or possible credential exposure. Report it through GitHub's private vulnerability reporting for this repository.
+Report vulnerabilities or possible credential exposure through GitHub's private vulnerability reporting. Do not open a public issue.
 
-Embrasure reads production data. Use a dedicated least-privilege Snowflake role and warehouse. The role should be able to read only the production relations under test and create/drop schemas only in the configured CI database.
-
-See [Security and data flow](docs/security-and-data-flow.md) for runtime connections, local storage, data handling, cleanup guarantees, and release verification.
+See [Security and data flow](docs/security-and-data-flow.md) for permissions, network connections, local storage, data handling, cleanup, updates, and release verification.

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,21 @@
+name: Install Embrasure
+description: Install a verified Embrasure CLI release and add it to PATH.
+inputs:
+  version:
+    description: Release version, such as 0.4.0. Defaults to the latest release.
+    required: false
+    default: latest
+runs:
+  using: composite
+  steps:
+    - name: Install Embrasure
+      shell: bash
+      env:
+        EMBRASURE_VERSION_INPUT: ${{ inputs.version }}
+        EMBRASURE_INSTALL_DIR: ${{ runner.temp }}/embrasure/bin
+      run: |
+        if [[ "${EMBRASURE_VERSION_INPUT}" != "latest" ]]; then
+          export EMBRASURE_VERSION="${EMBRASURE_VERSION_INPUT}"
+        fi
+        "${GITHUB_ACTION_PATH}/install.sh"
+        echo "${EMBRASURE_INSTALL_DIR}" >> "${GITHUB_PATH}"

--- a/docs/enterprise.md
+++ b/docs/enterprise.md
@@ -1,74 +1,10 @@
 # Enterprise setup
 
-The clean enterprise split is:
-
-- Developers and local agents: `oauth_local`. Snowflake handles SSO/MFA in the browser; no password is given to the CLI.
-- CI service users: a role-restricted programmatic access token or RSA key pair stored in the CI secret manager.
-- Existing identity platform: an externally issued OAuth token supplied through an environment variable.
-
-Each Snowflake account gets its own `accounts` entry, dbt selector, user, role, warehouse, and credential. Run `embrasure doctor` after setup; it verifies each one independently.
-
-## Large projects
-
-Embrasure reports the complete downstream blast radius. By default, it validates changed models and every model on the path to a critical downstream target. A target is critical when it has a configured critical dbt tag, `critical: true` in Embrasure, or directly supports a dbt exposure.
-
-```yaml
-validation:
-  downstream: critical # none | critical | all
-  critical_tags: [critical, tier_1]
-  incremental_mode: clone
-```
-
-Override this for one run with `--downstream` and repeatable `--critical-tag`. Policy-excluded models remain in the report as not validated. If the requested models exceed `safety.max_models`, Embrasure exits `2` before it creates any Snowflake schema; it never truncates the selection.
-
-Independent Snowflake comparisons run concurrently, bounded by `comparison.concurrency`.
-
-Use quick mode for an inexpensive first pass:
-
-```sh
-embrasure check --base origin/main --mode quick
-```
-
-Quick mode estimates cardinality, ignores estimated cardinality changes below 2%, and skips numeric percentiles. Deep mode is the default and runs exact cardinality plus percentiles. Both modes still check schema, row counts, null rates, ranges, averages, dbt tests, downstream impact, and primary keys exactly.
-
-Set a total comparison budget and limit scans on large fact tables:
-
-```yaml
-comparison:
-  mode: deep
-  concurrency: 4
-  timeout_seconds: 900
-
-models:
-  model.analytics.orders:
-    primary_key: [order_id]
-    where: "order_date >= DATEADD(day, -30, CURRENT_DATE)"
-    thresholds:
-      row_count_relative: 0.05
-```
-
-Explicit `primary_key` takes precedence over a simple dbt `unique_key`. Identifier strings and lists are inferred; SQL expressions are not guessed. By default, duplicate and null keys fail only when CI introduces or worsens them. Set `key_policy: strict` on a model to require zero CI duplicate and null keys.
-
-The predicate is applied to both relations. Use a stable boundary so both sides cover the same data. Snowflake also enforces `safety.statement_timeout_seconds` on each statement.
-
-## Incremental models
-
-The default `clone` mode tests the next incremental run without copying production data:
-
-1. Clone the production table into a run-owned baseline schema.
-2. Clone that baseline into the exact dbt candidate relation.
-3. Run dbt incrementally against the candidate.
-4. Compare the result with the unchanged baseline.
-
-All required baseline and candidate clones are created before dbt starts. An unsupported relation or permission error stops the run; there is no automatic full refresh. The report marks this strategy as `incremental_clone` and notes that historical recomputation was not tested.
-
-Use `--incremental-mode full-refresh` to build each candidate from scratch. Embrasure still creates a stable baseline clone for comparison, so production changes during the run cannot move the reference point. A new incremental model gets a normal first build and a report entry that no production comparison exists.
-
-Table-level zero-copy clones preserve Snowflake micro-partitions and avoid cloning unrelated schema objects. Views, hybrid tables, external tables, and other objects that do not support `CREATE TABLE … CLONE` must be redesigned or excluded; Embrasure does not copy them with CTAS.
+Each Snowflake account gets its own `accounts` entry, dbt selector, user, role, warehouse, and credential. Run `embrasure doctor` after setup to verify each account independently.
 
 ## 1. Grant a narrow validation role
 
-Run equivalent grants in every Snowflake account. Replace the example object names with yours.
+Run equivalent grants in every Snowflake account. Replace the example object names.
 
 ```sql
 USE ROLE SECURITYADMIN;
@@ -85,15 +21,15 @@ GRANT SELECT ON ALL VIEWS IN SCHEMA ANALYTICS.PROD TO ROLE DBT_CHANGE_VALIDATOR;
 GRANT SELECT ON FUTURE VIEWS IN SCHEMA ANALYTICS.PROD TO ROLE DBT_CHANGE_VALIDATOR;
 ```
 
-`SELECT` on each source table plus ownership of the run-created target schema permits table cloning. `embrasure doctor` creates a temporary schema, zero-copy clones one visible production table, and removes the schema. Use `embrasure doctor --read-only` when this write test is not allowed.
+`SELECT` on a source table plus ownership of the run-created target schema permits table cloning. `embrasure doctor` creates a temporary schema, clones one visible production table, and removes the schema. Use `embrasure doctor --read-only` when this write test is not allowed.
 
-Grant this role to each person or service user that runs the CLI. The role owns only the temporary schemas it creates; the CLI refuses to remove schemas outside its configured prefix and ownership marker.
-
-If selected models live in more schemas or databases, add `USAGE`, `SELECT`, and `CREATE SCHEMA` grants for those databases too. Keep the warehouse resource monitor, size, and auto-suspend policy under normal Snowflake administration.
+Grant the role to each person or service user that runs the CLI. The role owns only its temporary schemas. If selected models live in other schemas or databases, add the corresponding `USAGE`, `SELECT`, and `CREATE SCHEMA` grants. Keep warehouse resource monitors, size, and auto-suspend under normal Snowflake administration.
 
 ## 2. Choose authentication
 
-### Human or local coding agent
+### Local browser login
+
+`oauth_local` is the default for people and local coding agents. Snowflake handles SSO and MFA in the browser; the CLI receives no password.
 
 ```yaml
 auth:
@@ -105,11 +41,13 @@ embrasure auth login --account primary
 embrasure doctor
 ```
 
-Snowflake's built-in `SNOWFLAKE$LOCAL_APPLICATION` integration uses Authorization Code + PKCE and a loopback callback. Account administrators can apply their normal network policies and tune the integration's token lifetime.
+Snowflake's built-in `SNOWFLAKE$LOCAL_APPLICATION` integration uses Authorization Code with PKCE and a loopback callback. Account administrators retain their network policies and token lifetime controls.
 
-### CI with a programmatic access token
+### CI credentials
 
-Create a service user, grant the validation role, and create a token restricted to that role:
+Use a role-restricted programmatic access token or a read-only mounted RSA key. Store secrets in the CI secret manager.
+
+Programmatic access token:
 
 ```sql
 USE ROLE USERADMIN;
@@ -125,17 +63,13 @@ ALTER USER DBT_CHANGE_VALIDATOR_CI
   DAYS_TO_EXPIRY = 90;
 ```
 
-The token secret appears only in that command's result. Put it directly in the CI secret manager, then configure:
-
 ```yaml
 auth:
   type: programmatic_access_token
   token_env: SNOWFLAKE_PROGRAMMATIC_ACCESS_TOKEN
 ```
 
-Rotate the token on your organization's normal schedule. Snowflake authentication and network policies still apply.
-
-### CI with an RSA key pair
+RSA key pair:
 
 ```yaml
 auth:
@@ -144,17 +78,7 @@ auth:
   passphrase_env: SNOWFLAKE_PRIVATE_KEY_PASSPHRASE
 ```
 
-Mount the private key read-only and keep its passphrase in the CI secret manager. Never commit either value.
-
-### Existing external OAuth
-
-```yaml
-auth:
-  type: oauth
-  token_env: SNOWFLAKE_OAUTH_TOKEN
-```
-
-The organization remains responsible for issuing and refreshing that token before each run.
+For an existing external OAuth flow, set `type: oauth` and `token_env`. The organization must issue and refresh that token before each run.
 
 ## 3. Configure multiple accounts
 
@@ -187,11 +111,11 @@ accounts:
       token_env: SNOWFLAKE_ACCOUNT_B_PAT
 ```
 
-`doctor` checks both accounts. A normal run creates and cleans run-owned CI and baseline schemas in each required account/database and reports declared cross-account dependencies.
+`doctor` checks both accounts. A check creates and cleans run-owned candidate and baseline schemas in each required account and database. Declared cross-account dependencies appear in the impact report.
 
 ## 4. Optional Metabase impact
 
-Create a read-only Metabase API key that can list cards and dashboards, then configure:
+Create a read-only Metabase API key that can list cards and dashboards:
 
 ```yaml
 metabase:
@@ -199,7 +123,7 @@ metabase:
   api_key_env: METABASE_API_KEY
 ```
 
-`doctor` proves the key can read card metadata. Validation matches native-SQL cards conservatively. Query-builder/MBQL lineage that cannot be proven is reported as incomplete coverage, never silently treated as safe.
+`doctor` proves the key can read card metadata. Validation matches native SQL cards conservatively. Query-builder or MBQL lineage that cannot be proven becomes a coverage gap.
 
 ## 5. CI gate
 
@@ -208,16 +132,72 @@ embrasure doctor --json
 embrasure check --base origin/main --json --markdown embrasure-check.md
 ```
 
-Treat exit `0` as ready for review, `1` as a data finding, `2` as missing evidence, and `3` as setup/execution failure.
+Exit `0` is ready for review, `1` is a finding, `2` is missing evidence, and `3` is a setup or execution failure.
 
-Report v2 is the default JSON contract and includes validation scope, skipped models, notices, duplicate/null-key metrics, build strategy, and dbt topology changes. Legacy consumers can request the unchanged v1 shape only with JSON output:
+Report v2 is the default JSON contract. It includes validation scope, skipped models, notices, duplicate and null-key metrics, build strategy, and dbt topology changes. Legacy consumers can request v1 with `--json --report-version 1`.
 
-```sh
-embrasure check --json --report-version 1
+## Reference
+
+### Large projects
+
+Embrasure computes impact from the full changed set. By default, it validates changed models and paths to critical downstream targets. A target is critical when it has a configured tag, `critical: true`, or directly supports a dbt exposure.
+
+```yaml
+validation:
+  downstream: critical # none | critical | all
+  critical_tags: [critical, tier_1]
+  incremental_mode: clone
 ```
 
-## Lineage boundary
+Override policy with `--downstream` and repeatable `--critical-tag`. Use repeatable `--select` to intersect the resulting validation set. Excluded models remain visible as not validated.
 
-Embrasure treats dbt model lineage, dbt exposures, declared cross-account edges, and optional Metabase SQL matches as the evidence available locally. It does not claim complete column-to-dashboard lineage from dbt artifacts.
+If selection exceeds `safety.max_models`, Embrasure exits `2` before dbt builds or comparisons. It does not truncate the set. Independent comparisons run concurrently up to `comparison.concurrency`.
 
-Authoritative warehouse-to-BI column lineage requires a separate provider using Snowflake access history and BI APIs. Enterprise limits include additional Snowflake permissions, metadata latency, dynamic SQL that cannot be resolved, separate BI credentials, and gaps for inaccessible assets.
+Quick mode is the inexpensive first pass:
+
+```sh
+embrasure check --mode quick
+```
+
+Quick mode estimates cardinality, ignores estimated changes below 2%, and skips percentiles. Deep mode uses exact cardinality and percentiles. Both check schema, row counts, null rates, ranges, averages, dbt tests, impact, and primary keys.
+
+Limit total time and scans on large fact tables:
+
+```yaml
+comparison:
+  mode: deep
+  concurrency: 4
+  timeout_seconds: 900
+
+models:
+  model.analytics.orders:
+    primary_key: [order_id]
+    where: "order_date >= DATEADD(day, -30, CURRENT_DATE)"
+    thresholds:
+      row_count_relative: 0.05
+```
+
+An explicit `primary_key` takes precedence over a simple dbt `unique_key`. Embrasure infers identifier strings and lists, not SQL expressions. The default regression policy fails when CI introduces or worsens duplicate and null keys. Set `key_policy: strict` to require zero CI duplicate and null keys.
+
+The filter applies to both relations. Use a stable boundary so both sides cover the same data. Snowflake enforces `safety.statement_timeout_seconds` on each statement.
+
+### Incremental models
+
+The default `clone` mode tests the next incremental run without copying production data:
+
+1. Clone the production table into a run-owned baseline schema.
+2. Clone the baseline into the dbt candidate relation.
+3. Run dbt incrementally against the candidate.
+4. Compare the result with the unchanged baseline.
+
+All baseline and candidate clones are created before dbt starts. Unsupported relations or permission failures stop the run. The report uses `incremental_clone` and notes that historical recomputation was not tested.
+
+Use `--incremental-mode full-refresh` to build candidates from scratch. Embrasure still creates a stable baseline clone, so production changes during the run cannot move the reference. A new incremental model receives a normal first build and a coverage gap because no production relation exists.
+
+Table-level zero-copy clones preserve Snowflake micro-partitions. Views, hybrid tables, external tables, and other objects that do not support `CREATE TABLE ... CLONE` must use another validation path.
+
+### Lineage boundary
+
+Local evidence includes dbt model lineage, dbt exposures, declared cross-account edges, and optional Metabase SQL matches. It does not prove warehouse-to-dashboard column lineage.
+
+Authoritative column lineage requires Snowflake access history and BI APIs. Its limits include extra Snowflake permissions, metadata latency, dynamic SQL, separate BI credentials, and inaccessible assets.

--- a/docs/security-and-data-flow.md
+++ b/docs/security-and-data-flow.md
@@ -53,7 +53,7 @@ Snowflake returns the comparison evidence used in the local report:
 - Snowflake types
 - Row counts, null rates, cardinality, min/max values, averages, and percentiles
 - Counts of primary-key values found on only one side, duplicate rows, and null-key rows
-- Optional deterministic primary-key and duplicate-key examples, up to `safety.primary_key_sample_limit`
+- Optional stably ordered primary-key and duplicate-key examples, up to `safety.primary_key_sample_limit`
 
 Set `primary_key_sample_limit: 0` when key values must not appear in process memory or JSON output. Reports are written to stdout unless `--markdown <path>` is provided.
 

--- a/docs/security-and-data-flow.md
+++ b/docs/security-and-data-flow.md
@@ -1,6 +1,6 @@
 # Security and data flow
 
-Embrasure runs on your machine or runner. It does not require an Embrasure account, hosted service, API key, or network connection to Embrasure.
+By default, Embrasure runs on your machine or runner. Local `embrasure check` does not require an Embrasure account, hosted service, API key, or network connection to Embrasure. Cloud handoff is a separate, explicit opt-in through `embrasure check --cloud`.
 
 ## Data flow
 
@@ -16,9 +16,21 @@ Local Git repository + local dbt + Embrasure CLI
                  Local terminal or report
 
 Optional: Embrasure reads metadata from your configured Metabase URL.
+
+Optional and explicit: `embrasure check --cloud` sends a bounded source snapshot and local review evidence to Embrasure Cloud. The CLI prints every included path and the total size before upload.
 ```
 
-Validation SQL runs in Snowflake. Embrasure does not upload warehouse data, dbt artifacts, reports, credentials, or usage information to Embrasure.
+Local validation SQL runs in Snowflake. Without `--cloud`, Embrasure does not upload warehouse data, dbt artifacts, reports, credentials, or usage information to Embrasure.
+
+With `--cloud`, the CLI sends only:
+
+- GitHub repository owner and name, dbt subdirectory, base reference, and commit hashes
+- Eligible changed dbt text files, their paths, statuses, and SHA-256 hashes
+- The local review report and selected lineage evidence
+- The business intent supplied through `--context` or `--context-file`
+- CLI version and operating-system name
+
+Cloud handoff never sends Snowflake credentials, Embrasure access or refresh tokens, `profiles.yml`, `.env*`, private keys, binaries, symlinks, `target`, `logs`, `dbt_packages`, or virtual environments. A local secret-pattern scan runs before upload, and the API repeats all path, size, encoding, hash, and secret checks.
 
 ## Outbound connections
 
@@ -26,8 +38,9 @@ The CLI itself makes only these connections:
 
 - `https://<account>.snowflakecomputing.com` for browser authentication and Snowflake SQL API requests.
 - The configured Metabase URL when the optional Metabase integration is enabled.
+- `https://app.embrasure.ai` and `https://api.embrasure.ai` only after `embrasure cloud login` or an explicit `embrasure check --cloud`. Development can override the API with `EMBRASURE_API_URL` and the browser origin with `EMBRASURE_WEB_URL`.
 
-There is no telemetry, update check, analytics SDK, or call to `embrasure.ai`. The local `dbt` process may connect to Snowflake or download packages according to the dbt project's own configuration. Installing a release may connect to GitHub or Homebrew; normal validation does not.
+There is no telemetry, update check, or analytics SDK. The local `dbt` process may connect to Snowflake or download packages according to the dbt project's own configuration. Installing a release may connect to GitHub or Homebrew; normal local validation does not contact Embrasure.
 
 ## Data returned to the local process
 
@@ -47,6 +60,8 @@ Set `primary_key_sample_limit: 0` when key values must not appear in process mem
 - Programmatic access tokens and external OAuth tokens are read from environment variables.
 - RSA private keys are read from the configured local path.
 - Browser OAuth sessions are cached under `~/.config/embrasure-check/oauth/` by default. Files and directories use owner-only permissions on Unix. Run `embrasure auth logout` to remove a cached session.
+- Embrasure Cloud access and refresh tokens use the OS credential store under the separate `ai.embrasure.cli.cloud` service. Run `embrasure cloud logout` to revoke and remove that session. They are never stored in the local handoff receipt.
+- The OS application cache stores the last local-review fingerprint and report so an unchanged review can be reused. The handoff receipt stores only run IDs, URLs, hashes, and timestamps. Neither file stores uploaded source content or credentials.
 - Temporary dbt profiles, manifests, target directories, and the detached base worktree live under an operating-system temporary directory and are removed after the process exits normally.
 
 Credentials are not included in normal terminal output, JSON reports, or Markdown reports.

--- a/docs/security-and-data-flow.md
+++ b/docs/security-and-data-flow.md
@@ -29,8 +29,9 @@ With `--cloud`, the CLI sends only:
 - The local review report and selected lineage evidence
 - The business intent supplied through `--context` or `--context-file`
 - CLI version and operating-system name
+- `notify_slack: true`, which asks the service to send its configured Slack notification
 
-Cloud handoff never sends Snowflake credentials, Embrasure access or refresh tokens, `profiles.yml`, `.env*`, private keys, binaries, symlinks, `target`, `logs`, `dbt_packages`, or virtual environments. A local secret-pattern scan runs before upload, and the API repeats all path, size, encoding, hash, and secret checks.
+Cloud handoff never sends Snowflake credentials, Embrasure access or refresh tokens, `profiles.yml`, `.env*`, private keys, binaries, symlinks, `target`, `logs`, `dbt_packages`, or virtual environments. Before upload, a nine-substring denylist rejects common credential patterns. The Cloud API contract also requires the server to repeat path, size, encoding, hash, and secret checks.
 
 ## Outbound connections
 
@@ -39,8 +40,10 @@ The CLI itself makes only these connections:
 - `https://<account>.snowflakecomputing.com` for browser authentication and Snowflake SQL API requests.
 - The configured Metabase URL when the optional Metabase integration is enabled.
 - `https://app.embrasure.ai` and `https://api.embrasure.ai` only after `embrasure cloud login` or an explicit `embrasure check --cloud`. Development can override the API with `EMBRASURE_API_URL` and the browser origin with `EMBRASURE_WEB_URL`.
+- `https://api.github.com/repos/EmbrasureAI/embrasure-cli/releases/latest` for `embrasure update --check`, `embrasure update`, and the gated doctor notice.
+- `https://github.com/EmbrasureAI/embrasure-cli/releases/download/...` when `embrasure update` downloads a release and its checksums.
 
-There is no telemetry, update check, or analytics SDK. The local `dbt` process may connect to Snowflake or download packages according to the dbt project's own configuration. Installing a release may connect to GitHub or Homebrew; normal local validation does not contact Embrasure.
+There is no telemetry or analytics SDK. `embrasure update` is opt-in. Human, interactive `embrasure doctor` output may check for a release at most once every 24 hours. The notice is disabled for JSON output, piped stderr, `CI`, or `NO_UPDATE_NOTIFIER`, and network failures are silent. The local `dbt` process may connect to Snowflake or download packages according to the dbt project's own configuration. Normal local validation does not contact Embrasure.
 
 ## Data returned to the local process
 
@@ -83,16 +86,16 @@ Incremental baselines use Snowflake table-level zero-copy clones. Embrasure neve
 
 Each run uses unique candidate and baseline schema names and writes an ownership marker to every schema. Cleanup requires both the exact run namespace and matching marker. The CLI refuses to drop a schema that fails either check.
 
-Cleanup is attempted after success, findings, execution failures, Ctrl-C, and normal termination signals. No process can clean up after `SIGKILL`, a machine crash, or power loss. Administrators should periodically remove stale schemas with the configured prefix after confirming their ownership markers.
+Cleanup is attempted after success, findings, execution failures, Ctrl-C, and normal termination signals. No process can clean up after `SIGKILL`, a machine crash, or power loss. `embrasure clean` lists old marked schemas by default and removes them only with `--yes`. It searches only each configured account database and verifies both the configured prefix and an Embrasure ownership marker before removal.
 
 ## Release integrity
 
-Releases include native archives for macOS and Linux on Intel and ARM, a `SHA256SUMS` file, and an SPDX JSON software bill of materials.
+Releases include native archives for macOS and Linux on Intel and ARM, a `SHA256SUMS` file, and one source-tree SPDX JSON software bill of materials bound to each archive by attestation.
 
 Verify an archive checksum:
 
 ```sh
-archive=embrasure-0.4.0-aarch64-apple-darwin.tar.gz
+archive=embrasure-<version>-aarch64-apple-darwin.tar.gz
 grep " ${archive}$" SHA256SUMS | shasum -a 256 --check
 ```
 

--- a/embrasure-check.example.yml
+++ b/embrasure-check.example.yml
@@ -3,6 +3,8 @@ version: 1
 dbt:
   project_dir: .
   profile: analytics
+  # Optional executable or wrapper. The default is dbt.
+  # command: dbt
   # Optional. Without this, a production manifest is generated from --base.
   # state_dir: target/production-artifacts
   threads: 4
@@ -15,7 +17,7 @@ safety:
   primary_key_sample_limit: 20
 
 comparison:
-  # quick estimates cardinality and skips percentiles; deep runs every metric.
+  # quick estimates cardinality and skips percentiles.
   mode: deep
   concurrency: 4
   timeout_seconds: 900

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+set -eu
+
+repository="EmbrasureAI/embrasure-cli"
+version="${EMBRASURE_VERSION:-}"
+if [ -z "$version" ]; then
+  version="$(curl -fsSL -H 'Accept: application/vnd.github+json' -H 'User-Agent: embrasure-installer' "https://api.github.com/repos/${repository}/releases/latest" | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"v\{0,1\}\([^"]*\)".*/\1/p' | head -n 1)"
+fi
+if [ -z "$version" ]; then
+  echo "embrasure: could not determine the latest release" >&2
+  exit 1
+fi
+version="${version#v}"
+
+case "$(uname -s):$(uname -m)" in
+  Darwin:x86_64) target="x86_64-apple-darwin" ;;
+  Darwin:arm64) target="aarch64-apple-darwin" ;;
+  Linux:x86_64) target="x86_64-unknown-linux-gnu" ;;
+  Linux:aarch64|Linux:arm64) target="aarch64-unknown-linux-gnu" ;;
+  *) echo "embrasure: unsupported platform $(uname -s)/$(uname -m)" >&2; exit 1 ;;
+esac
+
+archive="embrasure-${version}-${target}.tar.gz"
+base="https://github.com/${repository}/releases/download/v${version}"
+temporary="$(mktemp -d "${TMPDIR:-/tmp}/embrasure-install.XXXXXX")"
+trap 'rm -rf "$temporary"' EXIT HUP INT TERM
+curl -fsSL "${base}/${archive}" -o "${temporary}/${archive}"
+curl -fsSL "${base}/SHA256SUMS" -o "${temporary}/SHA256SUMS"
+expected="$(awk -v name="$archive" '$2 == name { print $1 }' "${temporary}/SHA256SUMS")"
+if [ -z "$expected" ]; then
+  echo "embrasure: release checksum is missing for ${archive}" >&2
+  exit 1
+fi
+if command -v shasum >/dev/null 2>&1; then
+  actual="$(shasum -a 256 "${temporary}/${archive}" | awk '{print $1}')"
+elif command -v sha256sum >/dev/null 2>&1; then
+  actual="$(sha256sum "${temporary}/${archive}" | awk '{print $1}')"
+else
+  echo "embrasure: shasum or sha256sum is required" >&2
+  exit 1
+fi
+if [ "$actual" != "$expected" ]; then
+  echo "embrasure: checksum verification failed for ${archive}" >&2
+  exit 1
+fi
+tar -xzf "${temporary}/${archive}" -C "$temporary"
+
+if [ -n "${EMBRASURE_INSTALL_DIR:-}" ]; then
+  install_dir="$EMBRASURE_INSTALL_DIR"
+elif [ -d /usr/local/bin ] && [ -w /usr/local/bin ]; then
+  install_dir="/usr/local/bin"
+else
+  install_dir="${HOME}/.local/bin"
+fi
+mkdir -p "$install_dir"
+install -m 755 "${temporary}/embrasure-${version}-${target}/embrasure" "${install_dir}/embrasure"
+echo "Installed Embrasure ${version} to ${install_dir}/embrasure"
+
+case ":${PATH}:" in
+  *":${install_dir}:"*) ;;
+  *) echo "Add ${install_dir} to PATH before running embrasure." >&2 ;;
+esac

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -7,19 +7,15 @@ use std::{
 };
 
 use anyhow::{Context, Result, bail};
-use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
-use rand::{Rng, distributions::Alphanumeric};
-use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use tokio::{
-    io::{AsyncReadExt, AsyncWriteExt},
-    net::{TcpListener, TcpStream},
-    time::timeout,
-};
+use tokio::net::TcpListener;
 use url::Url;
 
-use crate::config::{AccountConfig, AuthConfig, Config};
+use crate::{
+    config::{AccountConfig, AuthConfig, Config},
+    loopback, update,
+};
 
 const LOCAL_CLIENT_ID: &str = "LOCAL_APPLICATION";
 
@@ -227,9 +223,8 @@ async fn login(account: &AccountConfig) -> Result<String> {
     // Keep the path at `/` for compatibility with accounts whose integration
     // was provisioned before optional callback paths rolled out.
     let redirect_uri = format!("http://127.0.0.1:{port}");
-    let verifier = random_string(64);
-    let challenge = URL_SAFE_NO_PAD.encode(Sha256::digest(verifier.as_bytes()));
-    let state = random_string(32);
+    let (verifier, challenge) = loopback::pkce_pair();
+    let state = loopback::random_string(32);
     let scope = format!("refresh_token session:role:{}", account.role);
     let mut authorize = Url::parse(&format!(
         "https://{}/oauth/authorize",
@@ -249,12 +244,13 @@ async fn login(account: &AccountConfig) -> Result<String> {
     if webbrowser::open(authorize.as_str()).is_err() {
         eprintln!("Open this URL to sign in:\n{authorize}");
     }
-    let (mut stream, _) = timeout(Duration::from_secs(300), listener.accept())
-        .await
-        .context("Snowflake browser login timed out after 5 minutes")??;
-    let request = timeout(Duration::from_secs(10), read_http_request(&mut stream))
-        .await
-        .context("Snowflake OAuth callback did not finish sending its request")??;
+    let (mut stream, request) = loopback::accept(
+        &listener,
+        Duration::from_secs(300),
+        "Snowflake browser login timed out after 5 minutes",
+        "Snowflake OAuth callback did not finish sending its request",
+    )
+    .await?;
     let request = String::from_utf8_lossy(&request);
     let target = request
         .lines()
@@ -285,12 +281,7 @@ async fn login(account: &AccountConfig) -> Result<String> {
             "Snowflake sign-in failed. Return to the terminal for details.",
         )
     };
-    let body = format!("<html><body><h1>{message}</h1></body></html>");
-    let response = format!(
-        "HTTP/1.1 {status}\r\nContent-Type: text/html; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
-        body.len()
-    );
-    stream.write_all(response.as_bytes()).await?;
+    loopback::respond(&mut stream, status, message, "").await?;
     let code = outcome?;
     let token = token_request(
         account,
@@ -305,29 +296,6 @@ async fn login(account: &AccountConfig) -> Result<String> {
     .await?;
     save_cached(account, &token)?;
     Ok(token.access_token)
-}
-
-async fn read_http_request(stream: &mut TcpStream) -> Result<Vec<u8>> {
-    const MAX_REQUEST_BYTES: usize = 16 * 1024;
-    let mut request = Vec::new();
-    let mut buffer = [0_u8; 1024];
-    loop {
-        let length = stream.read(&mut buffer).await?;
-        if length == 0 {
-            break;
-        }
-        request.extend_from_slice(&buffer[..length]);
-        if request.len() > MAX_REQUEST_BYTES {
-            bail!("Snowflake OAuth callback exceeded {MAX_REQUEST_BYTES} bytes");
-        }
-        if request.windows(4).any(|window| window == b"\r\n\r\n") {
-            break;
-        }
-    }
-    if request.is_empty() {
-        bail!("Snowflake OAuth callback closed without a request");
-    }
-    Ok(request)
 }
 
 async fn load_or_refresh_local_token(account: &AccountConfig) -> Result<String> {
@@ -357,9 +325,7 @@ async fn load_or_refresh_local_token(account: &AccountConfig) -> Result<String> 
 }
 
 async fn token_request(account: &AccountConfig, form: &[(&str, &str)]) -> Result<TokenResponse> {
-    let response = Client::builder()
-        .timeout(Duration::from_secs(30))
-        .build()?
+    let response = update::http_client()?
         .post(format!(
             "https://{}/oauth/token-request",
             account_host(&account.account)
@@ -481,14 +447,6 @@ pub fn account_host(account: &str) -> String {
     )
 }
 
-fn random_string(length: usize) -> String {
-    rand::thread_rng()
-        .sample_iter(&Alphanumeric)
-        .take(length)
-        .map(char::from)
-        .collect()
-}
-
 fn now() -> Result<u64> {
     Ok(SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs())
 }
@@ -511,8 +469,7 @@ mod tests {
 
     #[test]
     fn pkce_values_are_url_safe_and_long_enough() {
-        let verifier = random_string(64);
-        let challenge = URL_SAFE_NO_PAD.encode(Sha256::digest(verifier.as_bytes()));
+        let (verifier, challenge) = loopback::pkce_pair();
         assert_eq!(verifier.len(), 64);
         assert!(challenge.len() >= 43);
         assert!(!challenge.contains('='));

--- a/src/clean.rs
+++ b/src/clean.rs
@@ -1,0 +1,175 @@
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use serde::Serialize;
+use uuid::Uuid;
+
+use crate::{
+    auth,
+    config::Config,
+    snowflake::{SnowflakeClient, quote_identifier},
+};
+
+const MARKER_PREFIX: &str = "Temporary schema managed by Embrasure; ";
+
+#[derive(Debug, Serialize)]
+pub struct CleanReport {
+    pub schema_version: u8,
+    pub older_than_hours: u64,
+    pub candidates: Vec<CleanedSchema>,
+    pub errors: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CleanedSchema {
+    pub account: String,
+    pub database: String,
+    pub schema: String,
+    pub created: String,
+    pub removed: bool,
+}
+
+pub async fn run(config_path: &Path, older_than_hours: u64, remove: bool) -> CleanReport {
+    let mut report = CleanReport {
+        schema_version: 1,
+        older_than_hours,
+        candidates: vec![],
+        errors: vec![],
+    };
+    if let Err(error) = run_inner(config_path, older_than_hours, remove, &mut report).await {
+        report.errors.push(format!("{error:#}"));
+    }
+    report
+}
+
+async fn run_inner(
+    config_path: &Path,
+    older_than_hours: u64,
+    remove: bool,
+    report: &mut CleanReport,
+) -> Result<()> {
+    let mut config = Config::load(config_path)?;
+    config.resolve_from(config_path)?;
+    let resolved = auth::resolve_all(&config).await?;
+    for account in &config.accounts {
+        let result = async {
+            let client = SnowflakeClient::new(
+                account,
+                resolved
+                    .get(&account.name)
+                    .context("resolved Snowflake credential was not retained")?,
+                format!("embrasure:clean:{}", Uuid::new_v4()),
+                config.safety.statement_timeout_seconds,
+            )?;
+            let prefix = config.safety.schema_prefix.to_ascii_uppercase();
+            let query = format!(
+                "SELECT SCHEMA_NAME, COMMENT, TO_VARCHAR(CREATED) FROM {}.INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME LIKE {} ESCAPE '\\\\' AND COMMENT LIKE 'Temporary schema managed by Embrasure;%' AND CREATED < DATEADD('hour', -{}, CURRENT_TIMESTAMP()) ORDER BY CREATED, SCHEMA_NAME",
+                quote_identifier(&account.database),
+                quote_string(&format!("{prefix}\\_%")),
+                older_than_hours,
+            );
+            let rows = client.execute(&query).await?;
+            for row in rows.rows {
+                let Some(schema) = row.first().and_then(Option::as_deref) else {
+                    continue;
+                };
+                let Some(comment) = row.get(1).and_then(Option::as_deref) else {
+                    continue;
+                };
+                let created = row
+                    .get(2)
+                    .and_then(Option::as_deref)
+                    .unwrap_or("unknown")
+                    .to_owned();
+                if !is_managed_prefix(schema, &prefix) || parse_ownership_marker(comment).is_none()
+                {
+                    continue;
+                }
+                if remove {
+                    client
+                        .drop_marked_schema(&account.database, schema, &prefix)
+                        .await?;
+                }
+                report.candidates.push(CleanedSchema {
+                    account: account.name.clone(),
+                    database: account.database.clone(),
+                    schema: schema.to_owned(),
+                    created,
+                    removed: remove,
+                });
+            }
+            Ok::<(), anyhow::Error>(())
+        }
+        .await;
+        if let Err(error) = result {
+            report
+                .errors
+                .push(format!("account {}: {error:#}", account.name));
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn parse_ownership_marker(comment: &str) -> Option<Uuid> {
+    let tag = comment.strip_prefix(MARKER_PREFIX)?;
+    let mut parts = tag.split(':');
+    if parts.next()? != "embrasure" || parts.next()?.is_empty() {
+        return None;
+    }
+    let run_id = parts.next()?;
+    if parts.next().is_some() {
+        return None;
+    }
+    Uuid::parse_str(run_id).ok()
+}
+
+pub(crate) fn is_managed_prefix(schema: &str, prefix: &str) -> bool {
+    schema
+        .to_ascii_uppercase()
+        .starts_with(&format!("{}_", prefix.to_ascii_uppercase()))
+}
+
+fn quote_string(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
+}
+
+impl CleanReport {
+    pub fn human(&self) -> String {
+        let mut output = String::new();
+        if self.candidates.is_empty() && self.errors.is_empty() {
+            output.push_str("No managed temporary schemas matched.\n");
+        }
+        for item in &self.candidates {
+            let action = if item.removed {
+                "removed"
+            } else {
+                "would remove"
+            };
+            output.push_str(&format!(
+                "{action} {}.{} ({}, account {})\n",
+                item.database, item.schema, item.created, item.account
+            ));
+        }
+        for error in &self.errors {
+            output.push_str(&format!("error: {error}\n"));
+        }
+        output
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ownership_markers_and_prefixes_are_strict() {
+        assert!(parse_ownership_marker(
+            "Temporary schema managed by Embrasure; embrasure:0.4.0:550e8400-e29b-41d4-a716-446655440000"
+        )
+        .is_some());
+        assert!(parse_ownership_marker("Temporary schema managed by Embrasure; other").is_none());
+        assert!(is_managed_prefix("EMBRASURE_CHECK_ABC", "EMBRASURE_CHECK"));
+        assert!(!is_managed_prefix("EMBRASURE_CHECK", "EMBRASURE_CHECK"));
+        assert!(!is_managed_prefix("PROD", "EMBRASURE_CHECK"));
+    }
+}

--- a/src/clean.rs
+++ b/src/clean.rs
@@ -63,9 +63,9 @@ async fn run_inner(
             )?;
             let prefix = config.safety.schema_prefix.to_ascii_uppercase();
             let query = format!(
-                "SELECT SCHEMA_NAME, COMMENT, TO_VARCHAR(CREATED) FROM {}.INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME LIKE {} ESCAPE '\\\\' AND COMMENT LIKE 'Temporary schema managed by Embrasure;%' AND CREATED < DATEADD('hour', -{}, CURRENT_TIMESTAMP()) ORDER BY CREATED, SCHEMA_NAME",
+                "SELECT SCHEMA_NAME, COMMENT, TO_VARCHAR(CREATED) FROM {}.INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME LIKE {} ESCAPE '!' AND COMMENT LIKE 'Temporary schema managed by Embrasure;%' AND CREATED < DATEADD('hour', -{}, CURRENT_TIMESTAMP()) ORDER BY CREATED, SCHEMA_NAME",
                 quote_identifier(&account.database),
-                quote_string(&format!("{prefix}\\_%")),
+                quote_string(&format!("{prefix}!_%")),
                 older_than_hours,
             );
             let rows = client.execute(&query).await?;

--- a/src/cloud.rs
+++ b/src/cloud.rs
@@ -326,7 +326,10 @@ pub fn cached_review(snapshot: &PreparedSnapshot) -> Result<Option<Report>> {
             return Err(error).with_context(|| format!("could not read {}", path.display()));
         }
     };
-    Ok((cache.fingerprint == snapshot.fingerprint).then_some(cache.report))
+    Ok(
+        (cache.fingerprint == snapshot.fingerprint && cache_is_fresh(&cache.saved_at))
+            .then_some(cache.report),
+    )
 }
 
 pub fn save_review(snapshot: &PreparedSnapshot, report: &Report) -> Result<()> {
@@ -702,6 +705,14 @@ fn write_private_json(path: &Path, value: &impl Serialize) -> Result<()> {
     Ok(())
 }
 
+fn cache_is_fresh(saved_at: &str) -> bool {
+    let Ok(saved_at) = DateTime::parse_from_rfc3339(saved_at) else {
+        return false;
+    };
+    let age = Utc::now().signed_duration_since(saved_at.with_timezone(&Utc));
+    age >= chrono::Duration::zero() && age <= chrono::Duration::hours(1)
+}
+
 fn git_path(cwd: &Path, args: &[&str]) -> Result<PathBuf> {
     Ok(PathBuf::from(git_text(cwd, args)?).canonicalize()?)
 }
@@ -1002,5 +1013,14 @@ mod tests {
             "Connect this GitHub dbt project."
         );
         assert_eq!(api_error("not-json"), "request failed");
+    }
+
+    #[test]
+    fn local_review_cache_is_only_reused_immediately() {
+        assert!(cache_is_fresh(&Utc::now().to_rfc3339()));
+        assert!(!cache_is_fresh(
+            &(Utc::now() - chrono::Duration::hours(2)).to_rfc3339()
+        ));
+        assert!(!cache_is_fresh("not-a-timestamp"));
     }
 }

--- a/src/cloud.rs
+++ b/src/cloud.rs
@@ -278,7 +278,7 @@ pub fn prepare_snapshot(
         manifest.update(file.sha256.as_bytes());
         manifest.update(b"\n");
     }
-    let snapshot_hash = format!("{:x}", manifest.finalize());
+    let snapshot_hash = encode_hex(&manifest.finalize());
     let config_bytes = fs::read(config_path).unwrap_or_default();
     let fingerprint = hex_digest(
         format!(
@@ -863,7 +863,17 @@ fn contains_secret(value: &str) -> bool {
 }
 
 fn hex_digest(bytes: &[u8]) -> String {
-    format!("{:x}", Sha256::digest(bytes))
+    encode_hex(&Sha256::digest(bytes))
+}
+
+fn encode_hex(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut encoded = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        encoded.push(HEX[(byte >> 4) as usize] as char);
+        encoded.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    encoded
 }
 
 fn random_string(length: usize) -> String {

--- a/src/cloud.rs
+++ b/src/cloud.rs
@@ -1,8 +1,7 @@
 use std::{
     env, fs,
-    io::{IsTerminal, Write},
+    io::Write,
     path::{Component, Path, PathBuf},
-    process::Command,
     sync::{
         Arc,
         atomic::{AtomicBool, Ordering},
@@ -12,23 +11,17 @@ use std::{
 };
 
 use anyhow::{Context, Result, bail};
-use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use chrono::{DateTime, Utc};
 use directories::ProjectDirs;
 use keyring::Entry;
-use rand::{Rng, distributions::Alphanumeric};
-use reqwest::{Client, StatusCode};
+use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
-use tokio::{
-    io::{AsyncReadExt, AsyncWriteExt},
-    net::{TcpListener, TcpStream},
-    time::timeout,
-};
+use tokio::net::TcpListener;
 use url::Url;
 
-use crate::{config::Config, report::Report, run::CheckOptions};
+use crate::{config::Config, git, loopback, report::Report, run::CheckOptions, style, update};
 
 const KEYCHAIN_SERVICE: &str = "ai.embrasure.cli.cloud";
 const KEYCHAIN_ACCOUNT: &str = "session";
@@ -41,8 +34,6 @@ pub struct CloudSession {
     access_token: String,
     refresh_token: String,
     expires_at: String,
-    refresh_expires_at: String,
-    session_id: String,
     pub workspace_id: String,
     api_base_url: String,
 }
@@ -52,8 +43,6 @@ struct TokenResponse {
     access_token: String,
     refresh_token: String,
     expires_at: String,
-    refresh_expires_at: String,
-    session_id: String,
     workspace_id: String,
 }
 
@@ -112,7 +101,7 @@ pub struct Progress {
 
 impl Progress {
     pub fn start(label: &str) -> Self {
-        if !animation_enabled() {
+        if !style::animation_enabled() {
             eprintln!("{label}...");
             return Self {
                 stop: Arc::new(AtomicBool::new(true)),
@@ -150,10 +139,6 @@ impl Drop for Progress {
     }
 }
 
-pub fn animation_enabled() -> bool {
-    std::io::stderr().is_terminal() && env::var_os("NO_COLOR").is_none()
-}
-
 pub fn normalize_context(values: &[String], file: Option<&Path>) -> Result<String> {
     let mut parts = values
         .iter()
@@ -183,6 +168,7 @@ pub fn normalize_context(values: &[String], file: Option<&Path>) -> Result<Strin
 
 pub fn prepare_snapshot(
     config_path: &Path,
+    config: &Config,
     base_ref: &str,
     options: &CheckOptions,
 ) -> Result<PreparedSnapshot> {
@@ -190,8 +176,6 @@ pub fn prepare_snapshot(
         config_path.parent().unwrap_or_else(|| Path::new(".")),
         &["rev-parse", "--show-toplevel"],
     )?;
-    let mut config = Config::load(config_path)?;
-    config.resolve_from(config_path)?;
     let dbt_dir = config.dbt.project_dir.canonicalize().with_context(|| {
         format!(
             "could not resolve dbt project directory {}",
@@ -205,9 +189,9 @@ pub fn prepare_snapshot(
         .replace('\\', "/")
         .trim_matches('/')
         .to_owned();
-    let base_sha = git_text(&repository_root, &["rev-parse", "--verify", base_ref])?;
-    let head_sha = git_text(&repository_root, &["rev-parse", "--verify", "HEAD"]).ok();
-    let remote = git_text(&repository_root, &["remote", "get-url", "origin"])?;
+    let base_sha = git::text(&repository_root, &["rev-parse", "--verify", base_ref])?;
+    let head_sha = git::text(&repository_root, &["rev-parse", "--verify", "HEAD"]).ok();
+    let remote = git::text(&repository_root, &["remote", "get-url", "origin"])?;
     let (owner, name) = parse_github_remote(&remote)?;
     let mut candidates = changed_paths(&repository_root, base_ref)?;
     candidates.sort_by(|a, b| a.0.cmp(&b.0));
@@ -350,7 +334,23 @@ pub async fn handoff(
     intent: &str,
 ) -> Result<HandoffReceipt> {
     let mut session = valid_session().await?;
-    let payload = json!({
+    let payload = handoff_payload(snapshot, report, base_ref, intent);
+    let mut response = send_handoff(&session, &payload).await?;
+    if response.status() == StatusCode::UNAUTHORIZED {
+        session = refresh_session(&session).await?;
+        save_session(&session)?;
+        response = send_handoff(&session, &payload).await?;
+    }
+    parse_handoff(response, snapshot).await
+}
+
+fn handoff_payload(
+    snapshot: &PreparedSnapshot,
+    report: &Report,
+    base_ref: &str,
+    intent: &str,
+) -> Value {
+    json!({
         "idempotency_key": format!("cli:{}", snapshot.fingerprint),
         "repository": {
             "provider": "github",
@@ -367,8 +367,11 @@ pub async fn handoff(
         "local_review": report,
         "cli": {"version": env!("CARGO_PKG_VERSION"), "platform": env::consts::OS},
         "notify_slack": true,
-    });
-    let response = Client::new()
+    })
+}
+
+async fn send_handoff(session: &CloudSession, payload: &Value) -> Result<reqwest::Response> {
+    update::http_client()?
         .post(format!(
             "{}/v1/agent/cloud-handoffs",
             session.api_base_url.trim_end_matches('/')
@@ -377,42 +380,7 @@ pub async fn handoff(
         .json(&payload)
         .send()
         .await
-        .context("could not reach Embrasure Cloud")?;
-    if response.status() == StatusCode::UNAUTHORIZED {
-        session = refresh_session(&session).await?;
-        save_session(&session)?;
-        return handoff_once(snapshot, report, base_ref, intent, &session).await;
-    }
-    parse_handoff(response, snapshot).await
-}
-
-async fn handoff_once(
-    snapshot: &PreparedSnapshot,
-    report: &Report,
-    base_ref: &str,
-    intent: &str,
-    session: &CloudSession,
-) -> Result<HandoffReceipt> {
-    let payload = json!({
-        "idempotency_key": format!("cli:{}", snapshot.fingerprint),
-        "repository": {"provider":"github","owner":snapshot.owner,"name":snapshot.name,"dbt_root":snapshot.dbt_root,"base_ref":base_ref,"base_sha":snapshot.base_sha,"head_sha":snapshot.head_sha},
-        "snapshot_hash": snapshot.snapshot_hash,
-        "intent_context": intent,
-        "changed_files": snapshot.files,
-        "local_review": report,
-        "cli": {"version": env!("CARGO_PKG_VERSION"), "platform": env::consts::OS},
-        "notify_slack": true,
-    });
-    let response = Client::new()
-        .post(format!(
-            "{}/v1/agent/cloud-handoffs",
-            session.api_base_url.trim_end_matches('/')
-        ))
-        .bearer_auth(&session.access_token)
-        .json(&payload)
-        .send()
-        .await?;
-    parse_handoff(response, snapshot).await
+        .context("could not reach Embrasure Cloud")
 }
 
 async fn parse_handoff(
@@ -449,9 +417,8 @@ pub async fn login() -> Result<CloudSession> {
         .context("could not start the cloud login callback")?;
     let port = listener.local_addr()?.port();
     let return_url = format!("http://127.0.0.1:{port}/callback");
-    let state = random_string(32);
-    let verifier = random_string(64);
-    let challenge = URL_SAFE_NO_PAD.encode(Sha256::digest(verifier.as_bytes()));
+    let state = loopback::random_string(32);
+    let (verifier, challenge) = loopback::pkce_pair();
     let mut url = Url::parse(&format!(
         "{}/cli-auth/complete",
         web_base_url.trim_end_matches('/')
@@ -462,7 +429,10 @@ pub async fn login() -> Result<CloudSession> {
         .append_pair("return_url", &return_url)
         .append_pair("code_challenge", &challenge)
         .append_pair("code_challenge_method", "S256")
-        .append_pair("device_id", &format!("rust-cli-{}", random_string(24)))
+        .append_pair(
+            "device_id",
+            &format!("rust-cli-{}", loopback::random_string(24)),
+        )
         .append_pair("device_name", "Embrasure CLI")
         .append_pair("platform", env::consts::OS)
         .append_pair("client", "cli")
@@ -472,12 +442,13 @@ pub async fn login() -> Result<CloudSession> {
         url.as_str()
     );
     let _ = webbrowser::open(url.as_str());
-    let (mut stream, _) = timeout(Duration::from_secs(180), listener.accept())
-        .await
-        .context("cloud login timed out after 3 minutes")??;
-    let request = timeout(Duration::from_secs(10), read_http_request(&mut stream))
-        .await
-        .context("cloud login callback timed out")??;
+    let (mut stream, request) = loopback::accept(
+        &listener,
+        Duration::from_secs(180),
+        "cloud login timed out after 3 minutes",
+        "cloud login callback timed out",
+    )
+    .await?;
     let request = String::from_utf8_lossy(&request);
     let target = request
         .lines()
@@ -496,21 +467,23 @@ pub async fn login() -> Result<CloudSession> {
         .map(|(_, value)| value.into_owned())
         .unwrap_or_default();
     if callback.path() != "/callback" || callback_state != state || code.is_empty() {
-        write_http_response(
+        loopback::respond(
             &mut stream,
+            "400 Bad Request",
             "Cloud sign-in failed",
             "Return to the terminal and try again.",
         )
         .await?;
         bail!("cloud login returned an invalid callback");
     }
-    write_http_response(
+    loopback::respond(
         &mut stream,
+        "200 OK",
         "Embrasure Cloud is connected",
         "You can close this tab and return to your terminal.",
     )
     .await?;
-    let response = Client::new()
+    let response = update::http_client()?
         .post(format!("{}/v1/auth/session/token", api_base_url.trim_end_matches('/')))
         .json(&json!({"grant_type":"authorization_code","code":code,"code_verifier":verifier,"redirect_uri":return_url}))
         .send().await.context("could not exchange the cloud authorization code")?;
@@ -525,8 +498,6 @@ pub async fn login() -> Result<CloudSession> {
         access_token: token.access_token,
         refresh_token: token.refresh_token,
         expires_at: token.expires_at,
-        refresh_expires_at: token.refresh_expires_at,
-        session_id: token.session_id,
         workspace_id: token.workspace_id,
         api_base_url,
     };
@@ -555,22 +526,38 @@ pub async fn status(run_id: Option<&str>) -> Result<Value> {
 
 pub async fn logout() -> Result<()> {
     if let Ok(session) = load_session() {
-        let _ = Client::new()
-            .post(format!(
-                "{}/v1/auth/session/revoke",
-                session.api_base_url.trim_end_matches('/')
-            ))
-            .json(&json!({"refresh_token": session.refresh_token}))
-            .send()
-            .await;
+        if let Ok(client) = update::http_client() {
+            let _ = client
+                .post(format!(
+                    "{}/v1/auth/session/revoke",
+                    session.api_base_url.trim_end_matches('/')
+                ))
+                .json(&json!({"refresh_token": session.refresh_token}))
+                .send()
+                .await;
+        }
     }
     match keychain()?.delete_credential() {
         Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
-        Err(error) => Err(error).context("could not remove the Embrasure Cloud keychain session"),
+        Err(error) => Err(keyring_error(
+            error,
+            "could not remove the Embrasure Cloud keychain session",
+        )),
     }
 }
 
 async fn valid_session() -> Result<CloudSession> {
+    if let Ok(access_token) = env::var("EMBRASURE_CLOUD_TOKEN")
+        && !access_token.trim().is_empty()
+    {
+        return Ok(CloudSession {
+            access_token,
+            refresh_token: String::new(),
+            expires_at: "9999-12-31T23:59:59Z".into(),
+            workspace_id: env::var("EMBRASURE_CLOUD_WORKSPACE_ID").unwrap_or_default(),
+            api_base_url: api_base_url(),
+        });
+    }
     let session =
         load_session().context("not signed in to Embrasure Cloud; run `embrasure cloud login`")?;
     let expires = DateTime::parse_from_rfc3339(&session.expires_at)?.with_timezone(&Utc);
@@ -583,7 +570,7 @@ async fn valid_session() -> Result<CloudSession> {
 }
 
 async fn refresh_session(session: &CloudSession) -> Result<CloudSession> {
-    let response = Client::new()
+    let response = update::http_client()?
         .post(format!(
             "{}/v1/auth/session/refresh",
             session.api_base_url.trim_end_matches('/')
@@ -604,15 +591,13 @@ async fn refresh_session(session: &CloudSession) -> Result<CloudSession> {
         access_token: token.access_token,
         refresh_token: token.refresh_token,
         expires_at: token.expires_at,
-        refresh_expires_at: token.refresh_expires_at,
-        session_id: token.session_id,
         workspace_id: token.workspace_id,
         api_base_url: session.api_base_url.clone(),
     })
 }
 
 async fn api_get(session: &CloudSession, path: &str, query: &[(&str, &str)]) -> Result<Value> {
-    let response = Client::new()
+    let response = update::http_client()?
         .get(format!(
             "{}{}",
             session.api_base_url.trim_end_matches('/'),
@@ -635,20 +620,34 @@ async fn api_get(session: &CloudSession, path: &str, query: &[(&str, &str)]) -> 
 
 fn keychain() -> Result<Entry> {
     Entry::new(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT)
-        .context("could not open the Embrasure Cloud keychain entry")
+        .map_err(|error| keyring_error(error, "could not open the Embrasure Cloud keychain entry"))
 }
 
 fn save_session(session: &CloudSession) -> Result<()> {
     keychain()?
         .set_password(&serde_json::to_string(session)?)
-        .context("could not save the Embrasure Cloud session in the OS keychain")
+        .map_err(|error| {
+            keyring_error(
+                error,
+                "could not save the Embrasure Cloud session in the OS keychain",
+            )
+        })
 }
 
 fn load_session() -> Result<CloudSession> {
     let value = keychain()?
         .get_password()
-        .context("no Embrasure Cloud session is stored")?;
+        .map_err(|error| keyring_error(error, "no Embrasure Cloud session is stored"))?;
     serde_json::from_str(&value).context("the Embrasure Cloud keychain session is invalid")
+}
+
+fn keyring_error(error: keyring::Error, context: &str) -> anyhow::Error {
+    match error {
+        keyring::Error::PlatformFailure(_) | keyring::Error::NoStorageAccess(_) => anyhow::anyhow!(
+            "{context}: secure storage is unavailable; on headless Linux, start and unlock Secret Service or set EMBRASURE_CLOUD_TOKEN and optional EMBRASURE_CLOUD_WORKSPACE_ID"
+        ),
+        other => anyhow::Error::new(other).context(context.to_owned()),
+    }
 }
 
 fn api_base_url() -> String {
@@ -714,30 +713,13 @@ fn cache_is_fresh(saved_at: &str) -> bool {
 }
 
 fn git_path(cwd: &Path, args: &[&str]) -> Result<PathBuf> {
-    Ok(PathBuf::from(git_text(cwd, args)?).canonicalize()?)
-}
-
-fn git_text(cwd: &Path, args: &[&str]) -> Result<String> {
-    let output = Command::new("git")
-        .current_dir(cwd)
-        .args(args)
-        .output()
-        .with_context(|| format!("could not run git {}", args.join(" ")))?;
-    if !output.status.success() {
-        bail!(
-            "git {} failed: {}",
-            args.join(" "),
-            String::from_utf8_lossy(&output.stderr).trim()
-        );
-    }
-    Ok(String::from_utf8(output.stdout)?.trim().to_owned())
+    Ok(PathBuf::from(git::text(cwd, args)?).canonicalize()?)
 }
 
 fn changed_paths(root: &Path, base: &str) -> Result<Vec<(String, String)>> {
-    let output = Command::new("git")
-        .current_dir(root)
-        .args(["diff", "--name-status", "-z", base, "--"])
-        .output()?;
+    // Cloud snapshots intentionally follow tracked Git diff output only.
+    // Follow-up: decide whether cloud handoffs should include untracked files.
+    let output = git::output(root, &["diff", "--name-status", "-z", base, "--"])?;
     if !output.status.success() {
         bail!(
             "could not inspect working-tree changes: {}",
@@ -775,20 +757,6 @@ fn changed_paths(root: &Path, base: &str) -> Result<Vec<(String, String)>> {
         } else {
             2
         };
-    }
-    let untracked = Command::new("git")
-        .current_dir(root)
-        .args(["ls-files", "--others", "--exclude-standard", "-z"])
-        .output()?;
-    if !untracked.status.success() {
-        bail!("could not inspect untracked files");
-    }
-    for path in untracked
-        .stdout
-        .split(|byte| *byte == 0)
-        .filter(|part| !part.is_empty())
-    {
-        rows.push((String::from_utf8(path.to_vec())?, "added".into()));
     }
     Ok(rows)
 }
@@ -887,14 +855,6 @@ fn encode_hex(bytes: &[u8]) -> String {
     encoded
 }
 
-fn random_string(length: usize) -> String {
-    rand::thread_rng()
-        .sample_iter(&Alphanumeric)
-        .take(length)
-        .map(char::from)
-        .collect()
-}
-
 fn api_error(body: &str) -> String {
     let value: Value = serde_json::from_str(body).unwrap_or(Value::Null);
     value
@@ -904,35 +864,6 @@ fn api_error(body: &str) -> String {
         .and_then(Value::as_str)
         .unwrap_or("request failed")
         .to_owned()
-}
-
-async fn read_http_request(stream: &mut TcpStream) -> Result<Vec<u8>> {
-    let mut buffer = Vec::new();
-    let mut chunk = [0_u8; 2048];
-    while buffer.len() < 16 * 1024 {
-        let read = stream.read(&mut chunk).await?;
-        if read == 0 {
-            break;
-        }
-        buffer.extend_from_slice(&chunk[..read]);
-        if buffer.windows(4).any(|window| window == b"\r\n\r\n") {
-            break;
-        }
-    }
-    Ok(buffer)
-}
-
-async fn write_http_response(stream: &mut TcpStream, title: &str, message: &str) -> Result<()> {
-    let body = format!(
-        "<!doctype html><meta charset=utf-8><title>{title}</title><main><h1>{title}</h1><p>{message}</p></main>"
-    );
-    let response = format!(
-        "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-        body.len(),
-        body
-    );
-    stream.write_all(response.as_bytes()).await?;
-    Ok(())
 }
 
 #[cfg(test)]
@@ -980,7 +911,7 @@ mod tests {
     }
 
     #[test]
-    fn exclusions_and_animation_rules_are_deterministic() {
+    fn snapshot_exclusions_and_animation_rules_are_stable() {
         assert!(!eligible("profiles.yml"));
         assert!(!eligible("config/profiles.yml"));
         assert!(!eligible("config/credentials.json"));

--- a/src/cloud.rs
+++ b/src/cloud.rs
@@ -1,0 +1,996 @@
+use std::{
+    env, fs,
+    io::{IsTerminal, Write},
+    path::{Component, Path, PathBuf},
+    process::Command,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    thread,
+    time::Duration,
+};
+
+use anyhow::{Context, Result, bail};
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use chrono::{DateTime, Utc};
+use directories::ProjectDirs;
+use keyring::Entry;
+use rand::{Rng, distributions::Alphanumeric};
+use reqwest::{Client, StatusCode};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::{TcpListener, TcpStream},
+    time::timeout,
+};
+use url::Url;
+
+use crate::{config::Config, report::Report, run::CheckOptions};
+
+const KEYCHAIN_SERVICE: &str = "ai.embrasure.cli.cloud";
+const KEYCHAIN_ACCOUNT: &str = "session";
+const MAX_FILES: usize = 100;
+const MAX_FILE_BYTES: usize = 256 * 1024;
+const MAX_TOTAL_BYTES: usize = 2 * 1024 * 1024;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CloudSession {
+    access_token: String,
+    refresh_token: String,
+    expires_at: String,
+    refresh_expires_at: String,
+    session_id: String,
+    pub workspace_id: String,
+    api_base_url: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct TokenResponse {
+    access_token: String,
+    refresh_token: String,
+    expires_at: String,
+    refresh_expires_at: String,
+    session_id: String,
+    workspace_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HandoffReceipt {
+    pub handoff_id: String,
+    pub run_id: String,
+    pub run_url: String,
+    pub snapshot_hash: String,
+    pub base_sha: String,
+    pub accepted_at: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct ChangedFile {
+    path: String,
+    status: String,
+    sha256: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    content_utf8: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PreparedSnapshot {
+    dbt_root: String,
+    owner: String,
+    name: String,
+    base_sha: String,
+    head_sha: Option<String>,
+    snapshot_hash: String,
+    fingerprint: String,
+    files: Vec<ChangedFile>,
+    total_bytes: usize,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct ReviewCache {
+    fingerprint: String,
+    report: Report,
+    saved_at: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct HandoffResponse {
+    handoff_id: String,
+    run_id: String,
+    run_url: String,
+    accepted_at: String,
+    snapshot_hash: String,
+}
+
+pub struct Progress {
+    stop: Arc<AtomicBool>,
+    worker: Option<thread::JoinHandle<()>>,
+}
+
+impl Progress {
+    pub fn start(label: &str) -> Self {
+        if !animation_enabled() {
+            eprintln!("{label}...");
+            return Self {
+                stop: Arc::new(AtomicBool::new(true)),
+                worker: None,
+            };
+        }
+        let stop = Arc::new(AtomicBool::new(false));
+        let worker_stop = Arc::clone(&stop);
+        let label = label.to_owned();
+        let worker = thread::spawn(move || {
+            let frames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+            let mut index = 0;
+            while !worker_stop.load(Ordering::Relaxed) {
+                eprint!("\r{} {}", frames[index % frames.len()], label);
+                let _ = std::io::stderr().flush();
+                index += 1;
+                thread::sleep(Duration::from_millis(80));
+            }
+            eprint!("\r\x1b[2K");
+            let _ = std::io::stderr().flush();
+        });
+        Self {
+            stop,
+            worker: Some(worker),
+        }
+    }
+}
+
+impl Drop for Progress {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        if let Some(worker) = self.worker.take() {
+            let _ = worker.join();
+        }
+    }
+}
+
+pub fn animation_enabled() -> bool {
+    std::io::stderr().is_terminal() && env::var_os("NO_COLOR").is_none()
+}
+
+pub fn normalize_context(values: &[String], file: Option<&Path>) -> Result<String> {
+    let mut parts = values
+        .iter()
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+        .collect::<Vec<_>>();
+    if let Some(path) = file {
+        let value = fs::read_to_string(path)
+            .with_context(|| format!("could not read context file {}", path.display()))?;
+        if !value.trim().is_empty() {
+            parts.push(value.trim().to_owned());
+        }
+    }
+    if parts.is_empty() {
+        bail!("--cloud requires --context <business intent> or --context-file <path>");
+    }
+    let intent = parts.join("\n\n");
+    if intent.len() > 20_000 {
+        bail!("cloud validation context exceeds 20,000 characters");
+    }
+    if contains_secret(&intent) {
+        bail!("cloud validation context appears to contain a secret; remove credentials and retry");
+    }
+    Ok(intent)
+}
+
+pub fn prepare_snapshot(
+    config_path: &Path,
+    base_ref: &str,
+    options: &CheckOptions,
+) -> Result<PreparedSnapshot> {
+    let repository_root = git_path(
+        config_path.parent().unwrap_or_else(|| Path::new(".")),
+        &["rev-parse", "--show-toplevel"],
+    )?;
+    let mut config = Config::load(config_path)?;
+    config.resolve_from(config_path)?;
+    let dbt_dir = config.dbt.project_dir.canonicalize().with_context(|| {
+        format!(
+            "could not resolve dbt project directory {}",
+            config.dbt.project_dir.display()
+        )
+    })?;
+    let dbt_root = dbt_dir
+        .strip_prefix(&repository_root)
+        .context("the dbt project must be inside the Git repository")?
+        .to_string_lossy()
+        .replace('\\', "/")
+        .trim_matches('/')
+        .to_owned();
+    let base_sha = git_text(&repository_root, &["rev-parse", "--verify", base_ref])?;
+    let head_sha = git_text(&repository_root, &["rev-parse", "--verify", "HEAD"]).ok();
+    let remote = git_text(&repository_root, &["remote", "get-url", "origin"])?;
+    let (owner, name) = parse_github_remote(&remote)?;
+    let mut candidates = changed_paths(&repository_root, base_ref)?;
+    candidates.sort_by(|a, b| a.0.cmp(&b.0));
+    candidates.dedup_by(|a, b| a.0 == b.0);
+
+    let mut files = Vec::new();
+    let mut total_bytes = 0;
+    for (repo_path, status) in candidates {
+        let relative = Path::new(&repo_path);
+        let project_path = if dbt_root.is_empty() {
+            relative
+        } else if let Ok(path) = relative.strip_prefix(&dbt_root) {
+            path
+        } else {
+            continue;
+        };
+        let normalized = normalize_snapshot_path(project_path)?;
+        if !eligible(&normalized) {
+            continue;
+        }
+        let absolute = repository_root.join(relative);
+        let (content_utf8, sha256) = if status == "deleted" {
+            (None, hex_digest(&[]))
+        } else {
+            let metadata = fs::symlink_metadata(&absolute)
+                .with_context(|| format!("could not inspect snapshot file {repo_path}"))?;
+            if metadata.file_type().is_symlink() {
+                bail!("snapshot file is a symlink and cannot be uploaded: {repo_path}");
+            }
+            if !metadata.is_file() {
+                continue;
+            }
+            let bytes = fs::read(&absolute)
+                .with_context(|| format!("could not read snapshot file {repo_path}"))?;
+            if bytes.len() > MAX_FILE_BYTES {
+                bail!("snapshot file exceeds 256 KB: {repo_path}");
+            }
+            total_bytes += bytes.len();
+            if total_bytes > MAX_TOTAL_BYTES {
+                bail!("snapshot exceeds the 2 MB upload limit");
+            }
+            let content = String::from_utf8(bytes.clone())
+                .with_context(|| format!("snapshot file is not UTF-8 text: {repo_path}"))?;
+            if contains_secret(&content) {
+                bail!("possible secret found in snapshot file: {repo_path}");
+            }
+            (Some(content), hex_digest(&bytes))
+        };
+        files.push(ChangedFile {
+            path: normalized,
+            status,
+            sha256,
+            content_utf8,
+        });
+    }
+    if files.is_empty() {
+        bail!("no eligible dbt working-tree changes were found for cloud handoff");
+    }
+    if files.len() > MAX_FILES {
+        bail!("snapshot contains more than 100 eligible files");
+    }
+    let mut manifest = Sha256::new();
+    for file in &files {
+        manifest.update(file.path.as_bytes());
+        manifest.update([0]);
+        manifest.update(file.status.as_bytes());
+        manifest.update([0]);
+        manifest.update(file.sha256.as_bytes());
+        manifest.update(b"\n");
+    }
+    let snapshot_hash = format!("{:x}", manifest.finalize());
+    let config_bytes = fs::read(config_path).unwrap_or_default();
+    let fingerprint = hex_digest(
+        format!(
+            "{}\0{}\0{}\0{}\0{}\0{}\0{:?}",
+            repository_root.display(),
+            dbt_root,
+            base_sha,
+            snapshot_hash,
+            env!("CARGO_PKG_VERSION"),
+            hex_digest(&config_bytes),
+            options,
+        )
+        .as_bytes(),
+    );
+    Ok(PreparedSnapshot {
+        dbt_root,
+        owner,
+        name,
+        base_sha,
+        head_sha,
+        snapshot_hash,
+        fingerprint,
+        files,
+        total_bytes,
+    })
+}
+
+pub fn print_snapshot(snapshot: &PreparedSnapshot) {
+    eprintln!(
+        "Preparing a safe snapshot...\n{} changed files, {} bytes",
+        snapshot.files.len(),
+        snapshot.total_bytes
+    );
+    for file in &snapshot.files {
+        eprintln!("  {} {}", file.status, file.path);
+    }
+}
+
+pub fn cached_review(snapshot: &PreparedSnapshot) -> Result<Option<Report>> {
+    let path = review_cache_path()?;
+    let cache: ReviewCache = match fs::read(&path) {
+        Ok(bytes) => serde_json::from_slice(&bytes).context("local review cache is invalid")?,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(error).with_context(|| format!("could not read {}", path.display()));
+        }
+    };
+    Ok((cache.fingerprint == snapshot.fingerprint).then_some(cache.report))
+}
+
+pub fn save_review(snapshot: &PreparedSnapshot, report: &Report) -> Result<()> {
+    write_private_json(
+        &review_cache_path()?,
+        &ReviewCache {
+            fingerprint: snapshot.fingerprint.clone(),
+            report: report.clone(),
+            saved_at: Utc::now().to_rfc3339(),
+        },
+    )
+}
+
+pub async fn handoff(
+    snapshot: &PreparedSnapshot,
+    report: &Report,
+    base_ref: &str,
+    intent: &str,
+) -> Result<HandoffReceipt> {
+    let mut session = valid_session().await?;
+    let payload = json!({
+        "idempotency_key": format!("cli:{}", snapshot.fingerprint),
+        "repository": {
+            "provider": "github",
+            "owner": snapshot.owner,
+            "name": snapshot.name,
+            "dbt_root": snapshot.dbt_root,
+            "base_ref": base_ref,
+            "base_sha": snapshot.base_sha,
+            "head_sha": snapshot.head_sha,
+        },
+        "snapshot_hash": snapshot.snapshot_hash,
+        "intent_context": intent,
+        "changed_files": snapshot.files,
+        "local_review": report,
+        "cli": {"version": env!("CARGO_PKG_VERSION"), "platform": env::consts::OS},
+        "notify_slack": true,
+    });
+    let response = Client::new()
+        .post(format!(
+            "{}/v1/agent/cloud-handoffs",
+            session.api_base_url.trim_end_matches('/')
+        ))
+        .bearer_auth(&session.access_token)
+        .json(&payload)
+        .send()
+        .await
+        .context("could not reach Embrasure Cloud")?;
+    if response.status() == StatusCode::UNAUTHORIZED {
+        session = refresh_session(&session).await?;
+        save_session(&session)?;
+        return handoff_once(snapshot, report, base_ref, intent, &session).await;
+    }
+    parse_handoff(response, snapshot).await
+}
+
+async fn handoff_once(
+    snapshot: &PreparedSnapshot,
+    report: &Report,
+    base_ref: &str,
+    intent: &str,
+    session: &CloudSession,
+) -> Result<HandoffReceipt> {
+    let payload = json!({
+        "idempotency_key": format!("cli:{}", snapshot.fingerprint),
+        "repository": {"provider":"github","owner":snapshot.owner,"name":snapshot.name,"dbt_root":snapshot.dbt_root,"base_ref":base_ref,"base_sha":snapshot.base_sha,"head_sha":snapshot.head_sha},
+        "snapshot_hash": snapshot.snapshot_hash,
+        "intent_context": intent,
+        "changed_files": snapshot.files,
+        "local_review": report,
+        "cli": {"version": env!("CARGO_PKG_VERSION"), "platform": env::consts::OS},
+        "notify_slack": true,
+    });
+    let response = Client::new()
+        .post(format!(
+            "{}/v1/agent/cloud-handoffs",
+            session.api_base_url.trim_end_matches('/')
+        ))
+        .bearer_auth(&session.access_token)
+        .json(&payload)
+        .send()
+        .await?;
+    parse_handoff(response, snapshot).await
+}
+
+async fn parse_handoff(
+    response: reqwest::Response,
+    snapshot: &PreparedSnapshot,
+) -> Result<HandoffReceipt> {
+    let status = response.status();
+    let body = response.text().await.unwrap_or_default();
+    if !status.is_success() {
+        bail!("cloud handoff failed ({status}): {}", api_error(&body));
+    }
+    let result: HandoffResponse =
+        serde_json::from_str(&body).context("cloud handoff returned an invalid response")?;
+    if result.snapshot_hash != snapshot.snapshot_hash {
+        bail!("cloud handoff receipt did not match the uploaded snapshot");
+    }
+    let receipt = HandoffReceipt {
+        handoff_id: result.handoff_id,
+        run_id: result.run_id,
+        run_url: result.run_url,
+        snapshot_hash: result.snapshot_hash,
+        base_sha: snapshot.base_sha.clone(),
+        accepted_at: result.accepted_at,
+    };
+    write_private_json(&receipt_path()?, &receipt)?;
+    Ok(receipt)
+}
+
+pub async fn login() -> Result<CloudSession> {
+    let api_base_url = api_base_url();
+    let web_base_url = web_base_url(&api_base_url);
+    let listener = TcpListener::bind(("127.0.0.1", 0))
+        .await
+        .context("could not start the cloud login callback")?;
+    let port = listener.local_addr()?.port();
+    let return_url = format!("http://127.0.0.1:{port}/callback");
+    let state = random_string(32);
+    let verifier = random_string(64);
+    let challenge = URL_SAFE_NO_PAD.encode(Sha256::digest(verifier.as_bytes()));
+    let mut url = Url::parse(&format!(
+        "{}/cli-auth/complete",
+        web_base_url.trim_end_matches('/')
+    ))?;
+    url.query_pairs_mut()
+        .append_pair("state", &state)
+        .append_pair("api_base_url", &api_base_url)
+        .append_pair("return_url", &return_url)
+        .append_pair("code_challenge", &challenge)
+        .append_pair("code_challenge_method", "S256")
+        .append_pair("device_id", &format!("rust-cli-{}", random_string(24)))
+        .append_pair("device_name", "Embrasure CLI")
+        .append_pair("platform", env::consts::OS)
+        .append_pair("client", "cli")
+        .append_pair("client_version", env!("CARGO_PKG_VERSION"));
+    eprintln!(
+        "Opening Embrasure Cloud sign-in in your browser.\n{}",
+        url.as_str()
+    );
+    let _ = webbrowser::open(url.as_str());
+    let (mut stream, _) = timeout(Duration::from_secs(180), listener.accept())
+        .await
+        .context("cloud login timed out after 3 minutes")??;
+    let request = timeout(Duration::from_secs(10), read_http_request(&mut stream))
+        .await
+        .context("cloud login callback timed out")??;
+    let request = String::from_utf8_lossy(&request);
+    let target = request
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .context("cloud login callback was malformed")?;
+    let callback = Url::parse(&format!("http://127.0.0.1{target}"))?;
+    let callback_state = callback
+        .query_pairs()
+        .find(|(key, _)| key == "state")
+        .map(|(_, value)| value.into_owned())
+        .unwrap_or_default();
+    let code = callback
+        .query_pairs()
+        .find(|(key, _)| key == "code")
+        .map(|(_, value)| value.into_owned())
+        .unwrap_or_default();
+    if callback.path() != "/callback" || callback_state != state || code.is_empty() {
+        write_http_response(
+            &mut stream,
+            "Cloud sign-in failed",
+            "Return to the terminal and try again.",
+        )
+        .await?;
+        bail!("cloud login returned an invalid callback");
+    }
+    write_http_response(
+        &mut stream,
+        "Embrasure Cloud is connected",
+        "You can close this tab and return to your terminal.",
+    )
+    .await?;
+    let response = Client::new()
+        .post(format!("{}/v1/auth/session/token", api_base_url.trim_end_matches('/')))
+        .json(&json!({"grant_type":"authorization_code","code":code,"code_verifier":verifier,"redirect_uri":return_url}))
+        .send().await.context("could not exchange the cloud authorization code")?;
+    let status = response.status();
+    let body = response.text().await.unwrap_or_default();
+    if !status.is_success() {
+        bail!("cloud login failed: {}", api_error(&body));
+    }
+    let token: TokenResponse =
+        serde_json::from_str(&body).context("cloud login returned an invalid token")?;
+    let session = CloudSession {
+        access_token: token.access_token,
+        refresh_token: token.refresh_token,
+        expires_at: token.expires_at,
+        refresh_expires_at: token.refresh_expires_at,
+        session_id: token.session_id,
+        workspace_id: token.workspace_id,
+        api_base_url,
+    };
+    save_session(&session)?;
+    Ok(session)
+}
+
+pub async fn whoami() -> Result<Value> {
+    let session = valid_session().await?;
+    api_get(&session, "/v1/auth/whoami", &[]).await
+}
+
+pub async fn status(run_id: Option<&str>) -> Result<Value> {
+    let session = valid_session().await?;
+    let id = match run_id {
+        Some(value) => value.to_owned(),
+        None => read_receipt()?.run_id,
+    };
+    api_get(
+        &session,
+        &format!("/v1/agent/runs/{id}/cloud-summary"),
+        &[("workspace_id", session.workspace_id.as_str())],
+    )
+    .await
+}
+
+pub async fn logout() -> Result<()> {
+    if let Ok(session) = load_session() {
+        let _ = Client::new()
+            .post(format!(
+                "{}/v1/auth/session/revoke",
+                session.api_base_url.trim_end_matches('/')
+            ))
+            .json(&json!({"refresh_token": session.refresh_token}))
+            .send()
+            .await;
+    }
+    match keychain()?.delete_credential() {
+        Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
+        Err(error) => Err(error).context("could not remove the Embrasure Cloud keychain session"),
+    }
+}
+
+async fn valid_session() -> Result<CloudSession> {
+    let session =
+        load_session().context("not signed in to Embrasure Cloud; run `embrasure cloud login`")?;
+    let expires = DateTime::parse_from_rfc3339(&session.expires_at)?.with_timezone(&Utc);
+    if expires > Utc::now() + chrono::Duration::seconds(30) {
+        return Ok(session);
+    }
+    let refreshed = refresh_session(&session).await?;
+    save_session(&refreshed)?;
+    Ok(refreshed)
+}
+
+async fn refresh_session(session: &CloudSession) -> Result<CloudSession> {
+    let response = Client::new()
+        .post(format!(
+            "{}/v1/auth/session/refresh",
+            session.api_base_url.trim_end_matches('/')
+        ))
+        .json(&json!({"grant_type":"refresh_token","refresh_token":session.refresh_token}))
+        .send()
+        .await?;
+    let status = response.status();
+    let body = response.text().await.unwrap_or_default();
+    if !status.is_success() {
+        bail!(
+            "cloud session expired: {}; run `embrasure cloud login`",
+            api_error(&body)
+        );
+    }
+    let token: TokenResponse = serde_json::from_str(&body)?;
+    Ok(CloudSession {
+        access_token: token.access_token,
+        refresh_token: token.refresh_token,
+        expires_at: token.expires_at,
+        refresh_expires_at: token.refresh_expires_at,
+        session_id: token.session_id,
+        workspace_id: token.workspace_id,
+        api_base_url: session.api_base_url.clone(),
+    })
+}
+
+async fn api_get(session: &CloudSession, path: &str, query: &[(&str, &str)]) -> Result<Value> {
+    let response = Client::new()
+        .get(format!(
+            "{}{}",
+            session.api_base_url.trim_end_matches('/'),
+            path
+        ))
+        .bearer_auth(&session.access_token)
+        .query(query)
+        .send()
+        .await?;
+    let status = response.status();
+    let body = response.text().await.unwrap_or_default();
+    if !status.is_success() {
+        bail!(
+            "Embrasure Cloud request failed ({status}): {}",
+            api_error(&body)
+        );
+    }
+    serde_json::from_str(&body).context("Embrasure Cloud returned invalid JSON")
+}
+
+fn keychain() -> Result<Entry> {
+    Entry::new(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT)
+        .context("could not open the Embrasure Cloud keychain entry")
+}
+
+fn save_session(session: &CloudSession) -> Result<()> {
+    keychain()?
+        .set_password(&serde_json::to_string(session)?)
+        .context("could not save the Embrasure Cloud session in the OS keychain")
+}
+
+fn load_session() -> Result<CloudSession> {
+    let value = keychain()?
+        .get_password()
+        .context("no Embrasure Cloud session is stored")?;
+    serde_json::from_str(&value).context("the Embrasure Cloud keychain session is invalid")
+}
+
+fn api_base_url() -> String {
+    env::var("EMBRASURE_API_URL")
+        .unwrap_or_else(|_| "https://api.embrasure.ai".into())
+        .trim_end_matches('/')
+        .to_owned()
+}
+
+fn web_base_url(api: &str) -> String {
+    env::var("EMBRASURE_WEB_URL").unwrap_or_else(|_| {
+        if api.contains("localhost") || api.contains("127.0.0.1") {
+            "http://localhost:3000".into()
+        } else {
+            "https://app.embrasure.ai".into()
+        }
+    })
+}
+
+fn project_dirs() -> Result<ProjectDirs> {
+    ProjectDirs::from("ai", "Embrasure", "embrasure-cli")
+        .context("could not resolve the OS application directory")
+}
+
+fn review_cache_path() -> Result<PathBuf> {
+    Ok(project_dirs()?.cache_dir().join("cloud-review.json"))
+}
+fn receipt_path() -> Result<PathBuf> {
+    Ok(project_dirs()?
+        .data_local_dir()
+        .join("last-cloud-handoff.json"))
+}
+
+fn read_receipt() -> Result<HandoffReceipt> {
+    let path = receipt_path()?;
+    serde_json::from_slice(
+        &fs::read(&path)
+            .with_context(|| format!("no cloud handoff receipt at {}", path.display()))?,
+    )
+    .context("the cloud handoff receipt is invalid")
+}
+
+fn write_private_json(path: &Path, value: &impl Serialize) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(path, serde_json::to_vec_pretty(value)?)
+        .with_context(|| format!("could not write {}", path.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
+    }
+    Ok(())
+}
+
+fn git_path(cwd: &Path, args: &[&str]) -> Result<PathBuf> {
+    Ok(PathBuf::from(git_text(cwd, args)?).canonicalize()?)
+}
+
+fn git_text(cwd: &Path, args: &[&str]) -> Result<String> {
+    let output = Command::new("git")
+        .current_dir(cwd)
+        .args(args)
+        .output()
+        .with_context(|| format!("could not run git {}", args.join(" ")))?;
+    if !output.status.success() {
+        bail!(
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(String::from_utf8(output.stdout)?.trim().to_owned())
+}
+
+fn changed_paths(root: &Path, base: &str) -> Result<Vec<(String, String)>> {
+    let output = Command::new("git")
+        .current_dir(root)
+        .args(["diff", "--name-status", "-z", base, "--"])
+        .output()?;
+    if !output.status.success() {
+        bail!(
+            "could not inspect working-tree changes: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    let parts = output
+        .stdout
+        .split(|byte| *byte == 0)
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>();
+    let mut rows = Vec::new();
+    let mut index = 0;
+    while index + 1 < parts.len() {
+        let code = String::from_utf8_lossy(parts[index]);
+        let status = match code.chars().next().unwrap_or('M') {
+            'A' => "added",
+            'D' => "deleted",
+            _ => "modified",
+        };
+        let path_index = if code.starts_with('R') || code.starts_with('C') {
+            index + 2
+        } else {
+            index + 1
+        };
+        if path_index >= parts.len() {
+            break;
+        }
+        rows.push((
+            String::from_utf8(parts[path_index].to_vec())?,
+            status.into(),
+        ));
+        index += if code.starts_with('R') || code.starts_with('C') {
+            3
+        } else {
+            2
+        };
+    }
+    let untracked = Command::new("git")
+        .current_dir(root)
+        .args(["ls-files", "--others", "--exclude-standard", "-z"])
+        .output()?;
+    if !untracked.status.success() {
+        bail!("could not inspect untracked files");
+    }
+    for path in untracked
+        .stdout
+        .split(|byte| *byte == 0)
+        .filter(|part| !part.is_empty())
+    {
+        rows.push((String::from_utf8(path.to_vec())?, "added".into()));
+    }
+    Ok(rows)
+}
+
+fn parse_github_remote(remote: &str) -> Result<(String, String)> {
+    let path = if let Some(value) = remote.strip_prefix("git@github.com:") {
+        value.to_owned()
+    } else {
+        let url = Url::parse(remote).context("origin is not a supported GitHub URL")?;
+        if !url
+            .host_str()
+            .is_some_and(|host| host.eq_ignore_ascii_case("github.com"))
+        {
+            bail!("origin must be a GitHub repository");
+        }
+        url.path().trim_matches('/').to_owned()
+    };
+    let path = path.strip_suffix(".git").unwrap_or(&path);
+    let mut parts = path.split('/');
+    let owner = parts.next().unwrap_or_default();
+    let name = parts.next().unwrap_or_default();
+    if owner.is_empty() || name.is_empty() || parts.next().is_some() {
+        bail!("origin must identify one GitHub owner and repository");
+    }
+    Ok((owner.into(), name.into()))
+}
+
+fn normalize_snapshot_path(path: &Path) -> Result<String> {
+    if path.is_absolute()
+        || path
+            .components()
+            .any(|part| !matches!(part, Component::Normal(_)))
+    {
+        bail!("unsafe snapshot path: {}", path.display());
+    }
+    Ok(path.to_string_lossy().replace('\\', "/"))
+}
+
+fn eligible(path: &str) -> bool {
+    let lower = path.to_ascii_lowercase();
+    let parts = lower.split('/').collect::<Vec<_>>();
+    if parts.iter().any(|part| {
+        matches!(
+            *part,
+            ".git" | "target" | "logs" | "dbt_packages" | ".venv" | "venv" | "node_modules"
+        )
+    }) || parts.iter().any(|part| part.starts_with(".env"))
+        || parts.last().is_some_and(|name| {
+            matches!(
+                *name,
+                "profiles.yml"
+                    | "profiles.yaml"
+                    | "credentials"
+                    | "credentials.json"
+                    | "credentials.yml"
+                    | "credentials.yaml"
+            )
+        })
+    {
+        return false;
+    }
+    [".sql", ".yml", ".yaml", ".py", ".json", ".md"]
+        .iter()
+        .any(|suffix| lower.ends_with(suffix))
+}
+
+fn contains_secret(value: &str) -> bool {
+    let lower = value.to_ascii_lowercase();
+    lower.contains("-----begin private key-----")
+        || [
+            "password=",
+            "password:",
+            "client_secret=",
+            "client_secret:",
+            "private_key=",
+            "access_token=",
+            "xoxb-",
+            "github_pat_",
+            "ghp_",
+        ]
+        .iter()
+        .any(|needle| lower.contains(needle))
+}
+
+fn hex_digest(bytes: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(bytes))
+}
+
+fn random_string(length: usize) -> String {
+    rand::thread_rng()
+        .sample_iter(&Alphanumeric)
+        .take(length)
+        .map(char::from)
+        .collect()
+}
+
+fn api_error(body: &str) -> String {
+    let value: Value = serde_json::from_str(body).unwrap_or(Value::Null);
+    value
+        .pointer("/detail/message")
+        .or_else(|| value.get("detail"))
+        .or_else(|| value.get("error"))
+        .and_then(Value::as_str)
+        .unwrap_or("request failed")
+        .to_owned()
+}
+
+async fn read_http_request(stream: &mut TcpStream) -> Result<Vec<u8>> {
+    let mut buffer = Vec::new();
+    let mut chunk = [0_u8; 2048];
+    while buffer.len() < 16 * 1024 {
+        let read = stream.read(&mut chunk).await?;
+        if read == 0 {
+            break;
+        }
+        buffer.extend_from_slice(&chunk[..read]);
+        if buffer.windows(4).any(|window| window == b"\r\n\r\n") {
+            break;
+        }
+    }
+    Ok(buffer)
+}
+
+async fn write_http_response(stream: &mut TcpStream, title: &str, message: &str) -> Result<()> {
+    let body = format!(
+        "<!doctype html><meta charset=utf-8><title>{title}</title><main><h1>{title}</h1><p>{message}</p></main>"
+    );
+    let response = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        body.len(),
+        body
+    );
+    stream.write_all(response.as_bytes()).await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn context_is_required_and_secret_checked() {
+        assert!(normalize_context(&[], None).is_err());
+        assert!(normalize_context(&["access_token=secret-value".into()], None).is_err());
+        assert_eq!(
+            normalize_context(&["one row per order".into()], None).unwrap(),
+            "one row per order"
+        );
+    }
+
+    #[test]
+    fn context_values_and_file_are_normalized_in_order() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("intent.md");
+        fs::write(&path, "  Daily totals reconcile within one cent.  \n").unwrap();
+        assert_eq!(
+            normalize_context(
+                &[
+                    "  Preserve one row per order. ".into(),
+                    "Refunds reduce net revenue.".into(),
+                ],
+                Some(&path),
+            )
+            .unwrap(),
+            "Preserve one row per order.\n\nRefunds reduce net revenue.\n\nDaily totals reconcile within one cent."
+        );
+    }
+
+    #[test]
+    fn github_remotes_are_parsed() {
+        assert_eq!(
+            parse_github_remote("git@github.com:EmbrasureAI/demo.git").unwrap(),
+            ("EmbrasureAI".into(), "demo".into())
+        );
+        assert_eq!(
+            parse_github_remote("https://github.com/EmbrasureAI/demo.git").unwrap(),
+            ("EmbrasureAI".into(), "demo".into())
+        );
+    }
+
+    #[test]
+    fn exclusions_and_animation_rules_are_deterministic() {
+        assert!(!eligible("profiles.yml"));
+        assert!(!eligible("config/profiles.yml"));
+        assert!(!eligible("config/credentials.json"));
+        assert!(!eligible("target/manifest.json"));
+        assert!(eligible("models/finance/fct_order_margin.sql"));
+        assert!(normalize_snapshot_path(Path::new("../outside.sql")).is_err());
+        assert!(normalize_snapshot_path(Path::new("models/finance/model.sql")).is_ok());
+    }
+
+    #[test]
+    fn receipts_never_serialize_source_or_tokens() {
+        let receipt = HandoffReceipt {
+            handoff_id: "handoff_123".into(),
+            run_id: "run_123".into(),
+            run_url: "https://app.embrasure.ai/agents/context/runs/run_123".into(),
+            snapshot_hash: "a".repeat(64),
+            base_sha: "b".repeat(40),
+            accepted_at: "2026-08-15T00:00:00Z".into(),
+        };
+        let serialized = serde_json::to_string(&receipt).unwrap();
+        assert!(!serialized.contains("access_token"));
+        assert!(!serialized.contains("refresh_token"));
+        assert!(!serialized.contains("content_utf8"));
+    }
+
+    #[test]
+    fn api_errors_use_actionable_server_messages() {
+        assert_eq!(
+            api_error(r#"{"detail":{"message":"Connect this GitHub dbt project."}}"#),
+            "Connect this GitHub dbt project."
+        );
+        assert_eq!(api_error("not-json"), "request failed");
+    }
+}

--- a/src/cloud.rs
+++ b/src/cloud.rs
@@ -547,16 +547,16 @@ pub async fn logout() -> Result<()> {
 }
 
 async fn valid_session() -> Result<CloudSession> {
-    if let Ok(access_token) = env::var("EMBRASURE_CLOUD_TOKEN")
-        && !access_token.trim().is_empty()
-    {
-        return Ok(CloudSession {
-            access_token,
-            refresh_token: String::new(),
-            expires_at: "9999-12-31T23:59:59Z".into(),
-            workspace_id: env::var("EMBRASURE_CLOUD_WORKSPACE_ID").unwrap_or_default(),
-            api_base_url: api_base_url(),
-        });
+    if let Ok(access_token) = env::var("EMBRASURE_CLOUD_TOKEN") {
+        if !access_token.trim().is_empty() {
+            return Ok(CloudSession {
+                access_token,
+                refresh_token: String::new(),
+                expires_at: "9999-12-31T23:59:59Z".into(),
+                workspace_id: env::var("EMBRASURE_CLOUD_WORKSPACE_ID").unwrap_or_default(),
+                api_base_url: api_base_url(),
+            });
+        }
     }
     let session =
         load_session().context("not signed in to Embrasure Cloud; run `embrasure cloud login`")?;

--- a/src/compare.rs
+++ b/src/compare.rs
@@ -92,7 +92,9 @@ pub async fn compare_model(
                 format!("column {name} exists in CI but not production"),
             ));
         } else if let (Some(ci_column), Some(prod_column)) = (ci_column, prod_column)
-            && !equivalent_type(&ci_column.data_type, &prod_column.data_type)
+            && !ci_column
+                .data_type
+                .eq_ignore_ascii_case(&prod_column.data_type)
         {
             findings.push(finding(
                 model_id,
@@ -572,10 +574,6 @@ fn is_orderable(data_type: &str) -> bool {
             .unwrap_or_default(),
         "ARRAY" | "OBJECT" | "VARIANT" | "BINARY" | "GEOGRAPHY" | "GEOMETRY"
     )
-}
-
-fn equivalent_type(left: &str, right: &str) -> bool {
-    left.eq_ignore_ascii_case(right)
 }
 
 fn relative_change(current: f64, production: f64) -> f64 {

--- a/src/compare.rs
+++ b/src/compare.rs
@@ -91,19 +91,20 @@ pub async fn compare_model(
                 "column_added",
                 format!("column {name} exists in CI but not production"),
             ));
-        } else if let (Some(ci_column), Some(prod_column)) = (ci_column, prod_column)
-            && !ci_column
+        } else if let (Some(ci_column), Some(prod_column)) = (ci_column, prod_column) {
+            if !ci_column
                 .data_type
                 .eq_ignore_ascii_case(&prod_column.data_type)
-        {
-            findings.push(finding(
-                model_id,
-                "column_type",
-                format!(
-                    "column {name} changed from {} to {}",
-                    prod_column.data_type, ci_column.data_type,
-                ),
-            ));
+            {
+                findings.push(finding(
+                    model_id,
+                    "column_type",
+                    format!(
+                        "column {name} changed from {} to {}",
+                        prod_column.data_type, ci_column.data_type,
+                    ),
+                ));
+            }
         }
         let ci_value = ci_metrics.columns.get(&name).cloned();
         let prod_value = prod_metrics.columns.get(&name).cloned();
@@ -137,13 +138,15 @@ pub async fn compare_model(
                 ("p50", ci_value.p50, prod_value.p50),
                 ("p95", ci_value.p95, prod_value.p95),
             ] {
-                if numeric && let (Some(ci_number), Some(prod_number)) = (ci_number, prod_number) {
-                    let change = relative_change(ci_number, prod_number);
-                    if change > thresholds.numeric_relative {
-                        findings.push(finding(model_id, "distribution", format!(
-                            "column {name} {metric} is {ci_number:.6} in CI vs {prod_number:.6} in production (relative change {change:.6}, allowed {:.6})",
-                            thresholds.numeric_relative,
-                        )));
+                if numeric {
+                    if let (Some(ci_number), Some(prod_number)) = (ci_number, prod_number) {
+                        let change = relative_change(ci_number, prod_number);
+                        if change > thresholds.numeric_relative {
+                            findings.push(finding(model_id, "distribution", format!(
+                                "column {name} {metric} is {ci_number:.6} in CI vs {prod_number:.6} in production (relative change {change:.6}, allowed {:.6})",
+                                thresholds.numeric_relative,
+                            )));
+                        }
                     }
                 }
             }
@@ -164,12 +167,12 @@ pub async fn compare_model(
                             )));
                         }
                     }
-                } else if let (Some(ci_extreme), Some(prod_extreme)) = (ci_extreme, prod_extreme)
-                    && ci_extreme != prod_extreme
-                {
-                    findings.push(finding(model_id, "range", format!(
-                        "column {name} {metric} is {ci_extreme:?} in CI vs {prod_extreme:?} in production"
-                    )));
+                } else if let (Some(ci_extreme), Some(prod_extreme)) = (ci_extreme, prod_extreme) {
+                    if ci_extreme != prod_extreme {
+                        findings.push(finding(model_id, "range", format!(
+                            "column {name} {metric} is {ci_extreme:?} in CI vs {prod_extreme:?} in production"
+                        )));
+                    }
                 }
             }
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -442,16 +442,17 @@ impl Config {
             }
         }
         for (model, config) in &self.models {
-            if let Some(predicate) = &config.where_clause
-                && (predicate.trim().is_empty()
+            if let Some(predicate) = &config.where_clause {
+                if predicate.trim().is_empty()
                     || predicate.contains(';')
                     || predicate.contains("--")
                     || predicate.contains("/*")
-                    || predicate.contains("*/"))
-            {
-                bail!(
-                    "models.{model}.where must be one non-empty SQL predicate without comments or semicolons"
-                );
+                    || predicate.contains("*/")
+                {
+                    bail!(
+                        "models.{model}.where must be one non-empty SQL predicate without comments or semicolons"
+                    );
+                }
             }
             let effective = config.thresholds.apply(self.thresholds);
             if !valid_rate(effective.row_count_relative)

--- a/src/dbt.rs
+++ b/src/dbt.rs
@@ -16,6 +16,7 @@ use uuid::Uuid;
 use crate::{
     auth::ResolvedAuth,
     config::{AccountConfig, Config},
+    git,
     report::{ImpactReport, ImpactedAsset, LineageChange, LineageChangeKind, LineageEdge},
 };
 
@@ -80,13 +81,13 @@ pub struct Exposure {
 
 #[derive(Debug)]
 pub struct DbtContext {
-    _scratch: TempDir,
+    scratch: TempDir,
     pub repo_root: PathBuf,
     pub profiles_dir: PathBuf,
     state_dirs: BTreeMap<String, PathBuf>,
     manifests: BTreeMap<String, Manifest>,
     production_manifests: BTreeMap<String, Manifest>,
-    base_worktree: Option<PathBuf>,
+    base_worktree: Option<WorktreeRegistration>,
 }
 
 #[derive(Debug)]
@@ -506,7 +507,7 @@ pub fn prepare(
             .collect::<BTreeMap<_, _>>()
     } else {
         let base_worktree = scratch.path().join("base-worktree");
-        run_git(
+        git::success(
             &repo_root,
             &[
                 "worktree",
@@ -586,19 +587,14 @@ pub fn prepare(
             Manifest::load(&state_dir.join("manifest.json"))?,
         );
     }
-    let base_worktree = worktree_registration.as_mut().map(|registration| {
-        registration.active = false;
-        registration.path.clone()
-    });
-
     Ok(DbtContext {
-        _scratch: scratch,
+        scratch,
         repo_root,
         profiles_dir,
         state_dirs,
         manifests,
         production_manifests,
-        base_worktree,
+        base_worktree: worktree_registration,
     })
 }
 
@@ -623,23 +619,23 @@ impl DbtContext {
     }
 
     fn build_target(&self, account: &str) -> PathBuf {
-        self._scratch.path().join("build-target").join(account)
+        self.scratch.path().join("build-target").join(account)
     }
 
     pub fn cleanup_worktree(&mut self) -> Result<()> {
-        let Some(path) = self.base_worktree.take() else {
+        let Some(mut registration) = self.base_worktree.take() else {
             return Ok(());
         };
-        run_git(
-            &self.repo_root,
-            &["worktree", "remove", "--force", path_str(&path)?],
-        )
+        remove_worktree(&registration.repo, &registration.path)?;
+        registration.active = false;
+        Ok(())
     }
 
     pub fn changed_paths(&self, base: &str) -> Result<Vec<String>> {
-        let output = git_output(&self.repo_root, &["diff", "--name-only", base])?;
+        // Local validation includes untracked files because dbt can select newly-created models.
+        let output = git::text(&self.repo_root, &["diff", "--name-only", base])?;
         let mut paths = output.lines().map(str::to_owned).collect::<Vec<_>>();
-        let untracked = git_output(
+        let untracked = git::text(
             &self.repo_root,
             &["ls-files", "--others", "--exclude-standard"],
         )?;
@@ -647,19 +643,6 @@ impl DbtContext {
         paths.sort();
         paths.dedup();
         Ok(paths)
-    }
-}
-
-impl Drop for DbtContext {
-    fn drop(&mut self) {
-        if let Some(path) = self.base_worktree.take() {
-            let _ = Command::new("git")
-                .arg("-C")
-                .arg(&self.repo_root)
-                .args(["worktree", "remove", "--force"])
-                .arg(path)
-                .output();
-        }
     }
 }
 
@@ -933,6 +916,7 @@ pub fn ci_schema_name(prefix: &str, repo: &Path) -> Result<String> {
     ))
 }
 
+#[derive(Debug)]
 struct WorktreeRegistration {
     repo: PathBuf,
     path: PathBuf,
@@ -942,14 +926,13 @@ struct WorktreeRegistration {
 impl Drop for WorktreeRegistration {
     fn drop(&mut self) {
         if self.active {
-            let _ = Command::new("git")
-                .arg("-C")
-                .arg(&self.repo)
-                .args(["worktree", "remove", "--force"])
-                .arg(&self.path)
-                .output();
+            let _ = remove_worktree(&self.repo, &self.path);
         }
     }
+}
+
+fn remove_worktree(repo: &Path, path: &Path) -> Result<()> {
+    git::success(repo, &["worktree", "remove", "--force", path_str(path)?])
 }
 
 fn write_profiles(
@@ -1033,16 +1016,7 @@ fn maybe_dbt_deps(config: &Config, project: &Path, profiles: &Path) -> Result<()
 }
 
 fn dbt_command(config: &Config, project: &Path, profiles: &Path, args: &[&str]) -> Result<()> {
-    let output = dbt_process(config, project, profiles, args)?;
-    if !output.status.success() {
-        bail!(
-            "dbt {} failed ({}): {}",
-            args.first().unwrap_or(&"command"),
-            output.status,
-            String::from_utf8_lossy(&output.stderr).trim()
-        );
-    }
-    Ok(())
+    dbt_output(config, project, profiles, args).map(|_| ())
 }
 
 fn dbt_output(config: &Config, project: &Path, profiles: &Path, args: &[&str]) -> Result<String> {
@@ -1074,38 +1048,8 @@ fn dbt_process(config: &Config, project: &Path, profiles: &Path, args: &[&str]) 
         .with_context(|| format!("could not run {}", config.dbt.command))
 }
 
-fn run_git(repo: &Path, args: &[&str]) -> Result<()> {
-    let output = Command::new("git")
-        .arg("-C")
-        .arg(repo)
-        .args(args)
-        .output()
-        .context("could not run git")?;
-    if !output.status.success() {
-        bail!(
-            "git {} failed: {}",
-            args.first().unwrap_or(&"command"),
-            String::from_utf8_lossy(&output.stderr).trim()
-        );
-    }
-    Ok(())
-}
-
 fn git_output(repo: &Path, args: &[&str]) -> Result<String> {
-    let output = Command::new("git")
-        .arg("-C")
-        .arg(repo)
-        .args(args)
-        .output()
-        .context("could not run git")?;
-    if !output.status.success() {
-        bail!(
-            "git {} failed: {}",
-            args.first().unwrap_or(&"command"),
-            String::from_utf8_lossy(&output.stderr).trim()
-        );
-    }
-    String::from_utf8(output.stdout).context("git returned non-UTF-8 output")
+    git::text(repo, args)
 }
 
 fn path_str(path: &Path) -> Result<&str> {

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -9,6 +9,7 @@ use crate::{
     config::Config,
     metabase,
     snowflake::{QueryResult, Relation, SnowflakeClient, quote_identifier},
+    style::Style,
 };
 
 #[derive(Debug, Serialize)]
@@ -24,27 +25,6 @@ pub struct Diagnostic {
     pub check: String,
     pub status: &'static str,
     pub message: String,
-}
-
-impl DoctorReport {
-    pub fn human(&self) -> String {
-        let mut output = format!(
-            "embrasure doctor: {}\n",
-            if self.ready { "READY" } else { "NOT READY" }
-        );
-        for item in &self.checks {
-            let icon = match item.status {
-                "pass" => "✓",
-                "skip" => "-",
-                _ => "✗",
-            };
-            output.push_str(&format!(
-                "  {icon} {} / {}: {}\n",
-                item.scope, item.check, item.message
-            ));
-        }
-        output
-    }
 }
 
 pub async fn run(config_path: &Path, write_test: bool) -> DoctorReport {
@@ -313,6 +293,32 @@ fn relation_names(result: &QueryResult) -> Vec<String> {
 }
 
 impl DoctorReport {
+    #[cfg(test)]
+    pub fn human(&self) -> String {
+        self.human_styled(&Style::plain())
+    }
+
+    pub fn human_styled(&self, style: &Style) -> String {
+        let readiness = if self.ready {
+            style.good(&style.bold("READY"))
+        } else {
+            style.bad(&style.bold("NOT READY"))
+        };
+        let mut output = format!("embrasure doctor: {readiness}\n",);
+        for item in &self.checks {
+            let icon = match item.status {
+                "pass" => style.good("✓"),
+                "skip" => style.warn("-"),
+                _ => style.bad("✗"),
+            };
+            output.push_str(&format!(
+                "  {icon} {} / {}: {}\n",
+                item.scope, item.check, item.message
+            ));
+        }
+        output
+    }
+
     fn tool(&mut self, name: &str, command: &str) {
         match Command::new(command).arg("--version").output() {
             Ok(output) if output.status.success() => {

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,0 +1,28 @@
+use std::{path::Path, process::Output};
+
+use anyhow::{Context, Result, bail};
+
+pub fn output(repo: &Path, args: &[&str]) -> Result<Output> {
+    std::process::Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(args)
+        .output()
+        .with_context(|| format!("could not run git {}", args.join(" ")))
+}
+
+pub fn text(repo: &Path, args: &[&str]) -> Result<String> {
+    let output = output(repo, args)?;
+    if !output.status.success() {
+        bail!(
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(String::from_utf8(output.stdout)?.trim().to_owned())
+}
+
+pub fn success(repo: &Path, args: &[&str]) -> Result<()> {
+    text(repo, args).map(|_| ())
+}

--- a/src/init.rs
+++ b/src/init.rs
@@ -19,16 +19,6 @@ pub struct Options {
     pub production_schema: Option<String>,
 }
 
-#[derive(Debug, Default)]
-struct Defaults {
-    profile: Option<String>,
-    account: Option<String>,
-    user: Option<String>,
-    role: Option<String>,
-    database: Option<String>,
-    warehouse: Option<String>,
-}
-
 #[derive(Serialize)]
 struct GeneratedConfig<'a> {
     version: u8,
@@ -158,15 +148,15 @@ fn required(label: &str, default: Option<String>) -> Result<String> {
     bail!("{label} is required");
 }
 
-fn discover_defaults(project_file: &Path) -> Defaults {
+fn discover_defaults(project_file: &Path) -> Options {
     let profile = fs::read(project_file)
         .ok()
         .and_then(|bytes| serde_yaml::from_slice::<Value>(&bytes).ok())
         .and_then(|value| mapping_string(&value, "profile"));
 
-    let mut defaults = Defaults {
+    let mut defaults = Options {
         profile,
-        ..Defaults::default()
+        ..Options::default()
     };
     let Some(profile_name) = defaults.profile.as_deref() else {
         return defaults;

--- a/src/loopback.rs
+++ b/src/loopback.rs
@@ -1,0 +1,78 @@
+use std::time::Duration;
+
+use anyhow::{Context, Result, bail};
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use rand::{Rng, distributions::Alphanumeric};
+use sha2::{Digest, Sha256};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::{TcpListener, TcpStream},
+    time::timeout,
+};
+
+pub fn random_string(length: usize) -> String {
+    rand::thread_rng()
+        .sample_iter(&Alphanumeric)
+        .take(length)
+        .map(char::from)
+        .collect()
+}
+
+pub fn pkce_pair() -> (String, String) {
+    let verifier = random_string(64);
+    let challenge = URL_SAFE_NO_PAD.encode(Sha256::digest(verifier.as_bytes()));
+    (verifier, challenge)
+}
+
+pub async fn accept(
+    listener: &TcpListener,
+    accept_timeout: Duration,
+    accept_context: &str,
+    request_context: &str,
+) -> Result<(TcpStream, Vec<u8>)> {
+    let (mut stream, _) = timeout(accept_timeout, listener.accept())
+        .await
+        .with_context(|| accept_context.to_owned())??;
+    let request = timeout(Duration::from_secs(10), read_http_request(&mut stream))
+        .await
+        .with_context(|| request_context.to_owned())??;
+    Ok((stream, request))
+}
+
+pub async fn read_http_request(stream: &mut TcpStream) -> Result<Vec<u8>> {
+    const MAX_REQUEST_BYTES: usize = 16 * 1024;
+    let mut request = Vec::new();
+    let mut buffer = [0_u8; 2048];
+    loop {
+        let length = stream.read(&mut buffer).await?;
+        if length == 0 {
+            break;
+        }
+        request.extend_from_slice(&buffer[..length]);
+        if request.len() > MAX_REQUEST_BYTES {
+            bail!("OAuth callback exceeded {MAX_REQUEST_BYTES} bytes");
+        }
+        if request.windows(4).any(|window| window == b"\r\n\r\n") {
+            break;
+        }
+    }
+    if request.is_empty() {
+        bail!("OAuth callback closed without a request");
+    }
+    Ok(request)
+}
+
+pub async fn respond(
+    stream: &mut TcpStream,
+    status: &str,
+    title: &str,
+    message: &str,
+) -> Result<()> {
+    let body = format!("<html><body><h1>{title}</h1><p>{message}</p></body></html>");
+    let response = format!(
+        "HTTP/1.1 {status}\r\nContent-Type: text/html; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    );
+    stream.write_all(response.as_bytes()).await?;
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod auth;
+mod cloud;
 mod compare;
 mod config;
 mod dbt;
@@ -149,6 +150,15 @@ enum Command {
         /// Show every finding and impacted lineage node.
         #[arg(long)]
         verbose: bool,
+        /// Hand the exact validated working state to a durable Embrasure Cloud agent.
+        #[arg(long)]
+        cloud: bool,
+        /// Business intent used to create bounded validation assertions. Repeat to preserve ordering.
+        #[arg(long = "context", value_name = "BUSINESS_INTENT", requires = "cloud")]
+        context: Vec<String>,
+        /// Read additional business intent from a UTF-8 file.
+        #[arg(long, value_name = "PATH", requires = "cloud")]
+        context_file: Option<PathBuf>,
     },
     /// Check local tools, credentials, Snowflake permissions, and optional Metabase access.
     Doctor {
@@ -166,6 +176,11 @@ enum Command {
     Auth {
         #[command(subcommand)]
         command: AuthCommand,
+    },
+    /// Manage the optional Embrasure Cloud session and durable runs.
+    Cloud {
+        #[command(subcommand)]
+        command: CloudCommand,
     },
 }
 
@@ -193,6 +208,25 @@ enum AuthCommand {
         /// Configured account name. Optional when there is only one account.
         #[arg(long)]
         account: Option<String>,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+enum CloudCommand {
+    /// Sign in through the browser and save a separate OS-keychain session.
+    Login,
+    /// Show the signed-in Embrasure identity and workspace.
+    Whoami {
+        #[arg(long)]
+        json: bool,
+    },
+    /// Remove and revoke the saved Embrasure Cloud session.
+    Logout,
+    /// Show the latest handoff or a specified durable run.
+    Status {
+        run_id: Option<String>,
+        #[arg(long)]
+        json: bool,
     },
 }
 
@@ -240,19 +274,60 @@ async fn main() -> ExitCode {
             incremental_mode,
             report_version,
             verbose,
+            cloud: use_cloud,
+            context,
+            context_file,
         } => {
-            eprintln!("embrasure: validating changes against {base}");
-            let mut report = run::run_check(
-                &config,
-                &base,
-                run::CheckOptions {
-                    mode: mode.map(Into::into),
-                    downstream: downstream.map(Into::into),
-                    critical_tags: (!critical_tags.is_empty()).then_some(critical_tags),
-                    incremental_mode: incremental_mode.map(Into::into),
-                },
-            )
-            .await;
+            let options = run::CheckOptions {
+                mode: mode.map(Into::into),
+                downstream: downstream.map(Into::into),
+                critical_tags: (!critical_tags.is_empty()).then_some(critical_tags),
+                incremental_mode: incremental_mode.map(Into::into),
+            };
+            let intent = if use_cloud {
+                match cloud::normalize_context(&context, context_file.as_deref()) {
+                    Ok(value) => Some(value),
+                    Err(error) => {
+                        eprintln!("embrasure: {error:#}");
+                        return ExitCode::from(report::EXIT_EXECUTION);
+                    }
+                }
+            } else {
+                None
+            };
+            let snapshot = match cloud::prepare_snapshot(&config, &base, &options) {
+                Ok(value) => Some(value),
+                Err(error) if !use_cloud => {
+                    let _ = error;
+                    None
+                }
+                Err(error) => {
+                    eprintln!("embrasure: could not prepare cloud snapshot: {error:#}");
+                    return ExitCode::from(report::EXIT_EXECUTION);
+                }
+            };
+            let cached = snapshot
+                .as_ref()
+                .and_then(|value| cloud::cached_review(value).ok().flatten());
+            let mut report = if use_cloud {
+                if let Some(report) = cached {
+                    eprintln!("Reusing the local review for this exact working-tree state");
+                    report
+                } else {
+                    eprintln!(
+                        "The working tree or review configuration changed; rerunning local review"
+                    );
+                    run::run_check(&config, &base, options.clone()).await
+                }
+            } else {
+                eprintln!("embrasure: validating changes against {base}");
+                run::run_check(&config, &base, options.clone()).await
+            };
+            if let Some(snapshot) = &snapshot {
+                if let Err(error) = cloud::save_review(snapshot, &report) {
+                    eprintln!("embrasure: could not save the local review cache: {error:#}");
+                }
+            }
             if let Some(path) = markdown
                 && let Err(error) = report.write_markdown(&path)
             {
@@ -261,7 +336,54 @@ async fn main() -> ExitCode {
                     .push(format!("could not write Markdown report: {error:#}"));
                 report.finalize();
             }
-            if json {
+            if use_cloud {
+                if report.exit_code == report::EXIT_EXECUTION {
+                    if json {
+                        println!(
+                            "{}",
+                            serde_json::json!({"local_review": report, "cloud_handoff": null})
+                        );
+                    } else {
+                        print!("{}", report.human(verbose));
+                    }
+                    return ExitCode::from(report::EXIT_EXECUTION);
+                }
+                let snapshot = snapshot.expect("cloud snapshots are prepared before local review");
+                cloud::print_snapshot(&snapshot);
+                let progress = cloud::Progress::start("Handing off to Embrasure Cloud");
+                let receipt = cloud::handoff(
+                    &snapshot,
+                    &report,
+                    &base,
+                    intent.as_deref().unwrap_or_default(),
+                )
+                .await;
+                drop(progress);
+                match receipt {
+                    Ok(receipt) => {
+                        if json {
+                            println!("{}", serde_json::to_string_pretty(&serde_json::json!({"local_review": report, "cloud_handoff": receipt})).expect("cloud result is serializable"));
+                        } else {
+                            let downstream = report.impact.dbt_models.len();
+                            let exposures = report.impact.dbt_exposures.len()
+                                + report.impact.metabase_dashboards.len();
+                            println!(
+                                "\nCloud review accepted\nRun: {}\n{} downstream models and {} dashboard{} in scope\nYour laptop is no longer part of the execution path\nWatch: {}",
+                                receipt.run_id,
+                                downstream,
+                                exposures,
+                                if exposures == 1 { "" } else { "s" },
+                                receipt.run_url
+                            );
+                        }
+                        ExitCode::from(report.exit_code)
+                    }
+                    Err(error) => {
+                        eprintln!("embrasure: {error:#}");
+                        ExitCode::from(report::EXIT_EXECUTION)
+                    }
+                }
+            } else if json {
                 match report.json(report_version.unwrap_or(ReportVersionArg::V2).number()) {
                     Ok(value) => println!("{value}"),
                     Err(error) => {
@@ -269,10 +391,11 @@ async fn main() -> ExitCode {
                         return ExitCode::from(report::EXIT_EXECUTION);
                     }
                 }
+                ExitCode::from(report.exit_code)
             } else {
                 print!("{}", report.human(verbose));
+                ExitCode::from(report.exit_code)
             }
-            ExitCode::from(report.exit_code)
         }
         Command::Doctor {
             config,
@@ -342,6 +465,84 @@ async fn main() -> ExitCode {
                     }
                 }
             }
+        },
+        Command::Cloud { command } => match command {
+            CloudCommand::Login => match cloud::login().await {
+                Ok(session) => {
+                    println!(
+                        "Signed in to Embrasure Cloud.\nWorkspace: {}",
+                        session.workspace_id
+                    );
+                    ExitCode::SUCCESS
+                }
+                Err(error) => {
+                    eprintln!("embrasure: {error:#}");
+                    ExitCode::from(report::EXIT_EXECUTION)
+                }
+            },
+            CloudCommand::Whoami { json } => match cloud::whoami().await {
+                Ok(value) => {
+                    if json {
+                        println!("{}", serde_json::to_string_pretty(&value).unwrap());
+                    } else {
+                        println!(
+                            "Signed in as {}.\nWorkspace: {}",
+                            value
+                                .get("email")
+                                .or_else(|| value.get("user_id"))
+                                .and_then(|item| item.as_str())
+                                .unwrap_or("unknown"),
+                            value
+                                .get("workspace_id")
+                                .and_then(|item| item.as_str())
+                                .unwrap_or("selected during login")
+                        );
+                    }
+                    ExitCode::SUCCESS
+                }
+                Err(error) => {
+                    eprintln!("embrasure: {error:#}");
+                    ExitCode::from(report::EXIT_EXECUTION)
+                }
+            },
+            CloudCommand::Logout => match cloud::logout().await {
+                Ok(()) => {
+                    println!("Signed out of Embrasure Cloud.");
+                    ExitCode::SUCCESS
+                }
+                Err(error) => {
+                    eprintln!("embrasure: {error:#}");
+                    ExitCode::from(report::EXIT_EXECUTION)
+                }
+            },
+            CloudCommand::Status { run_id, json } => match cloud::status(run_id.as_deref()).await {
+                Ok(value) => {
+                    if json {
+                        println!("{}", serde_json::to_string_pretty(&value).unwrap());
+                    } else {
+                        println!(
+                            "Run: {}\nStatus: {}\nWatch: {}",
+                            value
+                                .get("run_id")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("unknown"),
+                            value
+                                .get("status")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("unknown"),
+                            value
+                                .get("run_url")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("unavailable")
+                        );
+                    }
+                    ExitCode::SUCCESS
+                }
+                Err(error) => {
+                    eprintln!("embrasure: {error:#}");
+                    ExitCode::from(report::EXIT_EXECUTION)
+                }
+            },
         },
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -351,13 +351,13 @@ async fn main() -> ExitCode {
                     eprintln!("embrasure: could not save the local review cache: {error:#}");
                 }
             }
-            if let Some(path) = markdown
-                && let Err(error) = report.write_markdown(&path)
-            {
-                report
-                    .execution_errors
-                    .push(format!("could not write Markdown report: {error:#}"));
-                report.finalize();
+            if let Some(path) = markdown {
+                if let Err(error) = report.write_markdown(&path) {
+                    report
+                        .execution_errors
+                        .push(format!("could not write Markdown report: {error:#}"));
+                    report.finalize();
+                }
             }
             let report_version = report_version.unwrap_or(report::ReportVersion::V2);
             if use_cloud {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,18 +1,23 @@
 mod auth;
+mod clean;
 mod cloud;
 mod compare;
 mod config;
 mod dbt;
 mod doctor;
+mod git;
 mod init;
+mod loopback;
 mod metabase;
 mod report;
 mod run;
 mod snowflake;
+mod style;
+mod update;
 
-use std::{path::PathBuf, process::ExitCode};
+use std::{io::IsTerminal, path::PathBuf, process::ExitCode};
 
-use clap::{Parser, Subcommand, ValueEnum};
+use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
 
 use crate::config::ComparisonMode;
 use crate::config::{DownstreamPolicy, IncrementalMode};
@@ -55,28 +60,18 @@ enum IncrementalModeArg {
     FullRefresh,
 }
 
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum CompletionShell {
+    Bash,
+    Zsh,
+    Fish,
+}
+
 impl From<IncrementalModeArg> for IncrementalMode {
     fn from(value: IncrementalModeArg) -> Self {
         match value {
             IncrementalModeArg::Clone => Self::Clone,
             IncrementalModeArg::FullRefresh => Self::FullRefresh,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, ValueEnum)]
-enum ReportVersionArg {
-    #[value(name = "1")]
-    V1,
-    #[value(name = "2")]
-    V2,
-}
-
-impl ReportVersionArg {
-    fn number(self) -> u8 {
-        match self {
-            Self::V1 => 1,
-            Self::V2 => 2,
         }
     }
 }
@@ -88,6 +83,9 @@ impl ReportVersionArg {
     about = "Validate dbt changes against production Snowflake data"
 )]
 struct Cli {
+    /// Configuration file.
+    #[arg(long, global = true, default_value = "embrasure-check.yml")]
+    config: PathBuf,
     #[command(subcommand)]
     command: Command,
 }
@@ -96,9 +94,6 @@ struct Cli {
 enum Command {
     /// Create a minimal configuration for the current dbt project.
     Init {
-        /// Configuration file to create.
-        #[arg(long, default_value = "embrasure-check.yml")]
-        config: PathBuf,
         /// Replace an existing configuration file.
         #[arg(long)]
         force: bool,
@@ -123,9 +118,6 @@ enum Command {
         /// Git revision used as the production comparison base.
         #[arg(long, default_value = "origin/main")]
         base: String,
-        /// Configuration file.
-        #[arg(long, default_value = "embrasure-check.yml")]
-        config: PathBuf,
         /// Emit exactly one versioned JSON document on stdout.
         #[arg(long)]
         json: bool,
@@ -146,10 +138,16 @@ enum Command {
         incremental_mode: Option<IncrementalModeArg>,
         /// JSON report contract version.
         #[arg(long, value_enum, requires = "json")]
-        report_version: Option<ReportVersionArg>,
+        report_version: Option<report::ReportVersion>,
         /// Show every finding and impacted lineage node.
         #[arg(long)]
         verbose: bool,
+        /// Validate only these changed models. Repeat for multiple models; combine with --downstream none for the fastest loop.
+        #[arg(long = "select", value_name = "MODEL")]
+        select: Vec<String>,
+        /// Plan validation without creating schemas or querying warehouse data.
+        #[arg(long, conflicts_with = "cloud")]
+        dry_run: bool,
         /// Hand the exact validated working state to a durable Embrasure Cloud agent.
         #[arg(long)]
         cloud: bool,
@@ -160,11 +158,8 @@ enum Command {
         #[arg(long, value_name = "PATH", requires = "cloud")]
         context_file: Option<PathBuf>,
     },
-    /// Check local tools, credentials, Snowflake permissions, and optional Metabase access.
+    /// Check local tools, credentials, Snowflake permissions, optional Metabase access, and available updates.
     Doctor {
-        /// Configuration file.
-        #[arg(long, default_value = "embrasure-check.yml")]
-        config: PathBuf,
         /// Skip the temporary schema create/drop permission test.
         #[arg(long)]
         read_only: bool,
@@ -182,29 +177,46 @@ enum Command {
         #[command(subcommand)]
         command: CloudCommand,
     },
+    /// Generate a shell completion script.
+    Completion {
+        #[arg(value_enum)]
+        shell: CompletionShell,
+    },
+    /// List or remove old Embrasure-managed temporary schemas.
+    Clean {
+        /// Minimum schema age in hours.
+        #[arg(long, default_value_t = 6)]
+        older_than: u64,
+        /// Remove matched schemas. Without this flag, only list them.
+        #[arg(long)]
+        yes: bool,
+        /// Emit one JSON document on stdout.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Check for or install the latest Embrasure release.
+    Update {
+        /// Report update availability without installing it.
+        #[arg(long)]
+        check: bool,
+    },
 }
 
 #[derive(Debug, Subcommand)]
 enum AuthCommand {
     /// Sign in to an account configured with type: oauth_local.
     Login {
-        #[arg(long, default_value = "embrasure-check.yml")]
-        config: PathBuf,
         /// Configured account name. Optional when there is only one account.
         #[arg(long)]
         account: Option<String>,
     },
     /// Show whether credentials are ready, without printing secrets.
     Status {
-        #[arg(long, default_value = "embrasure-check.yml")]
-        config: PathBuf,
         #[arg(long)]
         json: bool,
     },
     /// Remove the cached browser session for an account.
     Logout {
-        #[arg(long, default_value = "embrasure-check.yml")]
-        config: PathBuf,
         /// Configured account name. Optional when there is only one account.
         #[arg(long)]
         account: Option<String>,
@@ -233,9 +245,9 @@ enum CloudCommand {
 #[tokio::main]
 async fn main() -> ExitCode {
     let cli = Cli::parse();
+    let config = cli.config;
     match cli.command {
         Command::Init {
-            config,
             force,
             profile,
             account,
@@ -258,14 +270,10 @@ async fn main() -> ExitCode {
             },
         ) {
             Ok(()) => ExitCode::SUCCESS,
-            Err(error) => {
-                eprintln!("embrasure: {error:#}");
-                ExitCode::from(report::EXIT_EXECUTION)
-            }
+            Err(error) => fail(error),
         },
         Command::Check {
             base,
-            config,
             json,
             markdown,
             mode,
@@ -274,6 +282,8 @@ async fn main() -> ExitCode {
             incremental_mode,
             report_version,
             verbose,
+            select,
+            dry_run,
             cloud: use_cloud,
             context,
             context_file,
@@ -283,28 +293,30 @@ async fn main() -> ExitCode {
                 downstream: downstream.map(Into::into),
                 critical_tags: (!critical_tags.is_empty()).then_some(critical_tags),
                 incremental_mode: incremental_mode.map(Into::into),
+                select,
             };
             let intent = if use_cloud {
                 match cloud::normalize_context(&context, context_file.as_deref()) {
                     Ok(value) => Some(value),
-                    Err(error) => {
-                        eprintln!("embrasure: {error:#}");
-                        return ExitCode::from(report::EXIT_EXECUTION);
-                    }
+                    Err(error) => return fail(error),
                 }
             } else {
                 None
             };
-            let snapshot = match cloud::prepare_snapshot(&config, &base, &options) {
-                Ok(value) => Some(value),
-                Err(error) if !use_cloud => {
-                    let _ = error;
-                    None
+            let loaded_config = run::load_config(&config, &options);
+            let snapshot = match loaded_config.as_ref() {
+                Ok(loaded) if use_cloud => {
+                    match cloud::prepare_snapshot(&config, loaded, &base, &options) {
+                        Ok(value) => Some(value),
+                        Err(error) => {
+                            return fail(format_args!(
+                                "could not prepare cloud snapshot: {error:#}"
+                            ));
+                        }
+                    }
                 }
-                Err(error) => {
-                    eprintln!("embrasure: could not prepare cloud snapshot: {error:#}");
-                    return ExitCode::from(report::EXIT_EXECUTION);
-                }
+                Ok(loaded) => cloud::prepare_snapshot(&config, loaded, &base, &options).ok(),
+                Err(_) => None,
             };
             let cached = snapshot
                 .as_ref()
@@ -317,11 +329,21 @@ async fn main() -> ExitCode {
                     eprintln!(
                         "The working tree or review configuration changed; rerunning local review"
                     );
-                    run::run_check(&config, &base, options.clone()).await
+                    match loaded_config {
+                        Ok(config) => {
+                            run::run_check_with_config(config, &base, &options, dry_run).await
+                        }
+                        Err(error) => run::failed_check(&base, error),
+                    }
                 }
             } else {
                 eprintln!("embrasure: validating changes against {base}");
-                run::run_check(&config, &base, options.clone()).await
+                match loaded_config {
+                    Ok(config) => {
+                        run::run_check_with_config(config, &base, &options, dry_run).await
+                    }
+                    Err(error) => run::failed_check(&base, error),
+                }
             };
             if let Some(snapshot) = &snapshot {
                 if let Err(error) = cloud::save_review(snapshot, &report) {
@@ -336,15 +358,13 @@ async fn main() -> ExitCode {
                     .push(format!("could not write Markdown report: {error:#}"));
                 report.finalize();
             }
+            let report_version = report_version.unwrap_or(report::ReportVersion::V2);
             if use_cloud {
                 if report.exit_code == report::EXIT_EXECUTION {
                     if json {
-                        println!(
-                            "{}",
-                            serde_json::json!({"local_review": report, "cloud_handoff": null})
-                        );
+                        println!("{}", cloud_result_json(&report, None, report_version));
                     } else {
-                        print!("{}", report.human(verbose));
+                        print!("{}", report.human_styled(verbose, &style::Style::stdout()));
                     }
                     return ExitCode::from(report::EXIT_EXECUTION);
                 }
@@ -362,7 +382,10 @@ async fn main() -> ExitCode {
                 match receipt {
                     Ok(receipt) => {
                         if json {
-                            println!("{}", serde_json::to_string_pretty(&serde_json::json!({"local_review": report, "cloud_handoff": receipt})).expect("cloud result is serializable"));
+                            println!(
+                                "{}",
+                                cloud_result_json(&report, Some(&receipt), report_version)
+                            );
                         } else {
                             let downstream = report.impact.dbt_models.len();
                             let exposures = report.impact.dbt_exposures.len()
@@ -379,36 +402,37 @@ async fn main() -> ExitCode {
                         ExitCode::from(report.exit_code)
                     }
                     Err(error) => {
-                        eprintln!("embrasure: {error:#}");
-                        ExitCode::from(report::EXIT_EXECUTION)
+                        if json {
+                            println!("{}", cloud_result_json(&report, None, report_version));
+                        }
+                        fail(error)
                     }
                 }
             } else if json {
-                match report.json(report_version.unwrap_or(ReportVersionArg::V2).number()) {
+                match report.json(report_version) {
                     Ok(value) => println!("{value}"),
                     Err(error) => {
-                        eprintln!("embrasure: could not serialize JSON report: {error}");
-                        return ExitCode::from(report::EXIT_EXECUTION);
+                        return fail(format_args!("could not serialize JSON report: {error}"));
                     }
                 }
                 ExitCode::from(report.exit_code)
             } else {
-                print!("{}", report.human(verbose));
+                print!("{}", report.human_styled(verbose, &style::Style::stdout()));
                 ExitCode::from(report.exit_code)
             }
         }
-        Command::Doctor {
-            config,
-            read_only,
-            json,
-        } => {
+        Command::Doctor { read_only, json } => {
             let report = doctor::run(&config, !read_only).await;
             if json {
-                println!("{}", serde_json::to_string_pretty(&report).unwrap_or_else(|error| {
-                    format!(r#"{{"status":"error","message":"could not serialize report: {error}"}}"#)
-                }));
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&report).expect("doctor report is serializable")
+                );
             } else {
-                print!("{}", report.human());
+                print!("{}", report.human_styled(&style::Style::stdout()));
+                if let Some(notice) = update::doctor_notice().await {
+                    eprintln!("{notice}");
+                }
             }
             ExitCode::from(if report.ready {
                 0
@@ -417,19 +441,16 @@ async fn main() -> ExitCode {
             })
         }
         Command::Auth { command } => match command {
-            AuthCommand::Login { config, account } => {
+            AuthCommand::Login { account } => {
                 match auth::login_from_config(&config, account.as_deref()).await {
                     Ok(name) => {
                         println!("Signed in to Snowflake account {name}.");
                         ExitCode::SUCCESS
                     }
-                    Err(error) => {
-                        eprintln!("embrasure: {error:#}");
-                        ExitCode::from(report::EXIT_EXECUTION)
-                    }
+                    Err(error) => fail(error),
                 }
             }
-            AuthCommand::Status { config, json } => match auth::status_from_config(&config) {
+            AuthCommand::Status { json } => match auth::status_from_config(&config) {
                 Ok(statuses) => {
                     if json {
                         println!(
@@ -448,21 +469,15 @@ async fn main() -> ExitCode {
                         report::EXIT_EXECUTION
                     })
                 }
-                Err(error) => {
-                    eprintln!("embrasure: {error:#}");
-                    ExitCode::from(report::EXIT_EXECUTION)
-                }
+                Err(error) => fail(error),
             },
-            AuthCommand::Logout { config, account } => {
+            AuthCommand::Logout { account } => {
                 match auth::logout_from_config(&config, account.as_deref()) {
                     Ok(name) => {
                         println!("Removed the cached Snowflake session for account {name}.");
                         ExitCode::SUCCESS
                     }
-                    Err(error) => {
-                        eprintln!("embrasure: {error:#}");
-                        ExitCode::from(report::EXIT_EXECUTION)
-                    }
+                    Err(error) => fail(error),
                 }
             }
         },
@@ -475,15 +490,16 @@ async fn main() -> ExitCode {
                     );
                     ExitCode::SUCCESS
                 }
-                Err(error) => {
-                    eprintln!("embrasure: {error:#}");
-                    ExitCode::from(report::EXIT_EXECUTION)
-                }
+                Err(error) => fail(error),
             },
             CloudCommand::Whoami { json } => match cloud::whoami().await {
                 Ok(value) => {
                     if json {
-                        println!("{}", serde_json::to_string_pretty(&value).unwrap());
+                        println!(
+                            "{}",
+                            serde_json::to_string_pretty(&value)
+                                .expect("cloud identity is serializable")
+                        );
                     } else {
                         println!(
                             "Signed in as {}.\nWorkspace: {}",
@@ -500,25 +516,23 @@ async fn main() -> ExitCode {
                     }
                     ExitCode::SUCCESS
                 }
-                Err(error) => {
-                    eprintln!("embrasure: {error:#}");
-                    ExitCode::from(report::EXIT_EXECUTION)
-                }
+                Err(error) => fail(error),
             },
             CloudCommand::Logout => match cloud::logout().await {
                 Ok(()) => {
                     println!("Signed out of Embrasure Cloud.");
                     ExitCode::SUCCESS
                 }
-                Err(error) => {
-                    eprintln!("embrasure: {error:#}");
-                    ExitCode::from(report::EXIT_EXECUTION)
-                }
+                Err(error) => fail(error),
             },
             CloudCommand::Status { run_id, json } => match cloud::status(run_id.as_deref()).await {
                 Ok(value) => {
                     if json {
-                        println!("{}", serde_json::to_string_pretty(&value).unwrap());
+                        println!(
+                            "{}",
+                            serde_json::to_string_pretty(&value)
+                                .expect("cloud status is serializable")
+                        );
                     } else {
                         println!(
                             "Run: {}\nStatus: {}\nWatch: {}",
@@ -538,11 +552,94 @@ async fn main() -> ExitCode {
                     }
                     ExitCode::SUCCESS
                 }
-                Err(error) => {
-                    eprintln!("embrasure: {error:#}");
-                    ExitCode::from(report::EXIT_EXECUTION)
-                }
+                Err(error) => fail(error),
             },
         },
+        Command::Completion { shell } => {
+            let mut command = Cli::command();
+            let mut stdout = std::io::stdout();
+            match shell {
+                CompletionShell::Bash => clap_complete::generate(
+                    clap_complete::shells::Bash,
+                    &mut command,
+                    "embrasure",
+                    &mut stdout,
+                ),
+                CompletionShell::Zsh => clap_complete::generate(
+                    clap_complete::shells::Zsh,
+                    &mut command,
+                    "embrasure",
+                    &mut stdout,
+                ),
+                CompletionShell::Fish => clap_complete::generate(
+                    clap_complete::shells::Fish,
+                    &mut command,
+                    "embrasure",
+                    &mut stdout,
+                ),
+            }
+            if std::io::stderr().is_terminal() {
+                let hint = match shell {
+                    CompletionShell::Bash => {
+                        "Source this script from your Bash profile or completion directory."
+                    }
+                    CompletionShell::Zsh => {
+                        "Save this script in a directory listed by your Zsh fpath."
+                    }
+                    CompletionShell::Fish => {
+                        "Save this script as ~/.config/fish/completions/embrasure.fish."
+                    }
+                };
+                eprintln!("{hint}");
+            }
+            ExitCode::SUCCESS
+        }
+        Command::Clean {
+            older_than,
+            yes,
+            json,
+        } => {
+            let result = clean::run(&config, older_than, yes).await;
+            if json {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&result).expect("clean report is serializable")
+                );
+            } else {
+                print!("{}", result.human());
+            }
+            ExitCode::from(if result.errors.is_empty() {
+                report::EXIT_PASS
+            } else {
+                report::EXIT_EXECUTION
+            })
+        }
+        Command::Update { check } => match update::run(check).await {
+            Ok(message) => {
+                println!("{message}");
+                ExitCode::SUCCESS
+            }
+            Err(error) => fail(error),
+        },
     }
+}
+
+fn cloud_result_json(
+    report: &report::Report,
+    receipt: Option<&cloud::HandoffReceipt>,
+    version: report::ReportVersion,
+) -> String {
+    serde_json::to_string_pretty(&serde_json::json!({
+        "local_review": report
+            .json_value(version)
+            .expect("local review is serializable"),
+        "cloud_handoff": receipt,
+    }))
+    .expect("cloud result is serializable")
+}
+
+fn fail(error: impl std::fmt::Display) -> ExitCode {
+    let style = style::Style::stderr();
+    eprintln!("{}: {error:#}", style.bad("embrasure"));
+    ExitCode::from(report::EXIT_EXECUTION)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -315,6 +315,7 @@ async fn main() -> ExitCode {
                         }
                     }
                 }
+                Ok(_) if dry_run => None,
                 Ok(loaded) => cloud::prepare_snapshot(&config, loaded, &base, &options).ok(),
                 Err(_) => None,
             };

--- a/src/report.rs
+++ b/src/report.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Write as _, fs, path::Path};
 
 use anyhow::{Context, Result};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::config::{CrossAccountDependency, DownstreamPolicy, Thresholds};
 
@@ -10,7 +10,7 @@ pub const EXIT_FINDINGS: u8 = 1;
 pub const EXIT_INCOMPLETE: u8 = 2;
 pub const EXIT_EXECUTION: u8 = 3;
 
-#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum Status {
     Pass,
@@ -19,7 +19,7 @@ pub enum Status {
     ExecutionFailure,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Report {
     pub schema_version: u8,
     pub status: Status,
@@ -37,7 +37,7 @@ pub struct Report {
     pub execution_errors: Vec<String>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct CiSchema {
     pub account: String,
     pub database: String,
@@ -45,7 +45,7 @@ pub struct CiSchema {
     pub cleaned_up: bool,
 }
 
-#[derive(Debug, Clone, Default, Serialize)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct Summary {
     pub models_selected: usize,
     pub models_built: usize,
@@ -54,7 +54,7 @@ pub struct Summary {
     pub coverage_gaps: usize,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ModelReport {
     pub unique_id: String,
     pub name: String,
@@ -66,7 +66,7 @@ pub struct ModelReport {
     pub comparison: Option<ModelComparison>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ModelComparison {
     pub ci_row_count: u64,
     pub production_row_count: u64,
@@ -75,7 +75,7 @@ pub struct ModelComparison {
     pub primary_key: Option<PrimaryKeyComparison>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ColumnComparison {
     pub name: String,
     pub ci_type: Option<String>,
@@ -84,7 +84,7 @@ pub struct ColumnComparison {
     pub production: Option<ColumnMetrics>,
 }
 
-#[derive(Debug, Clone, Default, Serialize)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct ColumnMetrics {
     pub null_count: u64,
     pub null_rate: f64,
@@ -103,7 +103,7 @@ pub struct ColumnMetrics {
     pub p95: Option<f64>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct PrimaryKeyComparison {
     pub columns: Vec<String>,
     pub ci_only_count: u64,
@@ -119,28 +119,28 @@ pub struct PrimaryKeyComparison {
     pub ci_duplicate_examples: Vec<Vec<Option<String>>>,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Finding {
     pub model: String,
     pub check: String,
     pub message: String,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct CoverageGap {
     pub scope: String,
     pub check: String,
     pub reason: String,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Notice {
     pub scope: String,
     pub code: String,
     pub message: String,
 }
 
-#[derive(Debug, Clone, Default, Serialize)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct ValidationScope {
     pub downstream: DownstreamPolicy,
     pub impacted_models: usize,
@@ -149,13 +149,13 @@ pub struct ValidationScope {
     pub skipped_models: Vec<SkippedModel>,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SkippedModel {
     pub id: String,
     pub reason: String,
 }
 
-#[derive(Debug, Clone, Default, Serialize)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct ImpactReport {
     pub dbt_models: Vec<ImpactedAsset>,
     pub dbt_exposures: Vec<ImpactedAsset>,
@@ -165,7 +165,7 @@ pub struct ImpactReport {
     pub cross_account_dependencies: Vec<CrossAccountDependency>,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ImpactedAsset {
     pub id: String,
     pub name: String,
@@ -173,7 +173,7 @@ pub struct ImpactedAsset {
     pub url: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct LineageEdge {
     pub from: String,
     pub from_name: String,
@@ -181,14 +181,14 @@ pub struct LineageEdge {
     pub to_name: String,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(rename_all = "snake_case")]
 pub enum LineageChangeKind {
     Added,
     Removed,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct LineageChange {
     pub change: LineageChangeKind,
     pub edge: LineageEdge,

--- a/src/report.rs
+++ b/src/report.rs
@@ -3,12 +3,23 @@ use std::{fmt::Write as _, fs, path::Path};
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
-use crate::config::{CrossAccountDependency, DownstreamPolicy, Thresholds};
+use crate::{
+    config::{CrossAccountDependency, DownstreamPolicy, Thresholds},
+    style::Style,
+};
 
 pub const EXIT_PASS: u8 = 0;
 pub const EXIT_FINDINGS: u8 = 1;
 pub const EXIT_INCOMPLETE: u8 = 2;
 pub const EXIT_EXECUTION: u8 = 3;
+
+#[derive(Debug, Clone, Copy, clap::ValueEnum)]
+pub enum ReportVersion {
+    #[value(name = "1")]
+    V1,
+    #[value(name = "2")]
+    V2,
+}
 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -285,12 +296,17 @@ impl Report {
             .with_context(|| format!("could not write Markdown report {}", path.display()))
     }
 
+    #[cfg(test)]
     pub fn human(&self, verbose: bool) -> String {
+        self.human_styled(verbose, &Style::plain())
+    }
+
+    pub fn human_styled(&self, verbose: bool, style: &Style) -> String {
         let label = match self.status {
-            Status::Pass => "PASS",
-            Status::Findings => "FINDINGS",
-            Status::Incomplete => "INCOMPLETE",
-            Status::ExecutionFailure => "EXECUTION FAILURE",
+            Status::Pass => style.good("PASS"),
+            Status::Findings => style.bad("FINDINGS"),
+            Status::Incomplete => style.warn("INCOMPLETE"),
+            Status::ExecutionFailure => style.bad("EXECUTION FAILURE"),
         };
         let mut output = format!(
             "embrasure: {label}\n{} selected · {} built · {} compared · {} findings · {} coverage gaps\n{} impacted · {} validated · {} not validated\n",
@@ -338,16 +354,18 @@ impl Report {
                 );
             }
         }
-        for model in self.models.iter().filter(|_| verbose) {
-            if let Some(comparison) = &model.comparison {
-                let _ = writeln!(
-                    output,
-                    "- [evidence] {}: {} CI rows vs {} production rows across {} columns",
-                    model.unique_id,
-                    comparison.ci_row_count,
-                    comparison.production_row_count,
-                    comparison.columns.len(),
-                );
+        if verbose {
+            for model in &self.models {
+                if let Some(comparison) = &model.comparison {
+                    let _ = writeln!(
+                        output,
+                        "- [evidence] {}: {} CI rows vs {} production rows across {} columns",
+                        model.unique_id,
+                        comparison.ci_row_count,
+                        comparison.production_row_count,
+                        comparison.columns.len(),
+                    );
+                }
             }
         }
         self.write_human_lineage(&mut output, verbose);
@@ -378,11 +396,15 @@ impl Report {
         output
     }
 
-    pub fn json(&self, version: u8) -> serde_json::Result<String> {
+    pub fn json_value(&self, version: ReportVersion) -> serde_json::Result<serde_json::Value> {
         match version {
-            1 => serde_json::to_string_pretty(&ReportV1::from(self)),
-            _ => serde_json::to_string_pretty(self),
+            ReportVersion::V1 => serde_json::to_value(ReportV1::from(self)),
+            ReportVersion::V2 => serde_json::to_value(self),
         }
+    }
+
+    pub fn json(&self, version: ReportVersion) -> serde_json::Result<String> {
+        serde_json::to_string_pretty(&self.json_value(version)?)
     }
 
     pub fn markdown(&self) -> String {
@@ -920,13 +942,13 @@ mod tests {
         report
     }
 
-    fn assert_matches_schema(report: &Report, version: u8, schema: &str) {
+    fn assert_matches_schema(report: &Report, version: ReportVersion, schema: &str) {
         let schema: serde_json::Value = serde_json::from_str(schema).unwrap();
         let validator = jsonschema::validator_for(&schema).unwrap();
         let instance: serde_json::Value =
             serde_json::from_str(&report.json(version).unwrap()).unwrap();
         if let Err(error) = validator.validate(&instance) {
-            panic!("report v{version} violates its schema: {error}");
+            panic!("report violates its schema: {error}");
         }
     }
 
@@ -985,10 +1007,19 @@ mod tests {
     #[test]
     fn reports_match_their_published_json_schemas() {
         let report = representative_report();
-        assert_matches_schema(&report, 1, include_str!("../schemas/report-v1.schema.json"));
-        assert_matches_schema(&report, 2, include_str!("../schemas/report-v2.schema.json"));
+        assert_matches_schema(
+            &report,
+            ReportVersion::V1,
+            include_str!("../schemas/report-v1.schema.json"),
+        );
+        assert_matches_schema(
+            &report,
+            ReportVersion::V2,
+            include_str!("../schemas/report-v2.schema.json"),
+        );
 
-        let v1: serde_json::Value = serde_json::from_str(&report.json(1).unwrap()).unwrap();
+        let v1: serde_json::Value =
+            serde_json::from_str(&report.json(ReportVersion::V1).unwrap()).unwrap();
         assert!(v1.get("validation_scope").is_none());
         assert!(v1["models"][0].get("build_strategy").is_none());
         assert!(

--- a/src/run.rs
+++ b/src/run.rs
@@ -21,6 +21,7 @@ use crate::{
     snowflake::{Relation, SnowflakeClient, is_managed_schema},
 };
 
+#[cfg(test)]
 pub async fn run_check(config_path: &Path, base: &str, options: CheckOptions) -> Report {
     if base.trim().is_empty() || base.starts_with('-') {
         return error_report(
@@ -28,36 +29,58 @@ pub async fn run_check(config_path: &Path, base: &str, options: CheckOptions) ->
             anyhow::anyhow!("--base must be a non-empty Git revision and must not start with '-'"),
         );
     }
-    let mut config = match Config::load(config_path) {
+    let config = match load_config(config_path, &options) {
         Ok(config) => config,
         Err(error) => return error_report(base, error),
     };
+    run_check_with_config(config, base, &options, false).await
+}
+
+pub fn load_config(config_path: &Path, options: &CheckOptions) -> Result<Config> {
+    let mut config = Config::load(config_path)?;
     if let Some(mode) = options.mode {
         config.comparison.mode = mode;
     }
     if let Some(downstream) = options.downstream {
         config.validation.downstream = downstream;
     }
-    if let Some(tags) = options.critical_tags {
+    if let Some(tags) = &options.critical_tags {
         if tags.iter().any(|tag| tag.trim().is_empty()) {
-            return error_report(base, anyhow::anyhow!("--critical-tag must not be empty"));
+            bail!("--critical-tag must not be empty");
         }
-        config.validation.critical_tags = tags;
+        config.validation.critical_tags = tags.clone();
     }
     if let Some(mode) = options.incremental_mode {
         config.validation.incremental_mode = mode;
     }
-    if let Err(error) = config.resolve_from(config_path) {
-        return error_report(base, error);
+    config.resolve_from(config_path)?;
+    Ok(config)
+}
+
+pub async fn run_check_with_config(
+    config: Config,
+    base: &str,
+    options: &CheckOptions,
+    dry_run: bool,
+) -> Report {
+    if base.trim().is_empty() || base.starts_with('-') {
+        return error_report(
+            base,
+            anyhow::anyhow!("--base must be a non-empty Git revision and must not start with '-'"),
+        );
     }
     let mut report = Report::empty(base.to_owned(), config.thresholds);
     report.validation_scope.downstream = config.validation.downstream;
-    let run_result = execute(&config, base, &mut report).await;
+    let run_result = execute(&config, base, options, dry_run, &mut report).await;
     if let Err(error) = run_result {
-        report.execution_errors.push(format_error(&error));
+        report.execution_errors.push(format!("{error:#}"));
     }
     report.finalize();
     report
+}
+
+pub fn failed_check(base: &str, error: anyhow::Error) -> Report {
+    error_report(base, error)
 }
 
 #[derive(Debug, Clone, Default)]
@@ -66,9 +89,16 @@ pub struct CheckOptions {
     pub downstream: Option<DownstreamPolicy>,
     pub critical_tags: Option<Vec<String>>,
     pub incremental_mode: Option<IncrementalMode>,
+    pub select: Vec<String>,
 }
 
-async fn execute(config: &Config, base: &str, report: &mut Report) -> Result<()> {
+async fn execute(
+    config: &Config,
+    base: &str,
+    options: &CheckOptions,
+    dry_run: bool,
+    report: &mut Report,
+) -> Result<()> {
     let resolved_auth = auth::resolve_all(config)
         .await
         .context("could not resolve Snowflake credentials")?;
@@ -78,39 +108,52 @@ async fn execute(config: &Config, base: &str, report: &mut Report) -> Result<()>
 
     let main_result = {
         let main = async {
-            for account in &config.accounts {
-                let client = SnowflakeClient::new(
-                    account,
-                    resolved_auth
-                        .get(&account.name)
-                        .context("resolved Snowflake credential was not retained")?,
-                    query_tag.clone(),
-                    config.safety.statement_timeout_seconds,
-                )
-                .with_context(|| {
-                    format!("could not initialize Snowflake account {}", account.name)
-                })?;
-                clients.push(client);
-            }
-
-            let mut context = dbt::prepare(config, &resolved_auth, base, &schema, &query_tag)?;
-            let selections = plan_selections(config, &context, report)?;
-            let result = if let Some(selections) = selections {
-                for (index, account) in config.accounts.iter().enumerate() {
+            if !dry_run {
+                for account in &config.accounts {
+                    let client = SnowflakeClient::new(
+                        account,
+                        resolved_auth
+                            .get(&account.name)
+                            .context("resolved Snowflake credential was not retained")?,
+                        query_tag.clone(),
+                        config.safety.statement_timeout_seconds,
+                    )
+                    .with_context(|| {
+                        format!("could not initialize Snowflake account {}", account.name)
+                    })?;
                     report.ci_schemas.push(CiSchema {
                         account: account.name.clone(),
                         database: account.database.clone(),
                         schema: schema.clone(),
                         cleaned_up: false,
                     });
-                    clients[index]
+                    client
                         .create_schema(&account.database, &schema)
                         .await
                         .with_context(|| {
                             format!("could not create CI schema for account {}", account.name)
                         })?;
+                    clients.push(client);
                 }
-                execute_with_dbt(config, &mut context, &clients, &schema, &selections, report).await
+            }
+
+            let mut context = dbt::prepare(config, &resolved_auth, base, &schema, &query_tag)?;
+            let selections = plan_selections(config, &context, options, report)?;
+            let result = if let Some(selections) = selections {
+                if dry_run {
+                    plan_model_reports(config, &context, &selections, "planned", report)?;
+                    report.notices.push(Notice {
+                        scope: "validation".into(),
+                        code: "dry_run".into(),
+                        message:
+                            "planned validation without creating schemas or querying warehouse data"
+                                .into(),
+                    });
+                    Ok(())
+                } else {
+                    execute_with_dbt(config, &mut context, &clients, &schema, &selections, report)
+                        .await
+                }
             } else {
                 Ok(())
             };
@@ -132,7 +175,7 @@ async fn execute(config: &Config, base: &str, report: &mut Report) -> Result<()>
     };
 
     if let Err(error) = main_result {
-        report.execution_errors.push(format_error(&error));
+        report.execution_errors.push(format!("{error:#}"));
     }
     cleanup_schemas(config, &clients, &schema, report).await;
     Ok(())
@@ -144,9 +187,52 @@ struct AccountSelection {
     removed: BTreeSet<String>,
 }
 
+fn resolve_selected_models(
+    config: &Config,
+    context: &DbtContext,
+    requested: &[String],
+) -> Result<Vec<BTreeSet<String>>> {
+    let mut chosen = vec![BTreeSet::new(); config.accounts.len()];
+    for value in requested {
+        let mut matches = Vec::new();
+        for (index, account) in config.accounts.iter().enumerate() {
+            let manifest = context.manifest(&account.name)?;
+            if let Some(id) = manifest.node_id(value) {
+                if manifest
+                    .nodes
+                    .get(&id)
+                    .is_some_and(|node| node.resource_type == "model")
+                {
+                    matches.push((index, id));
+                }
+            } else if manifest
+                .nodes
+                .values()
+                .filter(|node| node.resource_type == "model" && node.name == *value)
+                .count()
+                > 1
+            {
+                bail!(
+                    "--select model {value} is ambiguous in account {}",
+                    account.name
+                );
+            }
+        }
+        match matches.as_slice() {
+            [] => bail!("--select model {value} is unknown"),
+            [(index, id)] => {
+                chosen[*index].insert(id.clone());
+            }
+            _ => bail!("--select model {value} is ambiguous across configured accounts"),
+        }
+    }
+    Ok(chosen)
+}
+
 fn plan_selections(
     config: &Config,
     context: &DbtContext,
+    options: &CheckOptions,
     report: &mut Report,
 ) -> Result<Option<Vec<AccountSelection>>> {
     let changed_paths = context.changed_paths(&report.base)?;
@@ -158,7 +244,8 @@ fn plan_selections(
         .collect::<BTreeSet<_>>();
     let mut selections = Vec::new();
     let mut selected_count = 0;
-    for account in &config.accounts {
+    let chosen = resolve_selected_models(config, context, &options.select)?;
+    for (account_index, account) in config.accounts.iter().enumerate() {
         let manifest = context.manifest(&account.name)?;
         let production = context.production_manifest(&account.name)?;
         report
@@ -209,7 +296,7 @@ fn plan_selections(
             })
             .map(|node| node.unique_id.clone())
             .collect::<BTreeSet<_>>();
-        let selected = match config.validation.downstream {
+        let mut selected = match config.validation.downstream {
             DownstreamPolicy::None => changed.clone(),
             DownstreamPolicy::All => current_impacted
                 .union(&surviving_removed_impact)
@@ -236,6 +323,22 @@ fn plan_selections(
                 selected
             }
         };
+        if !options.select.is_empty() {
+            for id in &chosen[account_index] {
+                if !selected.contains(id) {
+                    bail!(
+                        "--select model {id} is not changed or is outside the requested downstream scope"
+                    );
+                }
+            }
+            for id in selected.difference(&chosen[account_index]) {
+                report.validation_scope.skipped_models.push(SkippedModel {
+                    id: format!("{}:{id}", account.name),
+                    reason: "excluded by --select".into(),
+                });
+            }
+            selected.retain(|id| chosen[account_index].contains(id));
+        }
         let impacted = current_impacted
             .union(&removed_impacted)
             .cloned()
@@ -302,6 +405,73 @@ async fn termination_signal() -> Result<()> {
     Ok(())
 }
 
+fn plan_model_reports(
+    config: &Config,
+    context: &DbtContext,
+    selections: &[AccountSelection],
+    dbt_build: &str,
+    report: &mut Report,
+) -> Result<Vec<(String, Relation)>> {
+    let mut production_relations = Vec::new();
+    for (account, selection) in config.accounts.iter().zip(selections) {
+        let manifest = context.manifest(&account.name)?;
+        let production = context.production_manifest(&account.name)?;
+        for id in &selection.removed {
+            let node = &production.nodes[id];
+            production_relations.push((
+                id.clone(),
+                relation_for(node, &account.database, &node.schema),
+            ));
+            if !model_config(config, id, &node.name).allow_removal {
+                report.findings.push(Finding {
+                    check: "model_removed".into(),
+                    model: id.clone(),
+                    message: "dbt model exists at the base revision but is absent from the current manifest; set models.<unique_id>.allow_removal only after confirming the deletion and downstream migration".into(),
+                });
+            }
+        }
+        for id in &selection.selected {
+            let node = manifest.nodes.get(id).with_context(|| {
+                format!("selected dbt model {id} is absent from current manifest")
+            })?;
+            let ci_relation = relation_for(node, &account.database, &node.schema);
+            let production_relation = production
+                .nodes
+                .get(id)
+                .map(|production| relation_for(production, &account.database, &production.schema));
+            production_relations.push((
+                id.clone(),
+                production_relation.clone().unwrap_or_else(|| {
+                    relation_for(node, &account.database, &account.production_schema)
+                }),
+            ));
+            let build_strategy = if manifest.is_incremental(id) {
+                if production_relation.is_none() {
+                    "first_build"
+                } else {
+                    match config.validation.incremental_mode {
+                        IncrementalMode::Clone => "incremental_clone",
+                        IncrementalMode::FullRefresh => "full_refresh",
+                    }
+                }
+            } else {
+                "standard"
+            };
+            report.models.push(ModelReport {
+                unique_id: id.clone(),
+                name: node.name.clone(),
+                account: account.name.clone(),
+                ci_relation: ci_relation.sql(),
+                production_relation: production_relation.as_ref().map(Relation::sql),
+                dbt_build: dbt_build.into(),
+                build_strategy: build_strategy.into(),
+                comparison: None,
+            });
+        }
+    }
+    Ok(production_relations)
+}
+
 async fn execute_with_dbt(
     config: &Config,
     context: &mut DbtContext,
@@ -310,26 +480,12 @@ async fn execute_with_dbt(
     selections: &[AccountSelection],
     report: &mut Report,
 ) -> Result<()> {
+    let removed_production_relations =
+        plan_model_reports(config, context, selections, "pending", report)?;
     let mut all_selected = BTreeSet::new();
-    let mut removed_production_relations = Vec::new();
-    for (account, selection) in config.accounts.iter().zip(selections) {
-        let production_manifest = context.production_manifest(&account.name)?;
+    for selection in selections {
         all_selected.extend(selection.removed.iter().cloned());
         all_selected.extend(selection.selected.iter().cloned());
-        for model in &selection.removed {
-            let production_node = &production_manifest.nodes[model];
-            removed_production_relations.push((
-                model.clone(),
-                relation_for(production_node, &account.database, &production_node.schema),
-            ));
-            if !model_config(config, model, &production_node.name).allow_removal {
-                report.findings.push(Finding {
-                    check: "model_removed".into(),
-                    model: model.clone(),
-                    message: "dbt model exists at the base revision but is absent from the current manifest; set models.<unique_id>.allow_removal only after confirming the deletion and downstream migration".into(),
-                });
-            }
-        }
     }
 
     for (index, selection) in selections.iter().enumerate() {
@@ -479,51 +635,12 @@ async fn execute_with_dbt(
             });
         }
     }
-    let mut production_relations = removed_production_relations;
+    let production_relations = removed_production_relations;
     let mut comparison_jobs = Vec::new();
     for (index, (account, selection)) in config.accounts.iter().zip(selections).enumerate() {
         let selected = &selection.selected;
         let manifest = context.manifest(&account.name)?;
         let production_manifest = context.production_manifest(&account.name)?;
-        for id in selected {
-            let node = manifest.nodes.get(id).with_context(|| {
-                format!("selected dbt model {id} is absent from current manifest")
-            })?;
-            let ci_relation = relation_for(node, &account.database, &node.schema);
-            let production_relation = production_manifest
-                .nodes
-                .get(id)
-                .map(|production| relation_for(production, &account.database, &production.schema));
-            production_relations.push((
-                id.clone(),
-                production_relation.clone().unwrap_or_else(|| {
-                    relation_for(node, &account.database, &account.production_schema)
-                }),
-            ));
-            let build_strategy = if manifest.is_incremental(id) {
-                if production_relation.is_none() {
-                    "first_build"
-                } else {
-                    match config.validation.incremental_mode {
-                        IncrementalMode::Clone => "incremental_clone",
-                        IncrementalMode::FullRefresh => "full_refresh",
-                    }
-                }
-            } else {
-                "standard"
-            };
-            report.models.push(ModelReport {
-                unique_id: id.clone(),
-                name: node.name.clone(),
-                account: account.name.clone(),
-                ci_relation: ci_relation.sql(),
-                production_relation: production_relation.as_ref().map(Relation::sql),
-                dbt_build: "pending".into(),
-                build_strategy: build_strategy.into(),
-                comparison: None,
-            });
-        }
-
         let build = dbt::build_models(
             config,
             context,
@@ -631,7 +748,7 @@ async fn execute_with_dbt(
                 }
                 report.findings.extend(findings);
             }
-            Err(error) => report.execution_errors.push(format_error(&error)),
+            Err(error) => report.execution_errors.push(format!("{error:#}")),
         }
     }
 
@@ -768,7 +885,7 @@ async fn cleanup_schemas(
                 }
             }
             Err(error) => report.execution_errors.push(format!(
-                "CI schema cleanup failed for {}.{}; remove it manually: {error:#}",
+                "CI schema cleanup failed for {}.{}; run `embrasure clean` or remove it manually: {error:#}",
                 database, target_schema,
             )),
         }
@@ -829,13 +946,9 @@ fn find_model_mut<'a>(
 
 fn error_report(base: &str, error: anyhow::Error) -> Report {
     let mut report = Report::empty(base.to_owned(), crate::config::Thresholds::default());
-    report.execution_errors.push(format_error(&error));
+    report.execution_errors.push(format!("{error:#}"));
     report.finalize();
     report
-}
-
-fn format_error(error: &anyhow::Error) -> String {
-    format!("{error:#}")
 }
 
 #[cfg(test)]

--- a/src/run.rs
+++ b/src/run.rs
@@ -323,6 +323,7 @@ fn plan_selections(
                 selected
             }
         };
+        let mut select_excluded = BTreeSet::new();
         if !options.select.is_empty() {
             for id in &chosen[account_index] {
                 if !selected.contains(id) {
@@ -332,6 +333,7 @@ fn plan_selections(
                 }
             }
             for id in selected.difference(&chosen[account_index]) {
+                select_excluded.insert(id.clone());
                 report.validation_scope.skipped_models.push(SkippedModel {
                     id: format!("{}:{id}", account.name),
                     reason: "excluded by --select".into(),
@@ -346,6 +348,9 @@ fn plan_selections(
         report.validation_scope.impacted_models += impacted.len();
         report.validation_scope.requested_models += selected.len();
         for id in impacted.difference(&selected) {
+            if select_excluded.contains(id) {
+                continue;
+            }
             report.validation_scope.skipped_models.push(SkippedModel {
                 id: format!("{}:{id}", account.name),
                 reason: if removed.contains(id) {

--- a/src/run.rs
+++ b/src/run.rs
@@ -139,16 +139,18 @@ async fn execute(
 
             let mut context = dbt::prepare(config, &resolved_auth, base, &schema, &query_tag)?;
             let selections = plan_selections(config, &context, options, report)?;
+            if dry_run {
+                report.notices.push(Notice {
+                    scope: "validation".into(),
+                    code: "dry_run".into(),
+                    message:
+                        "planned validation without creating schemas or querying warehouse data"
+                            .into(),
+                });
+            }
             let result = if let Some(selections) = selections {
                 if dry_run {
                     plan_model_reports(config, &context, &selections, "planned", report)?;
-                    report.notices.push(Notice {
-                        scope: "validation".into(),
-                        code: "dry_run".into(),
-                        message:
-                            "planned validation without creating schemas or querying warehouse data"
-                                .into(),
-                    });
                     Ok(())
                 } else {
                     execute_with_dbt(config, &mut context, &clients, &schema, &selections, report)

--- a/src/snowflake.rs
+++ b/src/snowflake.rs
@@ -128,7 +128,7 @@ impl SnowflakeClient {
                 .send()
                 .await
                 .context("Snowflake SQL API request failed")?;
-            self.consume_response(response, request_id).await
+            self.consume_response(response, request_id, statement).await
         })
         .await
         .with_context(|| {
@@ -143,6 +143,7 @@ impl SnowflakeClient {
         &self,
         mut response: reqwest::Response,
         request_id: Uuid,
+        statement: &str,
     ) -> Result<QueryResult> {
         loop {
             let status = response.status();
@@ -167,11 +168,12 @@ impl SnowflakeClient {
                 continue;
             }
             if !status.is_success() || !body.is_success() {
-                bail!(
-                    "Snowflake statement failed (HTTP {status}, code {}): {}",
-                    body.code.as_deref().unwrap_or("unknown"),
-                    body.message.as_deref().unwrap_or("unknown error")
-                );
+                let code = body.code.as_deref().unwrap_or("unknown");
+                let message = body.message.as_deref().unwrap_or("unknown error");
+                let hint = privilege_hint(code, message, statement, &self.account)
+                    .map(|value| format!("; {value}"))
+                    .unwrap_or_default();
+                bail!("Snowflake statement failed (HTTP {status}, code {code}): {message}{hint}");
             }
             let handle = body.statement_handle.clone();
             let mut result = QueryResult {
@@ -267,6 +269,44 @@ impl SnowflakeClient {
         if comment != expected {
             bail!(
                 "refusing to drop schema {database}.{schema}: its ownership marker does not match this run"
+            );
+        }
+        self.execute(&format!(
+            "DROP SCHEMA IF EXISTS {}.{}",
+            quote_identifier(database),
+            quote_identifier(schema),
+        ))
+        .await?;
+        Ok(())
+    }
+
+    pub async fn drop_marked_schema(
+        &self,
+        database: &str,
+        schema: &str,
+        prefix: &str,
+    ) -> Result<()> {
+        if !crate::clean::is_managed_prefix(schema, prefix) {
+            bail!("refusing to drop schema {schema}: it is outside the managed prefix {prefix}");
+        }
+        let ownership = self
+            .execute(&format!(
+                "SELECT COMMENT FROM {}.INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = {}",
+                quote_identifier(database),
+                quote_string(schema),
+            ))
+            .await?;
+        let Some(comment) = ownership
+            .rows
+            .first()
+            .and_then(|row| row.first())
+            .and_then(Option::as_deref)
+        else {
+            return Ok(());
+        };
+        if crate::clean::parse_ownership_marker(comment).is_none() {
+            bail!(
+                "refusing to drop schema {database}.{schema}: its Embrasure ownership marker is invalid"
             );
         }
         self.execute(&format!(
@@ -455,6 +495,42 @@ pub fn is_managed_schema(schema: &str, run_schema: &str) -> bool {
     schema == run_schema || schema.starts_with(&format!("{run_schema}_"))
 }
 
+fn privilege_hint(
+    code: &str,
+    message: &str,
+    statement: &str,
+    account: &AccountConfig,
+) -> Option<String> {
+    let upper = statement.trim_start().to_ascii_uppercase();
+    let insufficient = code == "003001"
+        || message
+            .to_ascii_lowercase()
+            .contains("insufficient privilege");
+    let hint = if code == "002003" {
+        "the object may not exist, or the role lacks USAGE on its database or schema".to_owned()
+    } else if insufficient && upper.starts_with("CREATE TRANSIENT SCHEMA") {
+        format!(
+            "role {} needs CREATE SCHEMA on database {}",
+            account.role, account.database
+        )
+    } else if insufficient && upper.starts_with("CREATE TABLE") && upper.contains(" CLONE ") {
+        format!(
+            "role {} needs SELECT on the source and CREATE TABLE on the target schema",
+            account.role
+        )
+    } else if insufficient && upper.starts_with("DROP SCHEMA") {
+        format!(
+            "role {} needs ownership or compatible future grants for the temporary schema",
+            account.role
+        )
+    } else if insufficient {
+        format!("role {} lacks a required Snowflake privilege", account.role)
+    } else {
+        return None;
+    };
+    Some(format!("{hint}; run `embrasure doctor`"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -486,6 +562,46 @@ mod tests {
         ));
         assert!(!is_managed_schema("EMBRASURE_CHECK_PROD", run));
         assert!(!is_managed_schema("EMBRASURE_CHECK_SHA_TIME_RANDOMLY", run));
+    }
+
+    #[test]
+    fn privilege_errors_include_actionable_hints() {
+        let account = AccountConfig {
+            name: "primary".into(),
+            account: "org-account".into(),
+            user: "DBT_CI".into(),
+            role: "DBT_CI_ROLE".into(),
+            database: "ANALYTICS".into(),
+            warehouse: "DBT_CI_WH".into(),
+            production_schema: "PROD".into(),
+            selector: None,
+            auth: AuthConfig::OauthLocal,
+        };
+        assert!(
+            privilege_hint("003001", "denied", "CREATE TRANSIENT SCHEMA x.y", &account)
+                .unwrap()
+                .contains("CREATE SCHEMA on database ANALYTICS")
+        );
+        assert!(
+            privilege_hint(
+                "003001",
+                "denied",
+                "CREATE TABLE x.y.z CLONE a.b.c",
+                &account
+            )
+            .unwrap()
+            .contains("SELECT on the source")
+        );
+        assert!(
+            privilege_hint("003001", "denied", "DROP SCHEMA x.y", &account)
+                .unwrap()
+                .contains("ownership")
+        );
+        assert!(
+            privilege_hint("002003", "missing", "SELECT 1", &account)
+                .unwrap()
+                .contains("may not exist")
+        );
     }
 
     #[test]

--- a/src/style.rs
+++ b/src/style.rs
@@ -1,0 +1,70 @@
+use std::io::IsTerminal;
+
+#[derive(Debug, Clone, Copy)]
+pub struct Style {
+    enabled: bool,
+}
+
+impl Style {
+    pub fn stdout() -> Self {
+        Self::new(std::io::stdout().is_terminal())
+    }
+
+    pub fn stderr() -> Self {
+        Self::new(std::io::stderr().is_terminal())
+    }
+
+    #[cfg(test)]
+    pub const fn plain() -> Self {
+        Self { enabled: false }
+    }
+
+    fn new(is_terminal: bool) -> Self {
+        Self {
+            enabled: is_terminal && std::env::var_os("NO_COLOR").is_none(),
+        }
+    }
+
+    pub fn good(&self, value: &str) -> String {
+        self.paint("32", value)
+    }
+
+    pub fn bad(&self, value: &str) -> String {
+        self.paint("31", value)
+    }
+
+    pub fn warn(&self, value: &str) -> String {
+        self.paint("33", value)
+    }
+
+    pub fn bold(&self, value: &str) -> String {
+        self.paint("1", value)
+    }
+
+    fn paint(&self, code: &str, value: &str) -> String {
+        if self.enabled {
+            format!("\x1b[{code}m{value}\x1b[0m")
+        } else {
+            value.to_owned()
+        }
+    }
+}
+
+pub fn animation_enabled() -> bool {
+    std::io::stderr().is_terminal() && std::env::var_os("NO_COLOR").is_none()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plain_and_styled_strings_are_predictable() {
+        assert_eq!(Style::plain().good("PASS"), "PASS");
+        let styled = Style { enabled: true };
+        assert_eq!(styled.good("PASS"), "\x1b[32mPASS\x1b[0m");
+        assert_eq!(styled.bad("FAIL"), "\x1b[31mFAIL\x1b[0m");
+        assert_eq!(styled.warn("WARN"), "\x1b[33mWARN\x1b[0m");
+        assert_eq!(styled.bold("READY"), "\x1b[1mREADY\x1b[0m");
+    }
+}

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,0 +1,284 @@
+use std::{
+    env, fs,
+    io::IsTerminal,
+    path::{Path, PathBuf},
+    process::Command,
+    time::Duration,
+};
+
+use anyhow::{Context, Result, bail};
+use chrono::{DateTime, Utc};
+use directories::ProjectDirs;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+const LATEST_RELEASE: &str =
+    "https://api.github.com/repos/EmbrasureAI/embrasure-cli/releases/latest";
+const RELEASE_DOWNLOADS: &str = "https://github.com/EmbrasureAI/embrasure-cli/releases/download";
+
+#[derive(Debug, Deserialize)]
+struct LatestRelease {
+    tag_name: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct UpdateCache {
+    checked_at: String,
+    latest: String,
+}
+
+pub fn http_client() -> Result<Client> {
+    Client::builder()
+        .timeout(Duration::from_secs(30))
+        .user_agent(format!("embrasure/{}", env!("CARGO_PKG_VERSION")))
+        .build()
+        .context("could not initialize the HTTP client")
+}
+
+pub async fn run(check_only: bool) -> Result<String> {
+    let latest = latest_version().await?;
+    let current = env!("CARGO_PKG_VERSION");
+    if !is_newer(&latest, current)? {
+        return Ok(format!("Embrasure {current} is up to date."));
+    }
+    if check_only {
+        return Ok(format!(
+            "Embrasure {latest} is available; current version is {current}."
+        ));
+    }
+    let executable = env::current_exe().context("could not locate the current executable")?;
+    if installed_by_brew(&executable) {
+        let status = Command::new("brew")
+            .args(["upgrade", "embrasureai/tap/embrasure"])
+            .status()
+            .context("could not run Homebrew; run `brew upgrade embrasureai/tap/embrasure`")?;
+        if !status.success() {
+            bail!("Homebrew upgrade failed; run `brew upgrade embrasureai/tap/embrasure`");
+        }
+        return Ok(format!("Updated Embrasure to {latest} with Homebrew."));
+    }
+    self_replace(&executable, &latest).await?;
+    Ok(format!("Updated Embrasure to {latest}."))
+}
+
+pub async fn doctor_notice() -> Option<String> {
+    if !std::io::stderr().is_terminal()
+        || env::var_os("CI").is_some()
+        || env::var_os("NO_UPDATE_NOTIFIER").is_some()
+    {
+        return None;
+    }
+    if let Ok(cache) = read_cache()
+        && cache_is_fresh(&cache.checked_at)
+    {
+        return is_newer(&cache.latest, env!("CARGO_PKG_VERSION"))
+            .ok()
+            .filter(|newer| *newer)
+            .map(|_| {
+                format!(
+                    "Embrasure {} is available; run `embrasure update`.",
+                    cache.latest
+                )
+            });
+    }
+    let latest = latest_version().await.ok()?;
+    let _ = write_cache(&UpdateCache {
+        checked_at: Utc::now().to_rfc3339(),
+        latest: latest.clone(),
+    });
+    is_newer(&latest, env!("CARGO_PKG_VERSION"))
+        .ok()
+        .filter(|newer| *newer)
+        .map(|_| format!("Embrasure {latest} is available; run `embrasure update`."))
+}
+
+async fn latest_version() -> Result<String> {
+    let release: LatestRelease = http_client()?
+        .get(LATEST_RELEASE)
+        .send()
+        .await
+        .context("could not check GitHub for updates")?
+        .error_for_status()
+        .context("GitHub update check failed")?
+        .json()
+        .await
+        .context("GitHub returned an invalid release response")?;
+    Ok(release
+        .tag_name
+        .strip_prefix('v')
+        .unwrap_or(&release.tag_name)
+        .to_owned())
+}
+
+async fn self_replace(executable: &Path, version: &str) -> Result<()> {
+    let target = release_target()?;
+    let archive_name = format!("embrasure-{version}-{target}.tar.gz");
+    let base = format!("{RELEASE_DOWNLOADS}/v{version}");
+    let client = http_client()?;
+    let archive = download(&client, &format!("{base}/{archive_name}")).await?;
+    let checksums = download(&client, &format!("{base}/SHA256SUMS")).await?;
+    verify_checksum(&archive_name, &archive, &checksums)?;
+
+    let scratch = tempfile::tempdir().context("could not create update directory")?;
+    let archive_path = scratch.path().join(&archive_name);
+    fs::write(&archive_path, archive)?;
+    let status = Command::new("tar")
+        .args(["-xzf"])
+        .arg(&archive_path)
+        .arg("-C")
+        .arg(scratch.path())
+        .status()
+        .context("could not extract the update; install `tar` and retry")?;
+    if !status.success() {
+        bail!("could not extract {archive_name}");
+    }
+    let downloaded = scratch
+        .path()
+        .join(format!("embrasure-{version}-{target}"))
+        .join("embrasure");
+    let replacement = replacement_path(executable)?;
+    fs::copy(&downloaded, &replacement).with_context(|| {
+        format!(
+            "could not write next to {}; check directory permissions",
+            executable.display()
+        )
+    })?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&replacement, fs::Permissions::from_mode(0o755))?;
+    }
+    fs::rename(&replacement, executable).with_context(|| {
+        format!(
+            "could not replace {}; check directory permissions",
+            executable.display()
+        )
+    })?;
+    Ok(())
+}
+
+async fn download(client: &Client, url: &str) -> Result<Vec<u8>> {
+    Ok(client
+        .get(url)
+        .send()
+        .await?
+        .error_for_status()?
+        .bytes()
+        .await?
+        .to_vec())
+}
+
+fn verify_checksum(name: &str, archive: &[u8], checksums: &[u8]) -> Result<()> {
+    let checksums = std::str::from_utf8(checksums).context("SHA256SUMS is not UTF-8")?;
+    let expected = checksums
+        .lines()
+        .find_map(|line| {
+            let (checksum, file) = line.split_once(char::is_whitespace)?;
+            (file.trim_start_matches([' ', '*']) == name).then_some(checksum)
+        })
+        .with_context(|| format!("SHA256SUMS does not contain {name}"))?;
+    let actual = hex(&Sha256::digest(archive));
+    if actual != expected {
+        bail!("checksum verification failed for {name}");
+    }
+    Ok(())
+}
+
+fn release_target() -> Result<&'static str> {
+    match (env::consts::OS, env::consts::ARCH) {
+        ("macos", "x86_64") => Ok("x86_64-apple-darwin"),
+        ("macos", "aarch64") => Ok("aarch64-apple-darwin"),
+        ("linux", "x86_64") => Ok("x86_64-unknown-linux-gnu"),
+        ("linux", "aarch64") => Ok("aarch64-unknown-linux-gnu"),
+        (os, arch) => bail!("updates are not available for {os}/{arch}"),
+    }
+}
+
+fn installed_by_brew(executable: &Path) -> bool {
+    let path = executable.to_string_lossy();
+    path.contains("/Cellar/")
+        || path.contains("/opt/homebrew/")
+        || path.contains("/home/linuxbrew/")
+}
+
+fn replacement_path(executable: &Path) -> Result<PathBuf> {
+    let name = executable
+        .file_name()
+        .context("current executable has no file name")?;
+    Ok(executable.with_file_name(format!("{}.new", name.to_string_lossy())))
+}
+
+fn is_newer(candidate: &str, current: &str) -> Result<bool> {
+    Ok(parse_version(candidate)? > parse_version(current)?)
+}
+
+fn parse_version(value: &str) -> Result<(u64, u64, u64)> {
+    let numbers = value.split('.').collect::<Vec<_>>();
+    if numbers.len() != 3 {
+        bail!("invalid release version {value}");
+    }
+    Ok((
+        numbers[0].parse()?,
+        numbers[1].parse()?,
+        numbers[2].parse()?,
+    ))
+}
+
+fn cache_path() -> Result<PathBuf> {
+    Ok(ProjectDirs::from("ai", "Embrasure", "embrasure-cli")
+        .context("could not resolve the OS cache directory")?
+        .cache_dir()
+        .join("update-check.json"))
+}
+
+fn read_cache() -> Result<UpdateCache> {
+    Ok(serde_json::from_slice(&fs::read(cache_path()?)?)?)
+}
+
+fn write_cache(cache: &UpdateCache) -> Result<()> {
+    let path = cache_path()?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(&path, serde_json::to_vec(cache)?)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
+    }
+    Ok(())
+}
+
+fn cache_is_fresh(value: &str) -> bool {
+    let Ok(checked) = DateTime::parse_from_rfc3339(value) else {
+        return false;
+    };
+    let age = Utc::now().signed_duration_since(checked.with_timezone(&Utc));
+    age >= chrono::Duration::zero() && age <= chrono::Duration::hours(24)
+}
+
+fn hex(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut result = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        result.push(HEX[(byte >> 4) as usize] as char);
+        result.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn versions_and_checksums_are_strict() {
+        assert!(is_newer("0.5.0", "0.4.9").unwrap());
+        assert!(!is_newer("0.4.0", "0.4.0").unwrap());
+        assert!(parse_version("0.4").is_err());
+        let archive = b"archive";
+        let sums = format!("{}  release.tar.gz\n", hex(&Sha256::digest(archive)));
+        assert!(verify_checksum("release.tar.gz", archive, sums.as_bytes()).is_ok());
+    }
+}

--- a/src/update.rs
+++ b/src/update.rs
@@ -69,18 +69,18 @@ pub async fn doctor_notice() -> Option<String> {
     {
         return None;
     }
-    if let Ok(cache) = read_cache()
-        && cache_is_fresh(&cache.checked_at)
-    {
-        return is_newer(&cache.latest, env!("CARGO_PKG_VERSION"))
-            .ok()
-            .filter(|newer| *newer)
-            .map(|_| {
-                format!(
-                    "Embrasure {} is available; run `embrasure update`.",
-                    cache.latest
-                )
-            });
+    if let Ok(cache) = read_cache() {
+        if cache_is_fresh(&cache.checked_at) {
+            return is_newer(&cache.latest, env!("CARGO_PKG_VERSION"))
+                .ok()
+                .filter(|newer| *newer)
+                .map(|_| {
+                    format!(
+                        "Embrasure {} is available; run `embrasure update`.",
+                        cache.latest
+                    )
+                });
+        }
     }
     let latest = latest_version().await.ok()?;
     let _ = write_cache(&UpdateCache {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -53,6 +53,14 @@ fn init_creates_a_minimal_valid_config() {
     assert!(config.contains("account: my_org-my_account"));
     assert!(config.contains("type: oauth_local"));
     assert!(!config.contains("thresholds:"));
+
+    Command::cargo_bin("embrasure")
+        .unwrap()
+        .current_dir(directory.path())
+        .args(["auth", "status", "--json"])
+        .assert()
+        .code(3)
+        .stdout(predicate::str::contains(r#""account": "primary""#));
 }
 
 #[test]
@@ -223,4 +231,59 @@ fn cloud_subcommands_are_discoverable() {
         .stdout(predicate::str::contains("whoami"))
         .stdout(predicate::str::contains("logout"))
         .stdout(predicate::str::contains("status"));
+}
+
+#[test]
+fn global_config_works_before_and_after_subcommands() {
+    Command::cargo_bin("embrasure")
+        .unwrap()
+        .args(["--config", "missing-a.yml", "doctor", "--json"])
+        .assert()
+        .code(3)
+        .stdout(predicate::str::contains("missing-a.yml"));
+    Command::cargo_bin("embrasure")
+        .unwrap()
+        .args(["doctor", "--config", "missing-b.yml", "--json"])
+        .assert()
+        .code(3)
+        .stdout(predicate::str::contains("missing-b.yml"));
+    Command::cargo_bin("embrasure")
+        .unwrap()
+        .args(["cloud", "status", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--config"));
+}
+
+#[test]
+fn completions_support_only_documented_shells() {
+    for shell in ["bash", "zsh", "fish"] {
+        Command::cargo_bin("embrasure")
+            .unwrap()
+            .args(["completion", shell])
+            .assert()
+            .success()
+            .stdout(predicate::str::is_empty().not());
+    }
+    Command::cargo_bin("embrasure")
+        .unwrap()
+        .args(["completion", "powershell"])
+        .assert()
+        .failure();
+}
+
+#[test]
+fn dry_run_conflicts_with_cloud_and_json_is_ansi_free() {
+    Command::cargo_bin("embrasure")
+        .unwrap()
+        .args(["check", "--dry-run", "--cloud"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot be used with"));
+    Command::cargo_bin("embrasure")
+        .unwrap()
+        .args(["check", "--json", "--config", "missing.yml"])
+        .assert()
+        .code(3)
+        .stdout(predicate::str::contains("\x1b").not());
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -12,7 +12,8 @@ fn help_exposes_enterprise_setup_commands() {
         .stdout(predicate::str::contains("init"))
         .stdout(predicate::str::contains("check"))
         .stdout(predicate::str::contains("doctor"))
-        .stdout(predicate::str::contains("auth"));
+        .stdout(predicate::str::contains("auth"))
+        .stdout(predicate::str::contains("cloud"));
 }
 
 #[test]
@@ -187,4 +188,39 @@ fn legacy_report_version_requires_json_output() {
         .assert()
         .failure()
         .stderr(predicate::str::contains("--json"));
+}
+
+#[test]
+fn check_exposes_explicit_cloud_handoff_controls() {
+    Command::cargo_bin("embrasure")
+        .unwrap()
+        .args(["check", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--cloud"))
+        .stdout(predicate::str::contains("--context <BUSINESS_INTENT>"))
+        .stdout(predicate::str::contains("--context-file <PATH>"));
+}
+
+#[test]
+fn cloud_context_cannot_accidentally_enable_network_handoff() {
+    Command::cargo_bin("embrasure")
+        .unwrap()
+        .args(["check", "--context", "one row per order"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("--cloud"));
+}
+
+#[test]
+fn cloud_subcommands_are_discoverable() {
+    Command::cargo_bin("embrasure")
+        .unwrap()
+        .args(["cloud", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("login"))
+        .stdout(predicate::str::contains("whoami"))
+        .stdout(predicate::str::contains("logout"))
+        .stdout(predicate::str::contains("status"));
 }


### PR DESCRIPTION
## Summary

- preserve and finish the explicit cloud handoff flow
- add global config, styling, completions, select, dry-run, clean, update, privilege hints, and headless cloud auth
- automate verified installs, composite action releases, MSRV CI, archives, and Homebrew tap updates
- rewrite setup, enterprise, security, and operations documentation

## Verification

- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --locked (58 unit, 15 CLI)
- cargo +1.85 check --locked --all-targets
- cargo build --release --locked
- cargo package --locked
- shellcheck install.sh
- actionlint
- live installer smoke against v0.3.3
- live update check and CLI surface smokes

## Manual release setup

Create TAP_PUSH_TOKEN with contents-write access to EmbrasureAI/homebrew-tap before the next tagged release.