### PR TITLE
Add SQLGlot column lineage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,10 @@ jobs:
         run: |
           rustup toolchain install stable --profile minimal --component rustfmt,clippy
           rustup default stable
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+      - run: python3 -m pip install "sqlglot>=30,<31"
       - run: cargo fmt --check
       - run: cargo clippy --all-targets --all-features -- -D warnings
       - run: cargo test --locked

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,10 @@ jobs:
         run: |
           rustup toolchain install stable --profile minimal --component rustfmt,clippy
           rustup default stable
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+      - run: python3 -m pip install "sqlglot>=30,<31"
       - run: cargo fmt --check
       - run: cargo clippy --all-targets --all-features -- -D warnings
       - run: cargo test --locked

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,7 +404,7 @@ dependencies = [
 
 [[package]]
 name = "embrasure-cli"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embrasure-cli"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Embrasure CLI for validating dbt changes against production Snowflake data"

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Local checks connect directly to Snowflake. They require no Embrasure account or
 - Exact differences between arbitrary candidate and production SQL results
 - Existing dbt test failures
 - Affected dbt models and exposures
+- Column dependencies resolved from compiled dbt SQL
 - Declared cross-account dependencies
 - Optional Metabase dashboards
 - Models mapped to non-dbt file changes
@@ -30,6 +31,7 @@ From your dbt project directory:
 
 ```sh
 brew install embrasureai/tap/embrasure
+python3 -m pip install "sqlglot>=30,<31"
 embrasure init
 embrasure auth login
 embrasure check
@@ -40,7 +42,7 @@ By default, `check` compares your branch with `origin/main`.
 Requires Git, dbt Core 1.5 or newer, and dbt-snowflake 1.5 or newer. If you do not have dbt installed yet:
 
 ```sh
-python -m pip install "dbt-core>=1.5,<2" "dbt-snowflake>=1.5,<2"
+python3 -m pip install "dbt-core>=1.5,<2" "dbt-snowflake>=1.5,<2"
 ```
 
 If you do not use Homebrew, use the verified installer:
@@ -53,7 +55,7 @@ Example result:
 
 ```text
 embrasure: PASS
-2 selected · 2 built · 2 compared · 0 findings · 0 coverage gaps
+2 selected · 2 built · 2 compared · 0 query checks run · 0 findings · 0 coverage gaps
 5 impacted · 2 validated · 3 not validated
 ```
 
@@ -89,7 +91,7 @@ embrasure check --json --markdown embrasure-check.md
 embrasure check --json --report-version 1
 ```
 
-Published contracts: [report v1](schemas/report-v1.schema.json), [report v2](schemas/report-v2.schema.json), and [report v3](schemas/report-v3.schema.json). V3 is the default; v1 and v2 remain explicit compatibility projections.
+Published contracts: [v1](schemas/report-v1.schema.json), [v2](schemas/report-v2.schema.json), [v3](schemas/report-v3.schema.json), and [v4](schemas/report-v4.schema.json). V4 adds column lineage and is the default; older versions remain available with `--report-version`.
 
 | Exit code | Meaning |
 |---:|---|
@@ -155,7 +157,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: python -m pip install "dbt-core>=1.5,<2" "dbt-snowflake>=1.5,<2"
+      - run: python3 -m pip install "dbt-core>=1.5,<2" "dbt-snowflake>=1.5,<2" "sqlglot>=30,<31"
       - uses: EmbrasureAI/embrasure-cli@v1
       - run: embrasure check --base origin/main --json
         env:
@@ -217,7 +219,8 @@ Every temporary schema has a unique name and ownership marker. Query results are
 ## Current limits
 
 - Snowflake is the only supported warehouse.
-- dbt artifacts provide model lineage and exposures, not authoritative warehouse-to-dashboard column lineage.
+- Column lineage covers compiled dbt SQL that SQLGlot can resolve. Wildcards without an input schema and dynamic SQL are reported as unresolved.
+- Dashboard column lineage is not inferred from model lineage.
 - Metabase matching covers native SQL cards that reference fully qualified production relations. Unsupported or inaccessible metadata becomes a coverage gap.
 
 ## Development

--- a/docs/enterprise.md
+++ b/docs/enterprise.md
@@ -134,7 +134,7 @@ embrasure check --base origin/main --json --markdown embrasure-check.md
 
 Exit `0` is ready for review, `1` is a finding, `2` is missing evidence, and `3` is a setup or execution failure.
 
-Report v3 is the default JSON contract and adds query-diff evidence. V1 and v2 remain unchanged compatibility projections and can be requested with `--json --report-version 1` or `--json --report-version 2`.
+Report v4 is the default JSON contract and adds column lineage. V1 through v3 remain available with `--report-version`.
 
 ## Reference
 
@@ -200,6 +200,6 @@ Table-level zero-copy clones preserve Snowflake micro-partitions. Views, hybrid 
 
 ### Lineage boundary
 
-Local evidence includes dbt model lineage, dbt exposures, declared cross-account edges, and optional Metabase SQL matches. It does not prove warehouse-to-dashboard column lineage.
+Local evidence includes dbt model lineage, column dependencies resolved from compiled dbt SQL, dbt exposures, declared cross-account edges, and optional Metabase SQL matches. Wildcards without an input schema and dynamic SQL remain explicit gaps.
 
-Authoritative column lineage requires Snowflake access history and BI APIs. Its limits include extra Snowflake permissions, metadata latency, dynamic SQL, separate BI credentials, and inaccessible assets.
+Warehouse-to-dashboard column lineage still requires Snowflake access history and BI APIs.

--- a/schemas/report-v4.schema.json
+++ b/schemas/report-v4.schema.json
@@ -1,0 +1,298 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/EmbrasureAI/embrasure-cli/schemas/report-v4.schema.json",
+  "title": "Embrasure check report v4",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version", "status", "exit_code", "base", "ci_schemas", "thresholds",
+    "summary", "validation_scope", "models", "query_checks", "impact", "findings",
+    "coverage_gaps", "notices", "execution_errors"
+  ],
+  "properties": {
+    "schema_version": { "const": 4 },
+    "status": { "enum": ["pass", "findings", "incomplete", "execution_failure"] },
+    "exit_code": { "enum": [0, 1, 2, 3] },
+    "base": { "type": "string" },
+    "ci_schemas": { "type": "array", "items": { "$ref": "#/$defs/ci_schema" } },
+    "thresholds": { "$ref": "#/$defs/thresholds" },
+    "summary": { "$ref": "#/$defs/summary" },
+    "validation_scope": { "$ref": "#/$defs/validation_scope" },
+    "models": { "type": "array", "items": { "$ref": "#/$defs/model" } },
+    "query_checks": { "type": "array", "items": { "$ref": "#/$defs/query_check" } },
+    "impact": { "$ref": "#/$defs/impact" },
+    "findings": { "type": "array", "items": { "$ref": "#/$defs/finding" } },
+    "coverage_gaps": { "type": "array", "items": { "$ref": "#/$defs/coverage_gap" } },
+    "notices": { "type": "array", "items": { "$ref": "#/$defs/notice" } },
+    "execution_errors": { "type": "array", "items": { "type": "string" } }
+  },
+  "$defs": {
+    "ci_schema": {
+      "type": "object", "additionalProperties": false,
+      "required": ["account", "database", "schema", "cleaned_up"],
+      "properties": {
+        "account": { "type": "string" }, "database": { "type": "string" },
+        "schema": { "type": "string" }, "cleaned_up": { "type": "boolean" }
+      }
+    },
+    "thresholds": {
+      "type": "object", "additionalProperties": false,
+      "required": ["row_count_relative", "null_rate_absolute", "cardinality_relative", "numeric_relative"],
+      "properties": {
+        "row_count_relative": { "type": "number", "minimum": 0 },
+        "null_rate_absolute": { "type": "number", "minimum": 0 },
+        "cardinality_relative": { "type": "number", "minimum": 0 },
+        "numeric_relative": { "type": "number", "minimum": 0 }
+      }
+    },
+    "summary": {
+      "type": "object", "additionalProperties": false,
+      "required": [
+        "models_selected", "models_built", "models_compared", "query_checks_configured",
+        "query_checks_run", "query_checks_passed", "findings", "coverage_gaps"
+      ],
+      "properties": {
+        "models_selected": { "type": "integer", "minimum": 0 },
+        "models_built": { "type": "integer", "minimum": 0 },
+        "models_compared": { "type": "integer", "minimum": 0 },
+        "query_checks_configured": { "type": "integer", "minimum": 0 },
+        "query_checks_run": { "type": "integer", "minimum": 0 },
+        "query_checks_passed": { "type": "integer", "minimum": 0 },
+        "findings": { "type": "integer", "minimum": 0 },
+        "coverage_gaps": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "validation_scope": {
+      "type": "object", "additionalProperties": false,
+      "required": ["downstream", "impacted_models", "requested_models", "validated_models", "skipped_models"],
+      "properties": {
+        "downstream": { "enum": ["none", "critical", "all"] },
+        "impacted_models": { "type": "integer", "minimum": 0 },
+        "requested_models": { "type": "integer", "minimum": 0 },
+        "validated_models": { "type": "array", "items": { "type": "string" } },
+        "skipped_models": { "type": "array", "items": { "$ref": "#/$defs/skipped_model" } }
+      }
+    },
+    "skipped_model": {
+      "type": "object", "additionalProperties": false,
+      "required": ["id", "reason"],
+      "properties": { "id": { "type": "string" }, "reason": { "type": "string" } }
+    },
+    "model": {
+      "type": "object", "additionalProperties": false,
+      "required": ["unique_id", "name", "account", "ci_relation", "production_relation", "dbt_build", "build_strategy", "comparison"],
+      "properties": {
+        "unique_id": { "type": "string" }, "name": { "type": "string" },
+        "account": { "type": "string" }, "ci_relation": { "type": "string" },
+        "production_relation": { "type": ["string", "null"] },
+        "dbt_build": { "enum": ["planned", "pending", "passed", "failed"] },
+        "build_strategy": { "enum": ["standard", "first_build", "incremental_clone", "full_refresh"] },
+        "comparison": { "anyOf": [{ "$ref": "#/$defs/model_comparison" }, { "type": "null" }] }
+      }
+    },
+    "model_comparison": {
+      "type": "object", "additionalProperties": false,
+      "required": ["ci_row_count", "production_row_count", "row_count_relative_change", "columns", "primary_key"],
+      "properties": {
+        "ci_row_count": { "type": "integer", "minimum": 0 },
+        "production_row_count": { "type": "integer", "minimum": 0 },
+        "row_count_relative_change": { "type": "number", "minimum": 0 },
+        "columns": { "type": "array", "items": { "$ref": "#/$defs/column_comparison" } },
+        "primary_key": { "anyOf": [{ "$ref": "#/$defs/primary_key_comparison" }, { "type": "null" }] }
+      }
+    },
+    "column_comparison": {
+      "type": "object", "additionalProperties": false,
+      "required": ["name", "ci_type", "production_type", "ci", "production"],
+      "properties": {
+        "name": { "type": "string" }, "ci_type": { "type": ["string", "null"] },
+        "production_type": { "type": ["string", "null"] },
+        "ci": { "anyOf": [{ "$ref": "#/$defs/column_metrics" }, { "type": "null" }] },
+        "production": { "anyOf": [{ "$ref": "#/$defs/column_metrics" }, { "type": "null" }] }
+      }
+    },
+    "column_metrics": {
+      "type": "object", "additionalProperties": false,
+      "required": ["null_count", "null_rate", "cardinality"],
+      "properties": {
+        "null_count": { "type": "integer", "minimum": 0 },
+        "null_rate": { "type": "number", "minimum": 0, "maximum": 1 },
+        "cardinality": { "type": "integer", "minimum": 0 },
+        "min": { "type": "string" }, "max": { "type": "string" },
+        "average": { "type": "number" }, "p05": { "type": "number" },
+        "p50": { "type": "number" }, "p95": { "type": "number" }
+      }
+    },
+    "primary_key_comparison": {
+      "type": "object", "additionalProperties": false,
+      "required": [
+        "columns", "ci_only_count", "production_only_count", "ci_only_examples",
+        "production_only_examples", "ci_duplicate_key_count", "production_duplicate_key_count",
+        "ci_duplicate_rows", "production_duplicate_rows", "ci_null_key_rows",
+        "production_null_key_rows", "ci_duplicate_examples"
+      ],
+      "properties": {
+        "columns": { "type": "array", "minItems": 1, "items": { "type": "string" } },
+        "ci_only_count": { "type": "integer", "minimum": 0 },
+        "production_only_count": { "type": "integer", "minimum": 0 },
+        "ci_only_examples": { "$ref": "#/$defs/key_examples" },
+        "production_only_examples": { "$ref": "#/$defs/key_examples" },
+        "ci_duplicate_key_count": { "type": "integer", "minimum": 0 },
+        "production_duplicate_key_count": { "type": "integer", "minimum": 0 },
+        "ci_duplicate_rows": { "type": "integer", "minimum": 0 },
+        "production_duplicate_rows": { "type": "integer", "minimum": 0 },
+        "ci_null_key_rows": { "type": "integer", "minimum": 0 },
+        "production_null_key_rows": { "type": "integer", "minimum": 0 },
+        "ci_duplicate_examples": { "$ref": "#/$defs/key_examples" }
+      }
+    },
+    "key_examples": {
+      "type": "array", "items": { "type": "array", "items": { "type": ["string", "null"] } }
+    },
+    "query_check": {
+      "type": "object", "additionalProperties": false,
+      "required": [
+        "name", "account", "status", "current_refs", "production_refs", "primary_key",
+        "candidate_relation", "production_relation", "candidate_row_count",
+        "production_row_count", "columns", "comparison", "reason", "invalid_primary_key_reason",
+        "examples_truncated"
+      ],
+      "properties": {
+        "name": { "type": "string" }, "account": { "type": "string" },
+        "status": { "enum": ["planned", "pass", "findings", "incomplete", "skipped", "execution_failure"] },
+        "current_refs": { "type": "array", "items": { "type": "string" } },
+        "production_refs": { "type": "array", "items": { "type": "string" } },
+        "primary_key": { "type": "array", "items": { "type": "string" } },
+        "candidate_relation": { "type": ["string", "null"] },
+        "production_relation": { "type": ["string", "null"] },
+        "candidate_row_count": { "type": ["integer", "null"], "minimum": 0 },
+        "production_row_count": { "type": ["integer", "null"], "minimum": 0 },
+        "columns": { "type": "array", "items": { "$ref": "#/$defs/query_column" } },
+        "comparison": { "anyOf": [{ "$ref": "#/$defs/query_comparison" }, { "type": "null" }] },
+        "reason": { "type": ["string", "null"] },
+        "invalid_primary_key_reason": { "type": ["string", "null"] },
+        "examples_truncated": { "type": "boolean" }
+      }
+    },
+    "query_column": {
+      "type": "object", "additionalProperties": false,
+      "required": ["name", "candidate_type", "production_type"],
+      "properties": {
+        "name": { "type": "string" },
+        "candidate_type": { "type": ["string", "null"] },
+        "production_type": { "type": ["string", "null"] }
+      }
+    },
+    "query_comparison": {
+      "type": "object", "additionalProperties": false,
+      "required": [
+        "candidate_only_rows", "production_only_rows", "changed_rows",
+        "candidate_duplicate_keys", "production_duplicate_keys", "candidate_duplicate_rows",
+        "production_duplicate_rows", "candidate_null_key_rows", "production_null_key_rows",
+        "column_mismatches", "examples"
+      ],
+      "properties": {
+        "candidate_only_rows": { "type": "integer", "minimum": 0 },
+        "production_only_rows": { "type": "integer", "minimum": 0 },
+        "changed_rows": { "type": "integer", "minimum": 0 },
+        "candidate_duplicate_keys": { "type": "integer", "minimum": 0 },
+        "production_duplicate_keys": { "type": "integer", "minimum": 0 },
+        "candidate_duplicate_rows": { "type": "integer", "minimum": 0 },
+        "production_duplicate_rows": { "type": "integer", "minimum": 0 },
+        "candidate_null_key_rows": { "type": "integer", "minimum": 0 },
+        "production_null_key_rows": { "type": "integer", "minimum": 0 },
+        "column_mismatches": { "type": "array", "items": { "$ref": "#/$defs/query_column_mismatch" } },
+        "examples": { "type": "array", "items": { "$ref": "#/$defs/query_example" } }
+      }
+    },
+    "query_column_mismatch": {
+      "type": "object", "additionalProperties": false,
+      "required": ["column", "rows"],
+      "properties": {
+        "column": { "type": "string" }, "rows": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "query_example": {
+      "type": "object", "additionalProperties": false,
+      "required": ["key", "candidate", "production", "candidate_multiplicity", "production_multiplicity"],
+      "properties": {
+        "key": { "$ref": "#/$defs/query_example_values" },
+        "candidate": { "$ref": "#/$defs/query_example_values" },
+        "production": { "$ref": "#/$defs/query_example_values" },
+        "candidate_multiplicity": { "type": ["integer", "null"], "minimum": 0 },
+        "production_multiplicity": { "type": ["integer", "null"], "minimum": 0 }
+      }
+    },
+    "query_example_values": {
+      "type": "array", "items": { "type": ["string", "null"] }
+    },
+    "finding": {
+      "type": "object", "additionalProperties": false, "required": ["model", "check", "message"],
+      "properties": { "model": { "type": "string" }, "check": { "type": "string" }, "message": { "type": "string" } }
+    },
+    "coverage_gap": {
+      "type": "object", "additionalProperties": false, "required": ["scope", "check", "reason"],
+      "properties": { "scope": { "type": "string" }, "check": { "type": "string" }, "reason": { "type": "string" } }
+    },
+    "notice": {
+      "type": "object", "additionalProperties": false, "required": ["scope", "code", "message"],
+      "properties": { "scope": { "type": "string" }, "code": { "type": "string" }, "message": { "type": "string" } }
+    },
+    "asset": {
+      "type": "object", "additionalProperties": false, "required": ["id", "name"],
+      "properties": { "id": { "type": "string" }, "name": { "type": "string" }, "url": { "type": "string" } }
+    },
+    "lineage_edge": {
+      "type": "object", "additionalProperties": false, "required": ["from", "from_name", "to", "to_name"],
+      "properties": {
+        "from": { "type": "string" }, "from_name": { "type": "string" },
+        "to": { "type": "string" }, "to_name": { "type": "string" }
+      }
+    },
+    "lineage_change": {
+      "type": "object", "additionalProperties": false, "required": ["change", "edge"],
+      "properties": {
+        "change": { "enum": ["added", "removed"] }, "edge": { "$ref": "#/$defs/lineage_edge" }
+      }
+    },
+    "column_lineage_edge": {
+      "type": "object", "additionalProperties": false,
+      "required": ["account", "from", "from_name", "from_column", "to", "to_name", "to_column"],
+      "properties": {
+        "account": { "type": "string" }, "from": { "type": "string" },
+        "from_name": { "type": "string" }, "from_column": { "type": "string" },
+        "to": { "type": "string" }, "to_name": { "type": "string" },
+        "to_column": { "type": "string" }
+      }
+    },
+    "column_lineage_gap": {
+      "type": "object", "additionalProperties": false,
+      "required": ["account", "model", "reason"],
+      "properties": {
+        "account": { "type": "string" }, "model": { "type": "string" },
+        "reason": { "type": "string" }
+      }
+    },
+    "cross_account_dependency": {
+      "type": "object", "additionalProperties": false, "required": ["from", "to", "columns"],
+      "properties": {
+        "from": { "type": "string" }, "to": { "type": "string" },
+        "columns": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "impact": {
+      "type": "object", "additionalProperties": false,
+      "required": ["dbt_models", "dbt_exposures", "dbt_lineage", "dbt_lineage_changes", "column_lineage", "column_lineage_gaps", "metabase_dashboards", "cross_account_dependencies"],
+      "properties": {
+        "dbt_models": { "type": "array", "items": { "$ref": "#/$defs/asset" } },
+        "dbt_exposures": { "type": "array", "items": { "$ref": "#/$defs/asset" } },
+        "dbt_lineage": { "type": "array", "items": { "$ref": "#/$defs/lineage_edge" } },
+        "dbt_lineage_changes": { "type": "array", "items": { "$ref": "#/$defs/lineage_change" } },
+        "column_lineage": { "type": "array", "items": { "$ref": "#/$defs/column_lineage_edge" } },
+        "column_lineage_gaps": { "type": "array", "items": { "$ref": "#/$defs/column_lineage_gap" } },
+        "metabase_dashboards": { "type": "array", "items": { "$ref": "#/$defs/asset" } },
+        "cross_account_dependencies": { "type": "array", "items": { "$ref": "#/$defs/cross_account_dependency" } }
+      }
+    }
+  }
+}

--- a/src/dbt.rs
+++ b/src/dbt.rs
@@ -44,6 +44,8 @@ pub struct ManifestNode {
     pub depends_on: DependsOn,
     #[serde(default)]
     pub config: NodeConfig,
+    #[serde(default, alias = "compiled_sql")]
+    pub compiled_code: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -648,6 +650,10 @@ impl DbtContext {
         self.scratch.path().join("build-target").join(account)
     }
 
+    pub fn build_manifest(&self, account: &str) -> Result<Manifest> {
+        Manifest::load(&self.build_target(account).join("manifest.json"))
+    }
+
     pub fn cleanup_worktree(&mut self) -> Result<()> {
         let Some(mut registration) = self.base_worktree.take() else {
             return Ok(());
@@ -1099,6 +1105,7 @@ mod tests {
             tags: vec![],
             depends_on: DependsOn::default(),
             config: NodeConfig::default(),
+            compiled_code: None,
         }
     }
 

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -7,7 +7,7 @@ use uuid::Uuid;
 use crate::{
     auth,
     config::Config,
-    metabase,
+    lineage, metabase,
     snowflake::{QueryResult, Relation, SnowflakeClient, quote_identifier},
     style::Style,
 };
@@ -53,6 +53,10 @@ pub async fn run(config_path: &Path, write_test: bool) -> DoctorReport {
     }
     report.tool("git", "git");
     report.tool("dbt", &config.dbt.command);
+    match lineage::probe() {
+        Ok(version) => report.pass("local", "sqlglot", format!("SQLGlot {version}")),
+        Err(error) => report.fail("local", "sqlglot", format!("{error:#}")),
+    }
 
     for account in &config.accounts {
         let scope = format!("snowflake:{}", account.name);

--- a/src/lineage.rs
+++ b/src/lineage.rs
@@ -1,0 +1,413 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    env,
+    io::Write,
+    process::{Command, Stdio},
+};
+
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    dbt::{Manifest, ManifestNode},
+    report::{ColumnLineageEdge, ColumnLineageGap},
+};
+
+const SCRIPT: &str = include_str!("sqlglot_lineage.py");
+
+#[derive(Serialize)]
+struct Request<'a> {
+    models: Vec<ModelRequest<'a>>,
+}
+
+#[derive(Serialize)]
+struct ModelRequest<'a> {
+    unique_id: &'a str,
+    sql: &'a str,
+}
+
+#[derive(Deserialize)]
+struct Response {
+    sqlglot_version: String,
+    models: Vec<ModelResponse>,
+}
+
+#[derive(Deserialize)]
+struct ModelResponse {
+    unique_id: String,
+    edges: Vec<ParsedEdge>,
+    gaps: Vec<String>,
+}
+
+#[derive(Deserialize)]
+struct ParsedEdge {
+    output_column: String,
+    source_column: String,
+    source_database: Option<SqlIdentifier>,
+    source_schema: Option<SqlIdentifier>,
+    source_table: SqlIdentifier,
+    source_relation: String,
+}
+
+#[derive(Deserialize)]
+struct SqlIdentifier {
+    name: String,
+    quoted: bool,
+}
+
+pub struct Extraction {
+    pub edges: Vec<ColumnLineageEdge>,
+    pub gaps: Vec<ColumnLineageGap>,
+}
+
+pub fn extract(
+    account: &str,
+    current: &Manifest,
+    production: &Manifest,
+    compiled: &Manifest,
+    selected: &BTreeSet<String>,
+) -> Result<Extraction> {
+    let models = selected
+        .iter()
+        .filter_map(|id| {
+            compiled.nodes.get(id).and_then(|node| {
+                node.compiled_code
+                    .as_deref()
+                    .map(|sql| ModelRequest { unique_id: id, sql })
+            })
+        })
+        .collect::<Vec<_>>();
+    let missing_sql = selected
+        .iter()
+        .filter(|id| {
+            compiled
+                .nodes
+                .get(*id)
+                .and_then(|node| node.compiled_code.as_deref())
+                .is_none()
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+
+    let mut gaps = missing_sql
+        .into_iter()
+        .map(|model| ColumnLineageGap {
+            account: account.to_owned(),
+            model,
+            reason: "dbt did not emit compiled SQL for this model".into(),
+        })
+        .collect::<Vec<_>>();
+    if models.is_empty() {
+        return Ok(Extraction {
+            edges: vec![],
+            gaps,
+        });
+    }
+
+    let response = invoke(&Request { models })?;
+    let mut edges = Vec::new();
+    for model in response.models {
+        let Some(target) = current.nodes.get(&model.unique_id) else {
+            gaps.push(ColumnLineageGap {
+                account: account.to_owned(),
+                model: model.unique_id,
+                reason: "compiled model is absent from the current dbt manifest".into(),
+            });
+            continue;
+        };
+        gaps.extend(model.gaps.into_iter().map(|reason| ColumnLineageGap {
+            account: account.to_owned(),
+            model: model.unique_id.clone(),
+            reason,
+        }));
+        for edge in model.edges {
+            match resolve_source(target, &edge, current, production) {
+                SourceResolution::Dbt(source) => edges.push(ColumnLineageEdge {
+                    account: account.to_owned(),
+                    from: source.unique_id.clone(),
+                    from_name: source.name.clone(),
+                    from_column: edge.source_column,
+                    to: target.unique_id.clone(),
+                    to_name: target.name.clone(),
+                    to_column: edge.output_column,
+                }),
+                SourceResolution::External => edges.push(ColumnLineageEdge {
+                    account: account.to_owned(),
+                    from: edge.source_relation.clone(),
+                    from_name: edge.source_relation,
+                    from_column: edge.source_column,
+                    to: target.unique_id.clone(),
+                    to_name: target.name.clone(),
+                    to_column: edge.output_column,
+                }),
+                SourceResolution::Ambiguous => gaps.push(ColumnLineageGap {
+                    account: account.to_owned(),
+                    model: model.unique_id.clone(),
+                    reason: format!(
+                        "{} matches more than one dbt model, so its column edge was omitted",
+                        edge.source_relation
+                    ),
+                }),
+            }
+        }
+    }
+    Ok(Extraction { edges, gaps })
+}
+
+pub fn probe() -> Result<String> {
+    Ok(invoke(&Request { models: vec![] })?.sqlglot_version)
+}
+
+fn invoke(request: &Request<'_>) -> Result<Response> {
+    let mut child = Command::new(python_command())
+        .args(["-c", SCRIPT])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .context("could not start Python for SQLGlot column lineage")?;
+    serde_json::to_writer(
+        child
+            .stdin
+            .as_mut()
+            .context("SQLGlot stdin was not available")?,
+        request,
+    )?;
+    child
+        .stdin
+        .take()
+        .context("SQLGlot stdin was not available")?
+        .flush()?;
+    let output = child.wait_with_output()?;
+    if !output.status.success() {
+        bail!(
+            "SQLGlot column lineage failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    serde_json::from_slice(&output.stdout).context("SQLGlot returned invalid lineage JSON")
+}
+
+fn python_command() -> String {
+    env::var("EMBRASURE_PYTHON").unwrap_or_else(|_| "python3".into())
+}
+
+enum SourceResolution<'a> {
+    Dbt(&'a ManifestNode),
+    External,
+    Ambiguous,
+}
+
+fn resolve_source<'a>(
+    target: &ManifestNode,
+    source: &ParsedEdge,
+    current: &'a Manifest,
+    production: &'a Manifest,
+) -> SourceResolution<'a> {
+    let preferred = target
+        .depends_on
+        .nodes
+        .iter()
+        .filter_map(|id| current.nodes.get(id).or_else(|| production.nodes.get(id)))
+        .filter(|node| relation_matches(node, source))
+        .collect::<Vec<_>>();
+    if let Some(resolution) = unique_model(preferred) {
+        return resolution;
+    }
+
+    let candidates = current
+        .nodes
+        .values()
+        .chain(production.nodes.values())
+        .filter(|node| node.resource_type == "model" && relation_matches(node, source))
+        .collect::<Vec<_>>();
+    unique_model(candidates).unwrap_or(SourceResolution::External)
+}
+
+fn unique_model(candidates: Vec<&ManifestNode>) -> Option<SourceResolution<'_>> {
+    let unique = candidates
+        .into_iter()
+        .map(|node| (node.unique_id.as_str(), node))
+        .collect::<BTreeMap<_, _>>();
+    match unique.len() {
+        0 => None,
+        1 => Some(SourceResolution::Dbt(unique.values().next().unwrap())),
+        _ => Some(SourceResolution::Ambiguous),
+    }
+}
+
+fn relation_matches(node: &ManifestNode, source: &ParsedEdge) -> bool {
+    identifier_matches(
+        &node.alias,
+        node.config.quoting.identifier,
+        &source.source_table,
+    ) && source
+        .source_schema
+        .as_ref()
+        .is_none_or(|schema| identifier_matches(&node.schema, node.config.quoting.schema, schema))
+        && source.source_database.as_ref().is_none_or(|database| {
+            node.database.as_deref().is_some_and(|value| {
+                identifier_matches(value, node.config.quoting.database, database)
+            })
+        })
+}
+
+fn identifier_matches(value: &str, quoted: Option<bool>, parsed: &SqlIdentifier) -> bool {
+    if quoted.unwrap_or(false) || parsed.quoted {
+        value == parsed.name
+    } else {
+        value.eq_ignore_ascii_case(&parsed.name)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dbt::{DependsOn, NodeConfig};
+
+    fn model(id: &str, schema: &str, compiled_code: Option<&str>) -> ManifestNode {
+        ManifestNode {
+            unique_id: id.into(),
+            name: id.rsplit('.').next().unwrap().into(),
+            resource_type: "model".into(),
+            database: Some("DB".into()),
+            schema: schema.into(),
+            alias: id.rsplit('.').next().unwrap().into(),
+            fqn: id.split('.').map(ToOwned::to_owned).collect(),
+            tags: vec![],
+            depends_on: DependsOn::default(),
+            config: NodeConfig::default(),
+            compiled_code: compiled_code.map(ToOwned::to_owned),
+        }
+    }
+
+    fn manifest(nodes: Vec<ManifestNode>) -> Manifest {
+        Manifest {
+            nodes: nodes
+                .into_iter()
+                .map(|node| (node.unique_id.clone(), node))
+                .collect(),
+            exposures: BTreeMap::new(),
+            child_map: BTreeMap::new(),
+        }
+    }
+
+    #[test]
+    fn sqlglot_traces_aliases_expressions_and_ctes() {
+        let request = Request {
+            models: vec![ModelRequest {
+                unique_id: "model.project.summary",
+                sql: "with orders as (select customer_id, amount from raw.orders) select customer_id, sum(amount) as total from orders group by 1",
+            }],
+        };
+        let response = invoke(&request).unwrap();
+        let model = &response.models[0];
+        assert!(model.gaps.is_empty());
+        assert!(model.edges.iter().any(|edge| {
+            edge.output_column == "CUSTOMER_ID"
+                && edge.source_relation == "RAW.ORDERS"
+                && edge.source_column == "CUSTOMER_ID"
+        }));
+        assert!(model.edges.iter().any(|edge| {
+            edge.output_column == "TOTAL"
+                && edge.source_relation == "RAW.ORDERS"
+                && edge.source_column == "AMOUNT"
+        }));
+    }
+
+    #[test]
+    fn sqlglot_marks_wildcards_as_gaps_instead_of_guessing() {
+        let request = Request {
+            models: vec![ModelRequest {
+                unique_id: "model.project.orders",
+                sql: "select * from raw.orders",
+            }],
+        };
+        let response = invoke(&request).unwrap();
+        assert!(response.models[0].edges.is_empty());
+        assert!(response.models[0].gaps[0].contains("cannot be expanded"));
+    }
+
+    #[test]
+    fn constants_do_not_create_fake_lineage_gaps() {
+        let request = Request {
+            models: vec![ModelRequest {
+                unique_id: "model.project.loaded",
+                sql: "select current_timestamp() as loaded_at",
+            }],
+        };
+        let response = invoke(&request).unwrap();
+        assert!(response.models[0].edges.is_empty());
+        assert!(response.models[0].gaps.is_empty());
+    }
+
+    #[test]
+    fn quoted_column_names_are_returned_without_sql_quotes() {
+        let request = Request {
+            models: vec![ModelRequest {
+                unique_id: "model.project.orders",
+                sql: "select source.\"CamelCase\" as \"OutputCase\" from raw.orders source",
+            }],
+        };
+        let response = invoke(&request).unwrap();
+        assert_eq!(response.models[0].edges[0].source_column, "CamelCase");
+        assert_eq!(response.models[0].edges[0].output_column, "OutputCase");
+    }
+
+    #[test]
+    fn unions_keep_each_output_column_separate() {
+        let request = Request {
+            models: vec![ModelRequest {
+                unique_id: "model.project.orders",
+                sql: "select id, amount from raw.orders union all select id, amount from raw.archive",
+            }],
+        };
+        let response = invoke(&request).unwrap();
+        let output_columns = response.models[0]
+            .edges
+            .iter()
+            .map(|edge| edge.output_column.as_str())
+            .collect::<BTreeSet<_>>();
+        assert_eq!(output_columns, BTreeSet::from(["AMOUNT", "ID"]));
+        assert_eq!(response.models[0].edges.len(), 4);
+    }
+
+    #[test]
+    fn extraction_maps_compiled_relations_back_to_dbt_models() {
+        let orders = model("model.project.orders", "CI", None);
+        let mut summary = model("model.project.summary", "CI", None);
+        summary.depends_on.nodes = vec![orders.unique_id.clone()];
+        let current = manifest(vec![orders, summary]);
+        let production = manifest(vec![
+            model("model.project.orders", "PROD", None),
+            model("model.project.summary", "PROD", None),
+        ]);
+        let compiled = manifest(vec![model(
+            "model.project.summary",
+            "CI",
+            Some("select order_id, amount * 2 as gross from DB.CI.orders"),
+        )]);
+
+        let extraction = extract(
+            "primary",
+            &current,
+            &production,
+            &compiled,
+            &BTreeSet::from(["model.project.summary".into()]),
+        )
+        .unwrap();
+
+        assert!(extraction.gaps.is_empty());
+        assert!(extraction.edges.iter().any(|edge| {
+            edge.from == "model.project.orders"
+                && edge.from_column == "ORDER_ID"
+                && edge.to == "model.project.summary"
+                && edge.to_column == "ORDER_ID"
+        }));
+        assert!(extraction.edges.iter().any(|edge| {
+            edge.from == "model.project.orders"
+                && edge.from_column == "AMOUNT"
+                && edge.to_column == "GROSS"
+        }));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod dbt;
 mod doctor;
 mod git;
 mod init;
+mod lineage;
 mod loopback;
 mod metabase;
 mod query;
@@ -388,7 +389,7 @@ async fn main() -> ExitCode {
                     report.finalize();
                 }
             }
-            let report_version = report_version.unwrap_or(report::ReportVersion::V3);
+            let report_version = report_version.unwrap_or(report::ReportVersion::V4);
 
             #[cfg(feature = "cloud-demo")]
             if use_cloud {

--- a/src/report.rs
+++ b/src/report.rs
@@ -21,6 +21,8 @@ pub enum ReportVersion {
     V2,
     #[value(name = "3")]
     V3,
+    #[value(name = "4")]
+    V4,
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
@@ -249,6 +251,10 @@ pub struct ImpactReport {
     pub dbt_exposures: Vec<ImpactedAsset>,
     pub dbt_lineage: Vec<LineageEdge>,
     pub dbt_lineage_changes: Vec<LineageChange>,
+    #[serde(skip)]
+    pub column_lineage: Vec<ColumnLineageEdge>,
+    #[serde(skip)]
+    pub column_lineage_gaps: Vec<ColumnLineageGap>,
     pub metabase_dashboards: Vec<ImpactedAsset>,
     pub cross_account_dependencies: Vec<CrossAccountDependency>,
 }
@@ -280,6 +286,24 @@ pub enum LineageChangeKind {
 pub struct LineageChange {
     pub change: LineageChangeKind,
     pub edge: LineageEdge,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ColumnLineageEdge {
+    pub account: String,
+    pub from: String,
+    pub from_name: String,
+    pub from_column: String,
+    pub to: String,
+    pub to_name: String,
+    pub to_column: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ColumnLineageGap {
+    pub account: String,
+    pub model: String,
+    pub reason: String,
 }
 
 impl Report {
@@ -329,6 +353,10 @@ impl Report {
         self.impact.dbt_lineage.dedup();
         self.impact.dbt_lineage_changes.sort();
         self.impact.dbt_lineage_changes.dedup();
+        self.impact.column_lineage.sort();
+        self.impact.column_lineage.dedup();
+        self.impact.column_lineage_gaps.sort();
+        self.impact.column_lineage_gaps.dedup();
         self.impact.metabase_dashboards.sort();
         self.impact.metabase_dashboards.dedup();
         for dependency in &mut self.impact.cross_account_dependencies {
@@ -490,6 +518,34 @@ impl Report {
                 );
             }
         }
+        if !self.impact.column_lineage.is_empty() || !self.impact.column_lineage_gaps.is_empty() {
+            let _ = writeln!(
+                output,
+                "Column lineage: {} edges · {} unresolved",
+                self.impact.column_lineage.len(),
+                self.impact.column_lineage_gaps.len()
+            );
+            if verbose {
+                for edge in &self.impact.column_lineage {
+                    let _ = writeln!(
+                        output,
+                        "  {}.{} -> {}.{} ({})",
+                        edge.from_name,
+                        edge.from_column,
+                        edge.to_name,
+                        edge.to_column,
+                        edge.account
+                    );
+                }
+                for gap in &self.impact.column_lineage_gaps {
+                    let _ = writeln!(
+                        output,
+                        "  unresolved {} ({}): {}",
+                        gap.model, gap.account, gap.reason
+                    );
+                }
+            }
+        }
         for asset in &self.impact.metabase_dashboards {
             let _ = writeln!(output, "- [impact:metabase] {}", asset.name);
         }
@@ -508,6 +564,7 @@ impl Report {
             ReportVersion::V1 => serde_json::to_value(ReportV1::from(self)),
             ReportVersion::V2 => serde_json::to_value(ReportV2::from(self)),
             ReportVersion::V3 => serde_json::to_value(self),
+            ReportVersion::V4 => serde_json::to_value(ReportV4::from(self)),
         }
     }
 
@@ -722,6 +779,26 @@ impl Report {
                 );
             }
         }
+        if !self.impact.column_lineage.is_empty() || !self.impact.column_lineage_gaps.is_empty() {
+            output.push_str("\n## Column lineage\n\n");
+            if self.impact.column_lineage.is_empty() {
+                output.push_str("No column edges resolved.\n");
+            }
+            for edge in &self.impact.column_lineage {
+                let _ = writeln!(
+                    output,
+                    "- `{}`.`{}` → `{}`.`{}` ({})",
+                    edge.from_name, edge.from_column, edge.to_name, edge.to_column, edge.account
+                );
+            }
+            for gap in &self.impact.column_lineage_gaps {
+                let _ = writeln!(
+                    output,
+                    "- Unresolved `{}` ({}): {}",
+                    gap.model, gap.account, gap.reason
+                );
+            }
+        }
         if !self.execution_errors.is_empty() {
             output.push_str("\n## Execution errors\n\n");
             for error in &self.execution_errors {
@@ -830,6 +907,68 @@ impl Report {
                 "  ... {} more; rerun with --verbose",
                 total - state.count
             );
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct ReportV4<'a> {
+    schema_version: u8,
+    status: Status,
+    exit_code: u8,
+    base: &'a str,
+    ci_schemas: &'a [CiSchema],
+    thresholds: Thresholds,
+    summary: &'a Summary,
+    validation_scope: &'a ValidationScope,
+    models: &'a [ModelReport],
+    query_checks: &'a [QueryCheckReport],
+    impact: ImpactReportV4<'a>,
+    findings: &'a [Finding],
+    coverage_gaps: &'a [CoverageGap],
+    notices: &'a [Notice],
+    execution_errors: &'a [String],
+}
+
+#[derive(Serialize)]
+struct ImpactReportV4<'a> {
+    dbt_models: &'a [ImpactedAsset],
+    dbt_exposures: &'a [ImpactedAsset],
+    dbt_lineage: &'a [LineageEdge],
+    dbt_lineage_changes: &'a [LineageChange],
+    column_lineage: &'a [ColumnLineageEdge],
+    column_lineage_gaps: &'a [ColumnLineageGap],
+    metabase_dashboards: &'a [ImpactedAsset],
+    cross_account_dependencies: &'a [CrossAccountDependency],
+}
+
+impl<'a> From<&'a Report> for ReportV4<'a> {
+    fn from(report: &'a Report) -> Self {
+        Self {
+            schema_version: 4,
+            status: report.status,
+            exit_code: report.exit_code,
+            base: &report.base,
+            ci_schemas: &report.ci_schemas,
+            thresholds: report.thresholds,
+            summary: &report.summary,
+            validation_scope: &report.validation_scope,
+            models: &report.models,
+            query_checks: &report.query_checks,
+            impact: ImpactReportV4 {
+                dbt_models: &report.impact.dbt_models,
+                dbt_exposures: &report.impact.dbt_exposures,
+                dbt_lineage: &report.impact.dbt_lineage,
+                dbt_lineage_changes: &report.impact.dbt_lineage_changes,
+                column_lineage: &report.impact.column_lineage,
+                column_lineage_gaps: &report.impact.column_lineage_gaps,
+                metabase_dashboards: &report.impact.metabase_dashboards,
+                cross_account_dependencies: &report.impact.cross_account_dependencies,
+            },
+            findings: &report.findings,
+            coverage_gaps: &report.coverage_gaps,
+            notices: &report.notices,
+            execution_errors: &report.execution_errors,
         }
     }
 }
@@ -1243,7 +1382,22 @@ mod tests {
 
     #[test]
     fn reports_match_their_published_json_schemas() {
-        let report = representative_report();
+        let mut report = representative_report();
+        report.impact.column_lineage.push(ColumnLineageEdge {
+            account: "primary".into(),
+            from: "model.project.orders".into(),
+            from_name: "orders".into(),
+            from_column: "ORDER_ID".into(),
+            to: "model.project.summary".into(),
+            to_name: "summary".into(),
+            to_column: "ORDER_ID".into(),
+        });
+        report.impact.column_lineage_gaps.push(ColumnLineageGap {
+            account: "primary".into(),
+            model: "model.project.wildcard".into(),
+            reason: "SELECT * cannot be expanded".into(),
+        });
+        report.finalize();
         assert_matches_schema(
             &report,
             ReportVersion::V1,
@@ -1258,6 +1412,11 @@ mod tests {
             &report,
             ReportVersion::V3,
             include_str!("../schemas/report-v3.schema.json"),
+        );
+        assert_matches_schema(
+            &report,
+            ReportVersion::V4,
+            include_str!("../schemas/report-v4.schema.json"),
         );
         let mut planned = report.clone();
         planned.models[0].dbt_build = "planned".into();
@@ -1277,6 +1436,11 @@ mod tests {
             ReportVersion::V3,
             include_str!("../schemas/report-v3.schema.json"),
         );
+        assert_matches_schema(
+            &planned,
+            ReportVersion::V4,
+            include_str!("../schemas/report-v4.schema.json"),
+        );
 
         let v1: serde_json::Value =
             serde_json::from_str(&report.json(ReportVersion::V1).unwrap()).unwrap();
@@ -1291,6 +1455,20 @@ mod tests {
             serde_json::from_str(&report.json(ReportVersion::V2).unwrap()).unwrap();
         assert!(v2.get("query_checks").is_none());
         assert!(v2["summary"].get("query_checks_run").is_none());
+        let v3: serde_json::Value =
+            serde_json::from_str(&report.json(ReportVersion::V3).unwrap()).unwrap();
+        assert!(v3["impact"].get("column_lineage").is_none());
+        let v4: serde_json::Value =
+            serde_json::from_str(&report.json(ReportVersion::V4).unwrap()).unwrap();
+        assert_eq!(v4["schema_version"], 4);
+        assert_eq!(v4["impact"]["column_lineage"].as_array().unwrap().len(), 1);
+        assert_eq!(
+            v4["impact"]["column_lineage_gaps"]
+                .as_array()
+                .unwrap()
+                .len(),
+            1
+        );
 
         let schema: serde_json::Value =
             serde_json::from_str(include_str!("../schemas/report-v3.schema.json")).unwrap();

--- a/src/run.rs
+++ b/src/run.rs
@@ -16,11 +16,11 @@ use crate::{
         SafetyConfig, Thresholds,
     },
     dbt::{self, DbtContext, Manifest, ManifestNode},
-    git, metabase,
+    git, lineage, metabase,
     query::{QueryDiffInput, QueryTemplate, RefTarget, run_query_diff},
     report::{
-        CiSchema, CoverageGap, Finding, ModelReport, Notice, QueryCheckReport, QueryCheckStatus,
-        Report, SkippedModel,
+        CiSchema, ColumnLineageGap, CoverageGap, Finding, ModelReport, Notice, QueryCheckReport,
+        QueryCheckStatus, Report, SkippedModel,
     },
     snowflake::{Relation, SnowflakeClient, is_managed_schema},
 };
@@ -965,6 +965,26 @@ async fn execute_with_dbt(
                 });
             }
             continue;
+        }
+
+        match context.build_manifest(&account.name).and_then(|compiled| {
+            lineage::extract(
+                &account.name,
+                manifest,
+                production_manifest,
+                &compiled,
+                selected,
+            )
+        }) {
+            Ok(extraction) => {
+                report.impact.column_lineage.extend(extraction.edges);
+                report.impact.column_lineage_gaps.extend(extraction.gaps);
+            }
+            Err(error) => report.impact.column_lineage_gaps.push(ColumnLineageGap {
+                account: account.name.clone(),
+                model: "selected models".into(),
+                reason: format!("column lineage was unavailable: {error:#}"),
+            }),
         }
 
         for id in selected {
@@ -1920,6 +1940,7 @@ mod tests {
                 materialized: materialized.into(),
                 ..NodeConfig::default()
             },
+            compiled_code: None,
         }
     }
 
@@ -1956,6 +1977,7 @@ checks:
             tags: vec![],
             depends_on: DependsOn::default(),
             config: NodeConfig::default(),
+            compiled_code: None,
         };
         assert_eq!(relation_for(&node, "OTHER", "CHECK").schema, "CHECK");
     }
@@ -1996,6 +2018,7 @@ checks:
             tags: vec![],
             depends_on: DependsOn::default(),
             config: NodeConfig::default(),
+            compiled_code: None,
         };
 
         assert_eq!(
@@ -2025,6 +2048,7 @@ checks:
                 materialized: String::new(),
                 unique_key: None,
             },
+            compiled_code: None,
         };
 
         assert_eq!(

--- a/src/sqlglot_lineage.py
+++ b/src/sqlglot_lineage.py
@@ -1,0 +1,127 @@
+import json
+import sys
+
+import sqlglot
+from sqlglot import exp
+from sqlglot.lineage import lineage
+
+
+def identifier(value):
+    if value is None:
+        return None
+    return {"name": value.name, "quoted": bool(value.args.get("quoted"))}
+
+
+def terminal_nodes(node):
+    if not node.downstream:
+        yield node
+        return
+    for child in node.downstream:
+        yield from terminal_nodes(child)
+
+
+def relation_sql(table):
+    relation = table.copy()
+    relation.set("alias", None)
+    return relation.sql(dialect="snowflake")
+
+
+def trace_model(model):
+    edges = []
+    gaps = []
+    try:
+        expression = sqlglot.parse_one(model["sql"], dialect="snowflake")
+    except Exception as error:
+        return {
+            "unique_id": model["unique_id"],
+            "edges": [],
+            "gaps": [f"SQLGlot could not parse the compiled SQL: {error}"],
+        }
+
+    for select in expression.selects:
+        output_column = select.alias_or_name
+        if not output_column:
+            gaps.append("an output expression has no stable column name")
+            continue
+        if output_column == "*":
+            gaps.append("SELECT * cannot be expanded without an authoritative input schema")
+            continue
+        alias = select.args.get("alias")
+        output_is_quoted = bool(alias and alias.args.get("quoted")) or bool(
+            isinstance(select, exp.Column) and select.this.args.get("quoted")
+        )
+        try:
+            output_node = lineage(
+                exp.column(output_column, quoted=output_is_quoted),
+                expression,
+                dialect="snowflake",
+            )
+        except Exception as error:
+            gaps.append(f"{output_column} could not be resolved by SQLGlot: {error}")
+            continue
+        if not output_is_quoted:
+            output_column = output_column.upper()
+
+        for leaf in terminal_nodes(output_node):
+            table = leaf.expression
+            if leaf is output_node and not output_node.downstream:
+                continue
+            if not isinstance(table, exp.Table):
+                gaps.append(
+                    f"{output_column} ends at an unsupported SQL source: "
+                    f"{table.sql(dialect='snowflake')}"
+                )
+                continue
+
+            source_column = exp.to_column(leaf.name).name
+            if source_column == "*":
+                gaps.append(
+                    f"{output_column} depends on a wildcard that cannot be expanded "
+                    "without an authoritative input schema"
+                )
+                continue
+            if not source_column:
+                gaps.append(f"{output_column} has an unresolved source column")
+                continue
+
+            edges.append(
+                {
+                    "output_column": output_column,
+                    "source_column": source_column,
+                    "source_database": identifier(table.args.get("catalog")),
+                    "source_schema": identifier(table.args.get("db")),
+                    "source_table": identifier(table.this),
+                    "source_relation": relation_sql(table),
+                }
+            )
+
+    edges.sort(
+        key=lambda edge: (
+            edge["output_column"],
+            edge["source_relation"],
+            edge["source_column"],
+        )
+    )
+    return {
+        "unique_id": model["unique_id"],
+        "edges": edges,
+        "gaps": sorted(set(gaps)),
+    }
+
+
+def main():
+    major = int(sqlglot.__version__.split(".", 1)[0])
+    if major != 30:
+        raise RuntimeError(
+            f"SQLGlot 30.x is required; found {sqlglot.__version__}"
+        )
+    request = json.load(sys.stdin)
+    response = {
+        "sqlglot_version": sqlglot.__version__,
+        "models": [trace_model(model) for model in request["models"]],
+    }
+    json.dump(response, sys.stdout, separators=(",", ":"))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- trace compiled dbt SQL with SQLGlot and report direct column edges
- keep unresolved SQL explicit without guessing or changing check exit status
- add report v4 while preserving v1-v3 output
- verify SQLGlot in doctor, CI, release CI, and setup docs

## Validation
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --locked --all-features
- cargo +1.85 check --locked --all-targets
- cargo package --locked
- actionlint .github/workflows/ci.yml .github/workflows/release.yml
- SQLGlot 30.0 and 30.7 compatibility checks