### PR TITLE
Keep the default release local-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
       - run: cargo fmt --check
       - run: cargo clippy --all-targets --all-features -- -D warnings
       - run: cargo test --locked
+      - run: cargo test --locked --all-features
       # Guard the release manifest and packaged file set; this project is not published to crates.io.
       - run: cargo package --locked
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,10 @@ categories = ["command-line-utilities", "development-tools::testing"]
 name = "embrasure"
 path = "src/main.rs"
 
+[features]
+default = []
+cloud-demo = ["dep:keyring"]
+
 [dependencies]
 anyhow = "1.0"
 base64 = "0.23"
@@ -23,7 +27,7 @@ clap = { version = "4.5", features = ["derive"] }
 clap_complete = "4.5"
 globset = "0.4"
 directories = "6.0"
-keyring = "3.6"
+keyring = { version = "3.6", optional = true }
 openssl = { version = "0.10", features = ["vendored"] }
 rand = "0.8"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ embrasure check --dry-run
 embrasure check --dry-run --json
 ```
 
-Dry runs use local dbt parsing but do not resolve credentials, create Snowflake schemas, or query warehouse data. `--dry-run` cannot be combined with `--cloud`.
+Dry runs use local dbt parsing but do not resolve credentials, create Snowflake schemas, or query warehouse data.
 
 ## Reports and exit codes
 
@@ -155,20 +155,6 @@ jobs:
 ```
 
 `fetch-depth: 0` is required because selection compares the working tree with the base revision.
-
-## Cloud handoff
-
-Cloud handoff is optional. It sends the exact reviewed state and local evidence to a durable agent:
-
-```sh
-embrasure cloud login
-embrasure cloud whoami
-embrasure check --cloud \
-  --context "Preserve one row per order. Refunds reduce net revenue. Missing discounts are zero."
-embrasure cloud status
-```
-
-`--cloud` requires business intent and prints every eligible path before upload. A plain `check` primes the local review cache. The next `check --cloud` reuses it only when the repository, dbt root, base SHA, snapshot, CLI version, and check configuration match. Run `embrasure auth status` or `embrasure cloud whoami` to inspect session readiness without printing secrets.
 
 ## Maintenance
 

--- a/docs/security-and-data-flow.md
+++ b/docs/security-and-data-flow.md
@@ -1,6 +1,6 @@
 # Security and data flow
 
-By default, Embrasure runs on your machine or runner. Local `embrasure check` does not require an Embrasure account, hosted service, API key, or network connection to Embrasure. Cloud handoff is a separate, explicit opt-in through `embrasure check --cloud`.
+Embrasure runs on your machine or runner. `embrasure check` does not require an Embrasure account, hosted service, API key, or network connection to Embrasure.
 
 ## Data flow
 
@@ -13,25 +13,12 @@ Local Git repository + local dbt + Embrasure CLI
                          |
                          | Aggregate metrics and optional key examples
                          v
-                 Local terminal or report
+Local terminal or report
 
 Optional: Embrasure reads metadata from your configured Metabase URL.
-
-Optional and explicit: `embrasure check --cloud` sends a bounded source snapshot and local review evidence to Embrasure Cloud. The CLI prints every included path and the total size before upload.
 ```
 
-Local validation SQL runs in Snowflake. Without `--cloud`, Embrasure does not upload warehouse data, dbt artifacts, reports, credentials, or usage information to Embrasure.
-
-With `--cloud`, the CLI sends only:
-
-- GitHub repository owner and name, dbt subdirectory, base reference, and commit hashes
-- Eligible changed dbt text files, their paths, statuses, and SHA-256 hashes
-- The local review report and selected lineage evidence
-- The business intent supplied through `--context` or `--context-file`
-- CLI version and operating-system name
-- `notify_slack: true`, which asks the service to send its configured Slack notification
-
-Cloud handoff never sends Snowflake credentials, Embrasure access or refresh tokens, `profiles.yml`, `.env*`, private keys, binaries, symlinks, `target`, `logs`, `dbt_packages`, or virtual environments. Before upload, a nine-substring denylist rejects common credential patterns. The Cloud API contract also requires the server to repeat path, size, encoding, hash, and secret checks.
+Validation SQL runs in Snowflake. Embrasure does not upload warehouse data, dbt artifacts, reports, credentials, or usage information to Embrasure.
 
 ## Outbound connections
 
@@ -39,7 +26,6 @@ The CLI itself makes only these connections:
 
 - `https://<account>.snowflakecomputing.com` for browser authentication and Snowflake SQL API requests.
 - The configured Metabase URL when the optional Metabase integration is enabled.
