### PR TITLE
Add the verify skill

### DIFF
--- a/.agents/skills/verify/SKILL.md
+++ b/.agents/skills/verify/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: verify
+description: Run Embrasure's local verification loop for dbt changes. Use when implementing, debugging, or reviewing dbt models, tests, macros, seeds, snapshots, or SQL. Check against the PR base, fix every finding or gap, and rerun until clean.
+---
+
+# Verify
+
+Run from the dbt project root after making changes.
+
+## Loop
+
+1. Use the PR target as the base. Default to `origin/main` when no other target is known.
+2. Run:
+
+   ```sh
+   embrasure check --base origin/main --json
+   ```
+
+3. Handle the exit code:
+   - `0`: stop; the check passed.
+   - `1`: fix every finding and rerun.
+   - `2`: resolve or explain every coverage gap. Do not call this a pass.
+   - `3`: fix the setup, execution, or cleanup error. Run `embrasure doctor` for configuration or access problems.
+4. Repeat until the full check exits `0`.
+
+Use `--select <model> --downstream none` or `--mode quick` during iteration. Finish without those flags so Embrasure validates the complete downstream path. A dry run is only a preview.
+
+## Guardrails
+
+- Fix the root cause. Do not weaken tests, thresholds, coverage, or critical-model settings just to pass.
+- Confirm that changed business behavior matches the request.
+- Do not run ad hoc writes against production.
+- If credentials, permissions, or business intent block a safe fix, stop and report the blocker.
+
+## Report
+
+Report the base, fixes, models validated, downstream impact, and remaining gaps. Use the final Embrasure result as evidence.

--- a/.agents/skills/verify/agents/openai.yaml
+++ b/.agents/skills/verify/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Verify"
+  short_description: "Verify dbt changes with Embrasure"
+  default_prompt: "Use $verify to validate my dbt changes and fix every finding."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,14 @@ permissions:
   contents: read
 
 jobs:
+  action:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Install through the documented action
+        uses: EmbrasureAI/embrasure-cli@ee29a94f6bf8c6299f5ef6cf592ff8d41fe5aed8
+      - name: Verify the installed CLI
+        run: embrasure --version | grep '^embrasure '
+
   rust:
     runs-on: ubuntu-24.04
     steps:

--- a/README.md
+++ b/README.md
@@ -134,6 +134,14 @@ Only persisted dbt models are supported in `ref()`. Query checks accept one `SEL
 
 The composite action installs the CLI. Keep the check in a visible `run` step so exit codes and secrets remain explicit.
 
+In `embrasure-check.yml`, configure the account to read the CI secret:
+
+```yaml
+auth:
+  type: programmatic_access_token
+  token_env: SNOWFLAKE_PROGRAMMATIC_ACCESS_TOKEN
+```
+
 ```yaml
 jobs:
   embrasure:
@@ -148,7 +156,7 @@ jobs:
         with:
           python-version: "3.12"
       - run: python -m pip install "dbt-core>=1.5,<2" "dbt-snowflake>=1.5,<2"
-      - uses: EmbrasureAI/embrasure-cli@v1
+      - uses: EmbrasureAI/embrasure-cli@ee29a94f6bf8c6299f5ef6cf592ff8d41fe5aed8
       - run: embrasure check --base origin/main --json
         env:
           SNOWFLAKE_PROGRAMMATIC_ACCESS_TOKEN: ${{ secrets.SNOWFLAKE_PROGRAMMATIC_ACCESS_TOKEN }}


### PR DESCRIPTION
## Summary
- add the repo-local `$verify` skill for the Embrasure fix-and-rerun loop
- pin the documented composite action to an existing immutable revision
- document the required CI auth setting
- smoke-test the documented action on GitHub-hosted runners

## Verification
- skill validator passes
- installer downloads, verifies, and runs the latest release locally
- GitHub Actions smoke job exercises the documented action and PATH setup