### PR TITLE
Harden column lineage edge cases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,7 +404,7 @@ dependencies = [
 
 [[package]]
 name = "embrasure-cli"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embrasure-cli"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 rust-version = "1.85"
 description = "Embrasure CLI for validating dbt changes against production Snowflake data"

--- a/README.md
+++ b/README.md
@@ -54,17 +54,11 @@ If you do not use Homebrew, use the installer:
 curl -fsSL https://raw.githubusercontent.com/EmbrasureAI/embrasure-cli/main/install.sh | sh
 ```
 
-The installer writes to `/usr/local/bin` when writable, otherwise `~/.local/bin`. Set `EMBRASURE_INSTALL_DIR` to choose another directory.
-
 Use Embrasure from an existing Snowflake dbt project whose unchanged production models are already materialized. Embrasure uses those existing relations as the comparison baseline.
 
 Your Snowflake role needs warehouse usage, read access to the production relations, and permission to create and remove temporary schemas in the configured database.
 
-`init` reads the active dbt profile and asks only for missing values. Use `--config <path>` before or after any subcommand to choose another config file.
-
-Continue only when `embrasure doctor` reports `READY`. Embrasure generates a temporary dbt profile for its own runs; it does not modify your existing profile or production models.
-
-If dbt is installed in `.venv`, run `source .venv/bin/activate` in each new shell before using Embrasure.
+`init` reads the active dbt profile and asks only for missing values. Continue when `embrasure doctor` reports `READY`.
 
 Example result:
 

--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: Install Embrasure
 description: Install a verified Embrasure CLI release and add it to PATH.
 inputs:
   version:
-    description: Release version, such as 0.4.0. Defaults to the latest release.
+    description: Release version without the leading v. Defaults to the latest release.
     required: false
     default: latest
 runs:

--- a/src/lineage.rs
+++ b/src/lineage.rs
@@ -316,6 +316,95 @@ mod tests {
     }
 
     #[test]
+    fn sqlglot_traces_common_snowflake_patterns() {
+        let request = Request {
+            models: vec![
+                ModelRequest {
+                    unique_id: "model.project.case_join",
+                    sql: "select coalesce(o.customer_id, c.id) as customer_id, case when o.status = 'paid' then o.amount else 0 end as paid_amount from raw.orders o left join raw.customers c on o.customer_id = c.id",
+                },
+                ModelRequest {
+                    unique_id: "model.project.qualify",
+                    sql: "select customer_id, row_number() over (partition by customer_id order by created_at desc) as order_rank from raw.orders qualify order_rank = 1",
+                },
+                ModelRequest {
+                    unique_id: "model.project.variant",
+                    sql: "select payload:customer.id::number as customer_id from raw.events",
+                },
+                ModelRequest {
+                    unique_id: "model.project.flatten",
+                    sql: "select f.value:name::string as item_name from raw.events e, lateral flatten(input => e.payload:items) f",
+                },
+            ],
+        };
+        let response = invoke(&request).unwrap();
+        assert!(response.models.iter().all(|model| model.gaps.is_empty()));
+
+        let case_join = response
+            .models
+            .iter()
+            .find(|model| model.unique_id.ends_with("case_join"))
+            .unwrap();
+        assert!(case_join.edges.iter().any(|edge| {
+            edge.output_column == "PAID_AMOUNT"
+                && edge.source_relation == "RAW.ORDERS"
+                && edge.source_column == "STATUS"
+        }));
+        assert!(case_join.edges.iter().any(|edge| {
+            edge.output_column == "CUSTOMER_ID"
+                && edge.source_relation == "RAW.CUSTOMERS"
+                && edge.source_column == "ID"
+        }));
+
+        let qualify = response
+            .models
+            .iter()
+            .find(|model| model.unique_id.ends_with("qualify"))
+            .unwrap();
+        assert!(qualify.edges.iter().any(|edge| {
+            edge.output_column == "ORDER_RANK" && edge.source_column == "CREATED_AT"
+        }));
+
+        let variant = response
+            .models
+            .iter()
+            .find(|model| model.unique_id.ends_with("variant"))
+            .unwrap();
+        assert!(variant.edges.iter().any(|edge| {
+            edge.output_column == "CUSTOMER_ID" && edge.source_column == "PAYLOAD"
+        }));
+
+        let flatten = response
+            .models
+            .iter()
+            .find(|model| model.unique_id.ends_with("flatten"))
+            .unwrap();
+        assert!(
+            flatten.edges.iter().any(|edge| {
+                edge.output_column == "ITEM_NAME" && edge.source_column == "PAYLOAD"
+            })
+        );
+    }
+
+    #[test]
+    fn sqlglot_parse_gaps_are_stable_and_terminal_safe() {
+        let request = Request {
+            models: vec![ModelRequest {
+                unique_id: "model.project.invalid",
+                sql: "select from definitely not valid",
+            }],
+        };
+        let response = invoke(&request).unwrap();
+        let gap = &response.models[0].gaps[0];
+        assert_eq!(
+            gap,
+            "SQLGlot could not parse the compiled SQL: Invalid expression / Unexpected token at line 1, column 26"
+        );
+        assert!(!gap.contains('\u{1b}'));
+        assert!(!gap.contains("definitely not valid"));
+    }
+
+    #[test]
     fn sqlglot_marks_wildcards_as_gaps_instead_of_guessing() {
         let request = Request {
             models: vec![ModelRequest {
@@ -409,5 +498,124 @@ mod tests {
                 && edge.from_column == "AMOUNT"
                 && edge.to_column == "GROSS"
         }));
+    }
+
+    #[test]
+    fn extraction_keeps_multi_model_column_paths_composable() {
+        let staging = model("model.project.staging", "CI", None);
+        let mut summary = model("model.project.summary", "CI", None);
+        summary.depends_on.nodes = vec![staging.unique_id.clone()];
+        let current = manifest(vec![staging, summary]);
+        let production = manifest(vec![
+            model("model.project.staging", "PROD", None),
+            model("model.project.summary", "PROD", None),
+        ]);
+        let compiled = manifest(vec![
+            model(
+                "model.project.staging",
+                "CI",
+                Some("select order_id, amount from RAW.ORDERS"),
+            ),
+            model(
+                "model.project.summary",
+                "CI",
+                Some("select order_id, amount * 2 as gross from DB.CI.staging"),
+            ),
+        ]);
+
+        let extraction = extract(
+            "primary",
+            &current,
+            &production,
+            &compiled,
+            &BTreeSet::from([
+                "model.project.staging".into(),
+                "model.project.summary".into(),
+            ]),
+        )
+        .unwrap();
+
+        assert!(extraction.gaps.is_empty());
+        assert!(extraction.edges.iter().any(|edge| {
+            edge.from == "RAW.ORDERS"
+                && edge.from_column == "AMOUNT"
+                && edge.to == "model.project.staging"
+                && edge.to_column == "AMOUNT"
+        }));
+        assert!(extraction.edges.iter().any(|edge| {
+            edge.from == "model.project.staging"
+                && edge.from_column == "AMOUNT"
+                && edge.to == "model.project.summary"
+                && edge.to_column == "GROSS"
+        }));
+    }
+
+    #[test]
+    fn extraction_reports_missing_sql_and_ambiguous_relations() {
+        let mut left = model("model.project.left", "CI", None);
+        left.alias = "shared".into();
+        let mut right = model("model.project.right", "CI", None);
+        right.alias = "shared".into();
+        let target = model("model.project.target", "CI", None);
+        let missing = model("model.project.missing", "CI", None);
+        let current = manifest(vec![left, right, target, missing]);
+        let production = manifest(vec![]);
+        let compiled = manifest(vec![model(
+            "model.project.target",
+            "CI",
+            Some("select id from DB.CI.shared"),
+        )]);
+
+        let extraction = extract(
+            "primary",
+            &current,
+            &production,
+            &compiled,
+            &BTreeSet::from([
+                "model.project.missing".into(),
+                "model.project.target".into(),
+            ]),
+        )
+        .unwrap();
+
+        assert!(extraction.edges.is_empty());
+        assert!(extraction.gaps.iter().any(|gap| {
+            gap.model == "model.project.missing"
+                && gap.reason == "dbt did not emit compiled SQL for this model"
+        }));
+        assert!(extraction.gaps.iter().any(|gap| {
+            gap.model == "model.project.target"
+                && gap.reason.contains("matches more than one dbt model")
+        }));
+    }
+
+    #[test]
+    fn extraction_respects_quoted_relation_names() {
+        let mut source = model("model.project.source", "CaseSchema", None);
+        source.alias = "CaseTable".into();
+        source.config.quoting.schema = Some(true);
+        source.config.quoting.identifier = Some(true);
+        let mut target = model("model.project.target", "CI", None);
+        target.depends_on.nodes = vec![source.unique_id.clone()];
+        let current = manifest(vec![source, target]);
+        let compiled = manifest(vec![model(
+            "model.project.target",
+            "CI",
+            Some("select \"CaseColumn\" from DB.\"CaseSchema\".\"CaseTable\""),
+        )]);
+
+        let extraction = extract(
+            "primary",
+            &current,
+            &manifest(vec![]),
+            &compiled,
+            &BTreeSet::from(["model.project.target".into()]),
+        )
+        .unwrap();
+
+        assert!(extraction.gaps.is_empty());
+        assert_eq!(extraction.edges.len(), 1);
+        assert_eq!(extraction.edges[0].from, "model.project.source");
+        assert_eq!(extraction.edges[0].from_column, "CaseColumn");
     }
 }

--- a/src/run.rs
+++ b/src/run.rs
@@ -530,13 +530,6 @@ fn plan_selections(
             query_checks,
         });
     }
-    if !report.impact.dbt_models.is_empty() {
-        report.notices.push(Notice {
-            scope: "dbt".into(),
-            code: "column_lineage_unavailable".into(),
-            message: "dbt artifacts provide model-level, not authoritative column-level, dependency edges".into(),
-        });
-    }
     if selected_count > config.safety.max_models {
         let mut has_runnable_query = false;
         for (account, selection) in config.accounts.iter().zip(&mut selections) {
@@ -2496,6 +2489,12 @@ checks:
         assert_eq!(
             selections[0].selected,
             BTreeSet::from([changed_id.into(), target_id.into()])
+        );
+        assert!(
+            report
+                .notices
+                .iter()
+                .all(|notice| notice.code != "column_lineage_unavailable")
         );
 
         report.models.push(ModelReport {

--- a/src/sqlglot_lineage.py
+++ b/src/sqlglot_lineage.py
@@ -1,9 +1,28 @@
 import json
+import re
 import sys
 
 import sqlglot
 from sqlglot import exp
 from sqlglot.lineage import lineage
+
+
+ANSI_ESCAPE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+
+
+def error_text(error):
+    details = getattr(error, "errors", None)
+    if details:
+        detail = details[0]
+        description = detail.get("description", type(error).__name__)
+        line = detail.get("line")
+        column = detail.get("col")
+        if line is not None and column is not None:
+            return f"{description} at line {line}, column {column}"
+        return description
+
+    cleaned = ANSI_ESCAPE.sub("", str(error))
+    return " ".join(cleaned.split())[:500]
 
 
 def identifier(value):
@@ -35,7 +54,7 @@ def trace_model(model):
         return {
             "unique_id": model["unique_id"],
             "edges": [],
-            "gaps": [f"SQLGlot could not parse the compiled SQL: {error}"],
+            "gaps": [f"SQLGlot could not parse the compiled SQL: {error_text(error)}"],
         }
 
     for select in expression.selects:
@@ -57,7 +76,9 @@ def trace_model(model):
                 dialect="snowflake",
             )
         except Exception as error:
-            gaps.append(f"{output_column} could not be resolved by SQLGlot: {error}")
+            gaps.append(
+                f"{output_column} could not be resolved by SQLGlot: {error_text(error)}"
+            )
             continue
         if not output_is_quoted:
             output_column = output_column.upper()

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -183,7 +183,7 @@ fn check_exposes_scope_incremental_and_report_controls() {
         .stdout(predicate::str::contains(
             "--report-version <REPORT_VERSION>",
         ))
-        .stdout(predicate::str::contains("possible values: 1, 2, 3"))
+        .stdout(predicate::str::contains("possible values: 1, 2, 3, 4"))
         .stdout(predicate::str::contains("--verbose"));
 }
 


### PR DESCRIPTION
## Summary
- cover common Snowflake SQL, quoted relations, multi-model paths, missing SQL, and ambiguous mappings
- make SQLGlot parse gaps stable and terminal-safe
- remove the obsolete lineage warning and trim nonessential quickstart details
- prepare patch release 0.5.1

## Validation
- cargo fmt --check
- cargo clippy --locked --all-targets --all-features -- -D warnings
- cargo test --locked
- cargo test --locked --all-features
- cargo +1.85 check --locked --all-targets
- cargo package --locked
- actionlint; shellcheck install.sh; cargo audit
- real dbt dry-run fixture and default release binary smoke test
- SQLGlot 30.0.0 and 30.7.0 compatibility