-- `https://app.embrasure.ai` and `https://api.embrasure.ai` only after `embrasure cloud login` or an explicit `embrasure check --cloud`. Development can override the API with `EMBRASURE_API_URL` and the browser origin with `EMBRASURE_WEB_URL`.
 - `https://api.github.com/repos/EmbrasureAI/embrasure-cli/releases/latest` for `embrasure update --check`, `embrasure update`, and the gated doctor notice.
 - `https://github.com/EmbrasureAI/embrasure-cli/releases/download/...` when `embrasure update` downloads a release and its checksums.
 
@@ -66,8 +52,6 @@ Query checks accept a single read-only query expression, but syntax validation i
 - Programmatic access tokens and external OAuth tokens are read from environment variables.
 - RSA private keys are read from the configured local path.
 - Browser OAuth sessions are cached under `~/.config/embrasure-check/oauth/` by default. Files and directories use owner-only permissions on Unix. Run `embrasure auth logout` to remove a cached session.
-- Embrasure Cloud access and refresh tokens use the OS credential store under the separate `ai.embrasure.cli.cloud` service. Run `embrasure cloud logout` to revoke and remove that session. They are never stored in the local handoff receipt.
-- The OS application cache stores the last local-review fingerprint and report so an unchanged review can be reused. The handoff receipt stores only run IDs, URLs, hashes, and timestamps. Neither file stores uploaded source content or credentials.
 - Temporary dbt profiles, manifests, target directories, and the detached base worktree live under an operating-system temporary directory and are removed after the process exits normally.
 
 Credentials are not included in normal terminal output, JSON reports, or Markdown reports.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod auth;
 mod clean;
+#[cfg(feature = "cloud-demo")]
 mod cloud;
 mod compare;
 mod config;
