### PR TITLE
Maximize main branch review protection

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Require review from the other repository administrator before changes reach main.
+* @JacbK @ForVic

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
   schedule:
     - cron: "30 1 * * 6"
 


### PR DESCRIPTION
## Summary

- assign both repository administrators as code owners
- allow manual Scorecard rescans after repository-setting changes

After this merges, the main ruleset will require one code-owner approval, dismiss stale approvals, and require approval from someone other than the last pusher.

## Validation

- `actionlint .github/workflows/*.yml`
- `git diff --check`