### PR TITLE
Add Embrasure definition to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
   </picture>
 </p>
 
+<p align="center"><sub><em>An embrasure is an opening in a fortified wall, built to see and respond without giving up protection.</em></sub></p>
+
 <p align="center">
   <a href="https://github.com/EmbrasureAI/embrasure-cli/actions/workflows/github-code-scanning/codeql"><img src="https://github.com/EmbrasureAI/embrasure-cli/actions/workflows/github-code-scanning/codeql/badge.svg" alt="CodeQL"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/EmbrasureAI/embrasure-cli"><img src="https://api.scorecard.dev/projects/github.com/EmbrasureAI/embrasure-cli/badge" alt="OpenSSF Scorecard"></a>


### PR DESCRIPTION
## Summary
- add the Embrasure definition directly below the logo
- render it as centered, small italic text

## Check
- git diff --check