### PR TITLE
Improve OpenSSF Scorecard coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,10 @@ jobs:
   action:
     runs-on: ubuntu-24.04
     steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install through the documented action
-        uses: EmbrasureAI/embrasure-cli@v1
+        uses: ./
       - name: Verify the installed CLI
         run: embrasure --version | grep '^embrasure '
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,9 +132,16 @@ jobs:
       - name: Generate checksums
         run: cd dist && sha256sum -- *.tar.gz *.spdx.json > SHA256SUMS
       - name: Attest build provenance
+        id: provenance
         uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
           subject-checksums: dist/SHA256SUMS
+      - name: Stage build provenance
+        env:
+          PROVENANCE_BUNDLE: ${{ steps.provenance.outputs.bundle-path }}
+        run: |
+          test -s "${PROVENANCE_BUNDLE}"
+          cp "${PROVENANCE_BUNDLE}" "dist/embrasure-${GITHUB_REF_NAME}.intoto.jsonl"
       - name: Attest SBOM
         uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,5 @@
 # Security
 
-Report vulnerabilities or possible credential exposure through GitHub's private vulnerability reporting. Do not open a public issue.
+Report vulnerabilities or possible credential exposure through [GitHub's private vulnerability reporting](https://github.com/EmbrasureAI/embrasure-cli/security/advisories/new). Do not open a public issue.
 
 See [Security and data flow](docs/security-and-data-flow.md) for permissions, network connections, local storage, data handling, cleanup, updates, and release verification.


### PR DESCRIPTION
## Summary

- link the private vulnerability-reporting channel
- test the checked-out action instead of a mutable tag
- attach signed provenance to future GitHub releases

The equivalent Repository Rules migration and verified provenance backfill for the last five releases are already applied in GitHub.

## Validation

- `actionlint .github/workflows/*.yml`
- `cargo fmt --check`
- `cargo test --locked` (101 passed)