### PR TITLE
Add OpenSSF Scorecard

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,43 @@
+name: Scorecard
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "30 1 * * 6"
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code scanning
+        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@
   </picture>
 </p>
 
+<p align="center">
+  <a href="https://github.com/EmbrasureAI/embrasure-cli/actions/workflows/github-code-scanning/codeql"><img src="https://github.com/EmbrasureAI/embrasure-cli/actions/workflows/github-code-scanning/codeql/badge.svg" alt="CodeQL"></a>
+  <a href="https://scorecard.dev/viewer/?uri=github.com/EmbrasureAI/embrasure-cli"><img src="https://api.scorecard.dev/projects/github.com/EmbrasureAI/embrasure-cli/badge" alt="OpenSSF Scorecard"></a>
+</p>
+
 <p align="center"><strong>Catch unexpected data changes before a dbt PR is reviewed.</strong></p>
 
 Embrasure is open-source, local dbt PR validation for Snowflake:


### PR DESCRIPTION
## Summary
- add the official OpenSSF Scorecard workflow with least-privilege permissions and SHA-pinned actions
- publish results for the public Scorecard badge and upload SARIF to code scanning
- add centered CodeQL and OpenSSF Scorecard badges to the README

## Checks
- actionlint .github/workflows/*.yml
- git diff --check
- verified the managed CodeQL badge is passing