@@ -147,14 +148,18 @@ enum Command {
         #[arg(long = "select", value_name = "MODEL")]
         select: Vec<String>,
         /// Plan validation without creating schemas or querying warehouse data.
-        #[arg(long, conflicts_with = "cloud")]
+        #[arg(long)]
+        #[cfg_attr(feature = "cloud-demo", arg(conflicts_with = "cloud"))]
         dry_run: bool,
+        #[cfg(feature = "cloud-demo")]
         /// Hand the exact validated working state to a durable Embrasure Cloud agent.
         #[arg(long)]
         cloud: bool,
+        #[cfg(feature = "cloud-demo")]
         /// Business intent used to create bounded validation assertions. Repeat to preserve ordering.
         #[arg(long = "context", value_name = "BUSINESS_INTENT", requires = "cloud")]
         context: Vec<String>,
+        #[cfg(feature = "cloud-demo")]
         /// Read additional business intent from a UTF-8 file.
         #[arg(long, value_name = "PATH", requires = "cloud")]
         context_file: Option<PathBuf>,
@@ -173,7 +178,8 @@ enum Command {
         #[command(subcommand)]
         command: AuthCommand,
     },
-    /// Manage the optional Embrasure Cloud session and durable runs.
+    #[cfg(feature = "cloud-demo")]
+    /// Manage the Embrasure Cloud demo session and durable runs.
     Cloud {
         #[command(subcommand)]
         command: CloudCommand,
@@ -224,6 +230,7 @@ enum AuthCommand {
     },
 }
 
+#[cfg(feature = "cloud-demo")]
 #[derive(Debug, Subcommand)]
 enum CloudCommand {
     /// Sign in through the browser and save a separate OS-keychain session.
@@ -285,10 +292,15 @@ async fn main() -> ExitCode {
             verbose,
             select,
             dry_run,
-            cloud: use_cloud,
+            #[cfg(feature = "cloud-demo")]
+            cloud,
+            #[cfg(feature = "cloud-demo")]
             context,
+            #[cfg(feature = "cloud-demo")]
             context_file,
         } => {
+            #[cfg(feature = "cloud-demo")]
+            let use_cloud = cloud;
             let options = run::CheckOptions {
                 mode: mode.map(Into::into),
                 downstream: downstream.map(Into::into),
@@ -296,49 +308,70 @@ async fn main() -> ExitCode {
                 incremental_mode: incremental_mode.map(Into::into),
                 select,
             };
-            let intent = if use_cloud {
-                match cloud::normalize_context(&context, context_file.as_deref()) {
-                    Ok(value) => Some(value),
-                    Err(error) => return fail(error),
-                }
-            } else {
-                None
-            };
             let loaded_config = run::load_config(&config, &options);
-            let snapshot = match loaded_config.as_ref() {
-                Ok(loaded) if use_cloud => {
-                    match cloud::prepare_snapshot(&config, loaded, &base, &options) {
+
+            #[cfg(feature = "cloud-demo")]
+            let (intent, snapshot, mut report) = {
+                let intent = if use_cloud {
+                    match cloud::normalize_context(&context, context_file.as_deref()) {
                         Ok(value) => Some(value),
-                        Err(error) => {
-                            return fail(format_args!(
-                                "could not prepare cloud snapshot: {error:#}"
-                            ));
+                        Err(error) => return fail(error),
+                    }
+                } else {
+                    None
+                };
+                let snapshot = match loaded_config.as_ref() {
+                    Ok(loaded) if use_cloud => {
+                        match cloud::prepare_snapshot(&config, loaded, &base, &options) {
+                            Ok(value) => Some(value),
+                            Err(error) => {
+                                return fail(format_args!(
+                                    "could not prepare cloud snapshot: {error:#}"
+                                ));
+                            }
                         }
                     }
-                }
-                Ok(_) if dry_run => None,
-                Ok(loaded) => cloud::prepare_snapshot(&config, loaded, &base, &options).ok(),
-                Err(_) => None,
-            };
-            let cached = snapshot
-                .as_ref()
-                .and_then(|value| cloud::cached_review(value).ok().flatten());
-            let mut report = if use_cloud {
-                if let Some(report) = cached {
-                    eprintln!("Reusing the local review for this exact working-tree state");
-                    report
+                    Ok(_) if dry_run => None,
+                    Ok(loaded) => cloud::prepare_snapshot(&config, loaded, &base, &options).ok(),
+                    Err(_) => None,
+                };
+                let cached = snapshot
+                    .as_ref()
+                    .and_then(|value| cloud::cached_review(value).ok().flatten());
+                let report = if use_cloud {
+                    if let Some(report) = cached {
+                        eprintln!("Reusing the local review for this exact working-tree state");
+                        report
+                    } else {
+                        eprintln!(
+                            "The working tree or review configuration changed; rerunning local review"
+                        );
+                        match loaded_config {
+                            Ok(config) => {
+                                run::run_check_with_config(config, &base, &options, dry_run).await
+                            }
+                            Err(error) => run::failed_check(&base, error),
+                        }
+                    }
                 } else {
-                    eprintln!(
-                        "The working tree or review configuration changed; rerunning local review"
-                    );
+                    eprintln!("embrasure: validating changes against {base}");
                     match loaded_config {
                         Ok(config) => {
                             run::run_check_with_config(config, &base, &options, dry_run).await
                         }
                         Err(error) => run::failed_check(&base, error),
                     }
+                };
+                if let Some(snapshot) = &snapshot {
+                    if let Err(error) = cloud::save_review(snapshot, &report) {
+                        eprintln!("embrasure: could not save the local review cache: {error:#}");
+                    }
                 }
-            } else {
+                (intent, snapshot, report)
+            };
+
+            #[cfg(not(feature = "cloud-demo"))]
+            let mut report = {
                 eprintln!("embrasure: validating changes against {base}");
                 match loaded_config {
                     Ok(config) => {
@@ -347,11 +380,6 @@ async fn main() -> ExitCode {
                     Err(error) => run::failed_check(&base, error),
                 }
             };
-            if let Some(snapshot) = &snapshot {
-                if let Err(error) = cloud::save_review(snapshot, &report) {
-                    eprintln!("embrasure: could not save the local review cache: {error:#}");
-                }
-            }
             if let Some(path) = markdown {
                 if let Err(error) = report.write_markdown(&path) {
                     report
@@ -361,6 +389,8 @@ async fn main() -> ExitCode {
                 }
             }
             let report_version = report_version.unwrap_or(report::ReportVersion::V3);
+
+            #[cfg(feature = "cloud-demo")]
             if use_cloud {
                 if report.exit_code == report::EXIT_EXECUTION {
                     if json {
@@ -381,7 +411,7 @@ async fn main() -> ExitCode {
                 )
                 .await;
                 drop(progress);
-                match receipt {
+                return match receipt {
                     Ok(receipt) => {
                         if json {
                             println!(
@@ -409,8 +439,10 @@ async fn main() -> ExitCode {
                         }
                         fail(error)
                     }
-                }
-            } else if json {
+                };
+            }
+
+            if json {
                 match report.json(report_version) {
                     Ok(value) => println!("{value}"),
                     Err(error) => {
@@ -483,6 +515,7 @@ async fn main() -> ExitCode {
                 }
             }
         },
+        #[cfg(feature = "cloud-demo")]
         Command::Cloud { command } => match command {
             CloudCommand::Login => match cloud::login().await {
                 Ok(session) => {
@@ -626,6 +659,7 @@ async fn main() -> ExitCode {
     }
 }
 
+#[cfg(feature = "cloud-demo")]
 fn cloud_result_json(
     report: &report::Report,
     receipt: Option<&cloud::HandoffReceipt>,

--- a/src/style.rs
+++ b/src/style.rs
@@ -50,6 +50,7 @@ impl Style {
     }
 }
 
+#[cfg(feature = "cloud-demo")]
 pub fn animation_enabled() -> bool {
     std::io::stderr().is_terminal() && std::env::var_os("NO_COLOR").is_none()
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -12,8 +12,7 @@ fn help_exposes_enterprise_setup_commands() {
         .stdout(predicate::str::contains("init"))
         .stdout(predicate::str::contains("check"))
         .stdout(predicate::str::contains("doctor"))
-        .stdout(predicate::str::contains("auth"))
-        .stdout(predicate::str::contains("cloud"));
+        .stdout(predicate::str::contains("auth"));
 }
 
 #[test]
@@ -199,6 +198,7 @@ fn legacy_report_version_requires_json_output() {
 }
 
 #[test]
+#[cfg(feature = "cloud-demo")]
 fn check_exposes_explicit_cloud_handoff_controls() {
     Command::cargo_bin("embrasure")
         .unwrap()
@@ -211,6 +211,7 @@ fn check_exposes_explicit_cloud_handoff_controls() {
 }
 
 #[test]
+#[cfg(feature = "cloud-demo")]
 fn cloud_context_cannot_accidentally_enable_network_handoff() {
     Command::cargo_bin("embrasure")
         .unwrap()
@@ -221,6 +222,7 @@ fn cloud_context_cannot_accidentally_enable_network_handoff() {
 }
 
 #[test]
+#[cfg(feature = "cloud-demo")]
 fn cloud_subcommands_are_discoverable() {
     Command::cargo_bin("embrasure")
         .unwrap()
@@ -247,12 +249,30 @@ fn global_config_works_before_and_after_subcommands() {
         .assert()
         .code(3)
         .stdout(predicate::str::contains("missing-b.yml"));
+}
+
+#[test]
+#[cfg(not(feature = "cloud-demo"))]
+fn default_release_has_no_cloud_surface() {
     Command::cargo_bin("embrasure")
         .unwrap()
-        .args(["cloud", "status", "--help"])
+        .arg("--help")
         .assert()
         .success()
-        .stdout(predicate::str::contains("--config"));
+        .stdout(predicate::str::contains("cloud").not());
+    Command::cargo_bin("embrasure")
+        .unwrap()
+        .args(["check", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--cloud").not())
+        .stdout(predicate::str::contains("--context").not());
+    Command::cargo_bin("embrasure")
+        .unwrap()
+        .arg("cloud")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("unrecognized subcommand"));
 }
 
 #[test]
@@ -273,17 +293,22 @@ fn completions_support_only_documented_shells() {
 }
 
 #[test]
-fn dry_run_conflicts_with_cloud_and_json_is_ansi_free() {
-    Command::cargo_bin("embrasure")
-        .unwrap()
-        .args(["check", "--dry-run", "--cloud"])
-        .assert()
-        .failure()
-        .stderr(predicate::str::contains("cannot be used with"));
+fn json_output_is_ansi_free() {
     Command::cargo_bin("embrasure")
         .unwrap()
         .args(["check", "--json", "--config", "missing.yml"])
         .assert()
         .code(3)
         .stdout(predicate::str::contains("\x1b").not());
+}
+
+#[test]
+#[cfg(feature = "cloud-demo")]
+fn dry_run_conflicts_with_cloud() {
+    Command::cargo_bin("embrasure")
+        .unwrap()
+        .args(["check", "--dry-run", "--cloud"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot be used with"));
 }


### PR DESCRIPTION
## Summary
- ship only local dbt verification in the default binary
- preserve the cloud demo behind the non-default `cloud-demo` feature
- remove cloud handoff from public release documentation
- test default and demo-enabled builds in CI

## Verification
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --locked`
- `cargo test --locked --all-features`
- `cargo build --release --locked`
- `cargo package --locked --allow-dirty`