### PR TITLE
Improve check progress and final output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,5 +45,5 @@ jobs:
       - name: Check out source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install minimum supported Rust
-        run: rustup toolchain install 1.85 --profile minimal
-      - run: cargo +1.85 check --locked --all-targets
+        run: rustup toolchain install 1.88 --profile minimal
+      - run: cargo +1.88 check --locked --all-targets

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,6 +95,15 @@ name = "anyhow"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
+
+[[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "assert_cmd"
@@ -183,6 +198,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
+
+[[package]]
 name = "bytecount"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -193,6 +214,15 @@ name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cc"
@@ -305,10 +335,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "core-foundation-sys"
@@ -326,12 +379,102 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -394,6 +537,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
+name = "either"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+
+[[package]]
 name = "email_address"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -419,6 +577,7 @@ dependencies = [
  "openssl",
  "predicates",
  "rand 0.8.7",
+ "ratatui",
  "reqwest",
  "serde",
  "serde_json",
@@ -489,6 +648,18 @@ dependencies = [
  "ref-cast",
  "serde",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -611,9 +782,25 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
@@ -834,6 +1021,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -861,7 +1054,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6778b0196eefee7df739db78758e5cf9b37412268bfa5650bfeed028aed20d9c"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -875,6 +1090,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -969,6 +1193,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "kasuari"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
+dependencies = [
+ "hashbrown 0.16.1",
+ "portable-atomic",
+ "thiserror",
+]
+
+[[package]]
 name = "keyring"
 version = "3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -991,12 +1226,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libredox"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "line-clipping"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e752191d037c44ad111a8caa762921926658402f01cc1253f7bef2020ece4f5e"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -1012,6 +1262,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1025,6 +1281,15 @@ name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "lru"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
+dependencies = [
+ "hashbrown 0.17.1",
+]
 
 [[package]]
 name = "lru-slab"
@@ -1045,6 +1310,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -1101,6 +1367,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
 name = "num-integer"
 version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1137,6 +1409,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1259,6 +1540,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
+name = "palette"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddeed8580d347d2abf3dcf06a5f0b3dc020258338526b277847cd4248a70fc64"
+dependencies = [
+ "approx",
+ "libm",
+ "palette_derive",
+ "palette_math",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88537020289b719d81be994ccf1bbf4990f477e2f69ee52fe3e45f43a02e56be"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "palette_math"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e6eb142958d64335fb0e345c5b9ead2ecd6fc438c307e9d7d3c4fd428dbaf12"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1300,6 +1614,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "portable-atomic"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1307,6 +1627,12 @@ checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1487,6 +1813,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "ratatui"
+version = "0.30.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3274ba0a2c5e1bcad2a2005d20f4dc59dad26b2eb0940fb094500dba4099d57d"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-widgets",
+ "serde",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbb175c433c8e28a809d1f5773a2ae96e68c0ce40db865cbab1020bf33ae479c"
+dependencies = [
+ "bitflags",
+ "compact_str",
+ "hashbrown 0.17.1",
+ "itertools",
+ "kasuari",
+ "lru",
+ "palette",
+ "serde",
+ "strum",
+ "thiserror",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567584a3b0e6a8203c23de40b4861497266725eb5363dbfd18a1edd603cca9f0"
+dependencies = [
+ "cfg-if",
+ "crossterm",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66e3d19bcc9130ca376277d93b60767ff121ace3be06f5f95f81dd68956407d1"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.17.1",
+ "indoc",
+ "instability",
+ "itertools",
+ "line-clipping",
+ "ratatui-core",
+ "serde",
+ "strum",
+ "time",
+ "unicode-segmentation",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1806,6 +2198,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1860,10 +2273,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "subtle"
@@ -1951,6 +2391,27 @@ dependencies = [
  "quote",
  "syn 3.0.3",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
+dependencies = [
+ "deranged",
+ "libc",
+ "num-conv",
+ "num_threads",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "tinystr"
@@ -2095,6 +2556,29 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-truncate"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -2317,6 +2801,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2324,6 +2824,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "embrasure-cli"
 version = "0.5.2"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.88"
 description = "Embrasure CLI for validating dbt changes against production Snowflake data"
 license = "Apache-2.0"
 repository = "https://github.com/EmbrasureAI/embrasure-cli"
@@ -30,6 +30,7 @@ directories = "6.0"
 keyring = { version = "3.6", optional = true }
 openssl = { version = "0.10", features = ["vendored"] }
 rand = "0.8"
+ratatui = { version = "0.30.2", default-features = false, features = ["crossterm"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -58,10 +58,33 @@ Use Embrasure from an existing Snowflake dbt project whose unchanged production 
 Example result:
 
 ```text
-embrasure: PASS
-2 selected · 2 built · 2 compared · 0 query checks run · 0 findings · 0 coverage gaps
-5 impacted · 2 validated · 3 not validated
+✓ Safe to continue
+
+The change passed across every selected dbt model.
+
+Scope
+  5 affected models
+  2 selected for validation
+
+Evidence
+  2 / 2 models built · 2 compared with production
+  151,615,312 candidate rows evaluated
+  Schema, row counts, nulls, cardinality, and distributions checked
+  1 primary key checked
+  0 findings · 3 unvalidated models
+  Temporary Snowflake schema removed
+
+Lineage impact
+  fct_orders
+  └─ finance_daily
+     ├─ executive_revenue
+     ├─ regional_margin
+     └─ revenue_forecast_input
+
+Completed in 2m11s
 ```
+
+In an interactive terminal, `check` shows live progress while it runs. Redirected output, CI, and `--json` stay plain.
 
 ## Focus and preview
 
@@ -229,7 +252,7 @@ Every temporary schema has a unique name and ownership marker. Query results are
 
 ## Development
 
-Rust 1.85 or newer is required when building from source.
+Rust 1.88 or newer is required when building from source.
 
 ```sh
 cargo fmt --check

--- a/docs/security-and-data-flow.md
+++ b/docs/security-and-data-flow.md
@@ -73,6 +73,8 @@ Incremental baselines use Snowflake table-level zero-copy clones. Embrasure neve
 
 Each run uses unique candidate and baseline schema names and writes an ownership marker to every schema. Cleanup requires both the exact run namespace and matching marker. The CLI refuses to drop a schema that fails either check.
 
+Schemas are dropped with `RESTRICT` instead of the Snowflake `CASCADE` default, so cleanup never removes foreign keys held by objects outside the schema. Because `RESTRICT` only warns, the CLI confirms the schema is gone before reporting it as removed.
+
 Cleanup is attempted after success, findings, execution failures, Ctrl-C, and normal termination signals. No process can clean up after `SIGKILL`, a machine crash, or power loss. `embrasure clean` lists old marked schemas by default and removes them only with `--yes`. It searches only each configured account database and verifies both the configured prefix and an Embrasure ownership marker before removal.
 
 ## Release integrity

--- a/src/cloud.rs
+++ b/src/cloud.rs
@@ -539,17 +539,17 @@ pub async fn status(run_id: Option<&str>) -> Result<Value> {
 }
 
 pub async fn logout() -> Result<()> {
-    if let Ok(session) = load_session() {
-        if let Ok(client) = update::http_client() {
-            let _ = client
-                .post(format!(
-                    "{}/v1/auth/session/revoke",
-                    session.api_base_url.trim_end_matches('/')
-                ))
-                .json(&json!({"refresh_token": session.refresh_token}))
-                .send()
-                .await;
-        }
+    if let Ok(session) = load_session()
+        && let Ok(client) = update::http_client()
+    {
+        let _ = client
+            .post(format!(
+                "{}/v1/auth/session/revoke",
+                session.api_base_url.trim_end_matches('/')
+            ))
+            .json(&json!({"refresh_token": session.refresh_token}))
+            .send()
+            .await;
     }
     match keychain()?.delete_credential() {
         Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
@@ -561,16 +561,16 @@ pub async fn logout() -> Result<()> {
 }
 
 async fn valid_session() -> Result<CloudSession> {
-    if let Ok(access_token) = env::var("EMBRASURE_CLOUD_TOKEN") {
-        if !access_token.trim().is_empty() {
-            return Ok(CloudSession {
-                access_token,
-                refresh_token: String::new(),
-                expires_at: "9999-12-31T23:59:59Z".into(),
-                workspace_id: env::var("EMBRASURE_CLOUD_WORKSPACE_ID").unwrap_or_default(),
-                api_base_url: api_base_url(),
-            });
-        }
+    if let Ok(access_token) = env::var("EMBRASURE_CLOUD_TOKEN")
+        && !access_token.trim().is_empty()
+    {
+        return Ok(CloudSession {
+            access_token,
+            refresh_token: String::new(),
+            expires_at: "9999-12-31T23:59:59Z".into(),
+            workspace_id: env::var("EMBRASURE_CLOUD_WORKSPACE_ID").unwrap_or_default(),
+            api_base_url: api_base_url(),
+        });
     }
     let session =
         load_session().context("not signed in to Embrasure Cloud; run `embrasure cloud login`")?;

--- a/src/compare.rs
+++ b/src/compare.rs
@@ -91,20 +91,19 @@ pub async fn compare_model(
                 "column_added",
                 format!("column {name} exists in CI but not production"),
             ));
-        } else if let (Some(ci_column), Some(prod_column)) = (ci_column, prod_column) {
-            if !ci_column
+        } else if let (Some(ci_column), Some(prod_column)) = (ci_column, prod_column)
+            && !ci_column
                 .data_type
                 .eq_ignore_ascii_case(&prod_column.data_type)
-            {
-                findings.push(finding(
-                    model_id,
-                    "column_type",
-                    format!(
-                        "column {name} changed from {} to {}",
-                        prod_column.data_type, ci_column.data_type,
-                    ),
-                ));
-            }
+        {
+            findings.push(finding(
+                model_id,
+                "column_type",
+                format!(
+                    "column {name} changed from {} to {}",
+                    prod_column.data_type, ci_column.data_type,
+                ),
+            ));
         }
         let ci_value = ci_metrics.columns.get(&name).cloned();
         let prod_value = prod_metrics.columns.get(&name).cloned();
@@ -138,15 +137,13 @@ pub async fn compare_model(
                 ("p50", ci_value.p50, prod_value.p50),
                 ("p95", ci_value.p95, prod_value.p95),
             ] {
-                if numeric {
-                    if let (Some(ci_number), Some(prod_number)) = (ci_number, prod_number) {
-                        let change = relative_change(ci_number, prod_number);
-                        if change > thresholds.numeric_relative {
-                            findings.push(finding(model_id, "distribution", format!(
+                if numeric && let (Some(ci_number), Some(prod_number)) = (ci_number, prod_number) {
+                    let change = relative_change(ci_number, prod_number);
+                    if change > thresholds.numeric_relative {
+                        findings.push(finding(model_id, "distribution", format!(
                                 "column {name} {metric} is {ci_number:.6} in CI vs {prod_number:.6} in production (relative change {change:.6}, allowed {:.6})",
                                 thresholds.numeric_relative,
                             )));
-                        }
                     }
                 }
             }
@@ -167,12 +164,12 @@ pub async fn compare_model(
                             )));
                         }
                     }
-                } else if let (Some(ci_extreme), Some(prod_extreme)) = (ci_extreme, prod_extreme) {
-                    if ci_extreme != prod_extreme {
-                        findings.push(finding(model_id, "range", format!(
+                } else if let (Some(ci_extreme), Some(prod_extreme)) = (ci_extreme, prod_extreme)
+                    && ci_extreme != prod_extreme
+                {
+                    findings.push(finding(model_id, "range", format!(
                             "column {name} {metric} is {ci_extreme:?} in CI vs {prod_extreme:?} in production"
                         )));
-                    }
                 }
             }
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -499,14 +499,13 @@ impl Config {
                     check.name
                 );
             }
-            if let Some(account) = &check.account {
-                if !self
+            if let Some(account) = &check.account
+                && !self
                     .accounts
                     .iter()
                     .any(|candidate| candidate.name == *account)
-                {
-                    bail!("check {} references unknown account {account}", check.name);
-                }
+            {
+                bail!("check {} references unknown account {account}", check.name);
             }
             crate::query::QueryTemplate::parse(&check.sql)
                 .with_context(|| format!("invalid SQL template for check {}", check.name))?;
@@ -543,17 +542,16 @@ impl Config {
             }
         }
         for (model, config) in &self.models {
-            if let Some(predicate) = &config.where_clause {
-                if predicate.trim().is_empty()
+            if let Some(predicate) = &config.where_clause
+                && (predicate.trim().is_empty()
                     || predicate.contains(';')
                     || predicate.contains("--")
                     || predicate.contains("/*")
-                    || predicate.contains("*/")
-                {
-                    bail!(
-                        "models.{model}.where must be one non-empty SQL predicate without comments or semicolons"
-                    );
-                }
+                    || predicate.contains("*/"))
+            {
+                bail!(
+                    "models.{model}.where must be one non-empty SQL predicate without comments or semicolons"
+                );
             }
             let effective = config.thresholds.apply(self.thresholds);
             if !valid_rate(effective.row_count_relative)

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod init;
 mod lineage;
 mod loopback;
 mod metabase;
+mod progress;
 mod query;
 mod report;
 mod run;
@@ -18,7 +19,7 @@ mod snowflake;
 mod style;
 mod update;
 
-use std::{io::IsTerminal, path::PathBuf, process::ExitCode};
+use std::{io::IsTerminal, path::PathBuf, process::ExitCode, time::Instant};
 
 use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
 
@@ -300,6 +301,9 @@ async fn main() -> ExitCode {
             #[cfg(feature = "cloud-demo")]
             context_file,
         } => {
+            let check_started = Instant::now();
+            let progress_display = progress::Display::start(&base, json, dry_run);
+            let progress_active = progress_display.is_some();
             #[cfg(feature = "cloud-demo")]
             let use_cloud = cloud;
             let options = run::CheckOptions {
@@ -308,6 +312,7 @@ async fn main() -> ExitCode {
                 critical_tags: (!critical_tags.is_empty()).then_some(critical_tags),
                 incremental_mode: incremental_mode.map(Into::into),
                 select,
+                progress: progress_display.as_ref().map(progress::Display::reporter),
             };
             let loaded_config = run::load_config(&config, &options);
 
@@ -355,7 +360,9 @@ async fn main() -> ExitCode {
                         }
                     }
                 } else {
-                    eprintln!("embrasure: validating changes against {base}");
+                    if !progress_active {
+                        eprintln!("embrasure: validating changes against {base}");
+                    }
                     match loaded_config {
                         Ok(config) => {
                             run::run_check_with_config(config, &base, &options, dry_run).await
@@ -363,17 +370,19 @@ async fn main() -> ExitCode {
                         Err(error) => run::failed_check(&base, error),
                     }
                 };
-                if let Some(snapshot) = &snapshot {
-                    if let Err(error) = cloud::save_review(snapshot, &report) {
-                        eprintln!("embrasure: could not save the local review cache: {error:#}");
-                    }
+                if let Some(snapshot) = &snapshot
+                    && let Err(error) = cloud::save_review(snapshot, &report)
+                {
+                    eprintln!("embrasure: could not save the local review cache: {error:#}");
                 }
                 (intent, snapshot, report)
             };
 
             #[cfg(not(feature = "cloud-demo"))]
             let mut report = {
-                eprintln!("embrasure: validating changes against {base}");
+                if !progress_active {
+                    eprintln!("embrasure: validating changes against {base}");
+                }
                 match loaded_config {
                     Ok(config) => {
                         run::run_check_with_config(config, &base, &options, dry_run).await
@@ -381,15 +390,19 @@ async fn main() -> ExitCode {
                     Err(error) => run::failed_check(&base, error),
                 }
             };
-            if let Some(path) = markdown {
-                if let Err(error) = report.write_markdown(&path) {
-                    report
-                        .execution_errors
-                        .push(format!("could not write Markdown report: {error:#}"));
-                    report.finalize();
-                }
+            if let Some(path) = markdown
+                && let Err(error) = report.write_markdown(&path)
+            {
+                report
+                    .execution_errors
+                    .push(format!("could not write Markdown report: {error:#}"));
+                report.finalize();
             }
             let report_version = report_version.unwrap_or(report::ReportVersion::V4);
+
+            if let Some(display) = progress_display {
+                display.finish(&report);
+            }
 
             #[cfg(feature = "cloud-demo")]
             if use_cloud {
@@ -452,7 +465,14 @@ async fn main() -> ExitCode {
                 }
                 ExitCode::from(report.exit_code)
             } else {
-                print!("{}", report.human_styled(verbose, &style::Style::stdout()));
+                print!(
+                    "{}",
+                    report.human_styled_with_elapsed(
+                        verbose,
+                        &style::Style::stdout(),
+                        check_started.elapsed(),
+                    )
+                );
                 ExitCode::from(report.exit_code)
             }
         }

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1,0 +1,452 @@
+use std::{
+    io::{self, IsTerminal, Write},
+    sync::{Arc, Mutex},
+    thread,
+    time::{Duration, Instant},
+};
+
+use ratatui::{
+    Frame, Terminal, TerminalOptions, Viewport,
+    backend::{Backend, CrosstermBackend},
+    layout::Rect,
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::Paragraph,
+};
+
+use crate::report::{Report, Status};
+
+const FRAME_INTERVAL: Duration = Duration::from_millis(80);
+const VIEWPORT_HEIGHT: u16 = 8;
+const SPINNER: &[char] = &['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Phase {
+    Setup,
+    Schema,
+    Impact,
+    Build,
+    Compare,
+    Cleanup,
+}
+
+impl Phase {
+    const ALL: [Self; 6] = [
+        Self::Setup,
+        Self::Schema,
+        Self::Impact,
+        Self::Build,
+        Self::Compare,
+        Self::Cleanup,
+    ];
+
+    const fn index(self) -> usize {
+        match self {
+            Self::Setup => 0,
+            Self::Schema => 1,
+            Self::Impact => 2,
+            Self::Build => 3,
+            Self::Compare => 4,
+            Self::Cleanup => 5,
+        }
+    }
+
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Setup => "Verify local setup",
+            Self::Schema => "Create temporary Snowflake schemas",
+            Self::Impact => "Map affected models",
+            Self::Build => "Build selected models",
+            Self::Compare => "Compare results with production",
+            Self::Cleanup => "Remove temporary Snowflake schemas",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct State {
+    base: String,
+    started: Instant,
+    phase: Phase,
+    failed_phase: Option<Phase>,
+    affected: usize,
+    selected: usize,
+    built: usize,
+    comparisons_done: usize,
+    comparisons_total: usize,
+    cleanup_done: usize,
+    cleanup_total: usize,
+    finished: bool,
+    status: Option<Status>,
+}
+
+impl State {
+    fn new(base: &str) -> Self {
+        Self {
+            base: base.to_owned(),
+            started: Instant::now(),
+            phase: Phase::Setup,
+            failed_phase: None,
+            affected: 0,
+            selected: 0,
+            built: 0,
+            comparisons_done: 0,
+            comparisons_total: 0,
+            cleanup_done: 0,
+            cleanup_total: 0,
+            finished: false,
+            status: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Reporter {
+    state: Arc<Mutex<State>>,
+}
+
+impl Reporter {
+    pub fn phase(&self, phase: Phase) {
+        self.update(|state| state.phase = phase);
+    }
+
+    pub fn scope(&self, affected: usize, selected: usize) {
+        self.update(|state| {
+            state.affected = affected;
+            state.selected = selected;
+        });
+    }
+
+    pub fn built(&self, count: usize) {
+        self.update(|state| state.built = count);
+    }
+
+    pub fn comparisons(&self, done: usize, total: usize) {
+        self.update(|state| {
+            state.comparisons_done = done;
+            state.comparisons_total = total;
+        });
+    }
+
+    pub fn cleanup(&self, done: usize, total: usize) {
+        self.update(|state| {
+            state.cleanup_done = done;
+            state.cleanup_total = total;
+        });
+    }
+
+    pub fn fail_current(&self) {
+        self.update(|state| {
+            state.failed_phase.get_or_insert(state.phase);
+        });
+    }
+
+    fn update(&self, update: impl FnOnce(&mut State)) {
+        if let Ok(mut state) = self.state.lock() {
+            update(&mut state);
+        }
+    }
+}
+
+pub struct Display {
+    reporter: Reporter,
+    worker: Option<thread::JoinHandle<()>>,
+}
+
+impl Display {
+    pub fn start(base: &str, json: bool, dry_run: bool) -> Option<Self> {
+        if !enabled(json, dry_run) {
+            return None;
+        }
+        let backend = CrosstermBackend::new(io::stderr());
+        let terminal = Terminal::with_options(
+            backend,
+            TerminalOptions {
+                viewport: Viewport::Inline(VIEWPORT_HEIGHT),
+            },
+        )
+        .ok()?;
+        let reporter = Reporter {
+            state: Arc::new(Mutex::new(State::new(base))),
+        };
+        let state = Arc::clone(&reporter.state);
+        let worker = thread::Builder::new()
+            .name("embrasure-progress".to_owned())
+            .spawn(move || render_loop(terminal, state))
+            .ok()?;
+        Some(Self {
+            reporter,
+            worker: Some(worker),
+        })
+    }
+
+    pub fn reporter(&self) -> Reporter {
+        self.reporter.clone()
+    }
+
+    pub fn finish(mut self, report: &Report) {
+        self.reporter.update(|state| {
+            state.finished = true;
+            state.status = Some(report.status);
+            state.cleanup_total = report.ci_schemas.len();
+            state.cleanup_done = report
+                .ci_schemas
+                .iter()
+                .filter(|schema| schema.cleaned_up)
+                .count();
+            if state.cleanup_done < state.cleanup_total {
+                state.failed_phase = Some(Phase::Cleanup);
+            } else if report.status == Status::ExecutionFailure && state.failed_phase.is_none() {
+                state.failed_phase = Some(state.phase);
+            }
+        });
+        if let Some(worker) = self.worker.take() {
+            let _ = worker.join();
+        }
+    }
+}
+
+impl Drop for Display {
+    fn drop(&mut self) {
+        self.reporter.update(|state| state.finished = true);
+        if let Some(worker) = self.worker.take() {
+            let _ = worker.join();
+        }
+    }
+}
+
+fn enabled(json: bool, dry_run: bool) -> bool {
+    enabled_for(
+        json,
+        dry_run,
+        io::stdout().is_terminal() && io::stderr().is_terminal(),
+        std::env::var_os("CI").is_some()
+            || std::env::var_os("NO_COLOR").is_some()
+            || std::env::var("TERM").is_ok_and(|term| term.eq_ignore_ascii_case("dumb")),
+    )
+}
+
+const fn enabled_for(
+    json: bool,
+    dry_run: bool,
+    interactive_terminal: bool,
+    plain_output: bool,
+) -> bool {
+    !json && !dry_run && interactive_terminal && !plain_output
+}
+
+type ProgressTerminal = Terminal<CrosstermBackend<io::Stderr>>;
+
+fn render_loop(mut terminal: ProgressTerminal, state: Arc<Mutex<State>>) {
+    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let mut frame = 0usize;
+        loop {
+            let snapshot = match state.lock() {
+                Ok(state) => state.clone(),
+                Err(_) => break,
+            };
+            if terminal
+                .draw(|area| render(area, &snapshot, frame))
+                .is_err()
+            {
+                break;
+            }
+            frame = frame.wrapping_add(1);
+            if snapshot.finished {
+                break;
+            }
+            thread::sleep(FRAME_INTERVAL);
+        }
+    }));
+    let cleared = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        clear_for_report(&mut terminal).is_ok()
+    }))
+    .unwrap_or(false);
+    let _ = terminal.show_cursor();
+    let _ = Backend::flush(terminal.backend_mut());
+    drop(terminal);
+    if !cleared {
+        let mut stderr = io::stderr();
+        for _ in 0..VIEWPORT_HEIGHT {
+            let _ = stderr.write_all(b"\r\n");
+        }
+        let _ = stderr.flush();
+    }
+}
+
+fn clear_for_report<B: Backend>(terminal: &mut Terminal<B>) -> Result<(), B::Error> {
+    terminal
+        .draw(|frame| frame.set_cursor_position(frame.area().as_position()))
+        .map(|_| ())
+}
+
+fn render(frame: &mut Frame<'_>, state: &State, tick: usize) {
+    let render_area = Rect::new(
+        frame.area().x,
+        frame.area().y,
+        frame.area().width,
+        frame.area().height.min(VIEWPORT_HEIGHT),
+    );
+    frame.render_widget(Paragraph::new(lines(state, tick)), render_area);
+}
+
+fn lines(state: &State, frame: usize) -> Vec<Line<'static>> {
+    let elapsed = format_elapsed(state.started.elapsed());
+    let outcome = match state.status {
+        Some(Status::Pass) => " · safe to continue",
+        Some(Status::Findings) => " · findings found",
+        Some(Status::Incomplete) => " · incomplete",
+        Some(Status::ExecutionFailure) => " · stopped",
+        None => "",
+    };
+    let mut lines = vec![Line::from(vec![
+        Span::styled(
+            "Embrasure review",
+            Style::default().add_modifier(Modifier::BOLD),
+        ),
+        Span::raw(format!(" · {} · {elapsed}{outcome}", state.base)),
+    ])];
+    for phase in Phase::ALL {
+        let index = phase.index();
+        let current = state.phase.index();
+        let failed = state.failed_phase == Some(phase);
+        let (symbol, style) = if failed {
+            ("×".to_owned(), Style::default().fg(Color::Red))
+        } else if index < current || (state.finished && index == current) {
+            ("✓".to_owned(), Style::default().fg(Color::Green))
+        } else if index == current {
+            (
+                SPINNER[frame % SPINNER.len()].to_string(),
+                Style::default().fg(Color::Cyan),
+            )
+        } else {
+            ("○".to_owned(), Style::default().fg(Color::DarkGray))
+        };
+        lines.push(step_line(&symbol, style, phase, state));
+    }
+    lines
+}
+
+fn step_line(symbol: &str, style: Style, phase: Phase, state: &State) -> Line<'static> {
+    let detail = match phase {
+        Phase::Impact if state.affected > 0 => {
+            format!(
+                "  {} affected · {} selected",
+                state.affected, state.selected
+            )
+        }
+        Phase::Build if state.selected > 0 => format!("  {} / {}", state.built, state.selected),
+        Phase::Compare if state.comparisons_total > 0 => {
+            format!("  {} / {}", state.comparisons_done, state.comparisons_total)
+        }
+        Phase::Cleanup if state.cleanup_total > 0 => {
+            format!("  {} / {}", state.cleanup_done, state.cleanup_total)
+        }
+        _ => String::new(),
+    };
+    Line::from(vec![
+        Span::styled(format!("{symbol} "), style),
+        Span::raw(format!("{}{detail}", phase.label())),
+    ])
+}
+
+fn format_elapsed(duration: Duration) -> String {
+    let seconds = duration.as_secs();
+    format!("{:02}:{:02}", seconds / 60, seconds % 60)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::backend::TestBackend;
+
+    #[test]
+    fn progress_uses_real_scope_and_counters() {
+        let mut state = State::new("origin/main");
+        state.phase = Phase::Compare;
+        state.affected = 5;
+        state.selected = 4;
+        state.built = 4;
+        state.comparisons_done = 3;
+        state.comparisons_total = 5;
+        let rendered = lines(&state, 0)
+            .into_iter()
+            .map(|line| line.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(rendered.contains("5 affected · 4 selected"));
+        assert!(rendered.contains("Build selected models  4 / 4"));
+        assert!(rendered.contains("Compare results with production  3 / 5"));
+    }
+
+    #[test]
+    fn review_board_renders_in_a_small_terminal() {
+        let mut state = State::new("origin/main");
+        state.phase = Phase::Build;
+        state.affected = 5;
+        state.selected = 4;
+        state.built = 2;
+        let backend = TestBackend::new(60, VIEWPORT_HEIGHT);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|frame| render(frame, &state, 0)).unwrap();
+
+        let content = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+        assert!(content.contains("Embrasure review · origin/main"));
+        assert!(content.contains("Build selected models  2 / 4"));
+    }
+
+    #[test]
+    fn review_board_handles_a_tiny_terminal() {
+        let state = State::new("origin/main");
+        let backend = TestBackend::new(20, 3);
+        let mut terminal = Terminal::new(backend).unwrap();
+
+        terminal.draw(|frame| render(frame, &state, 0)).unwrap();
+    }
+
+    #[test]
+    fn final_output_replaces_the_review_board() {
+        let state = State::new("origin/main");
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::with_options(
+            backend,
+            TerminalOptions {
+                viewport: Viewport::Inline(VIEWPORT_HEIGHT),
+            },
+        )
+        .unwrap();
+        terminal.draw(|frame| render(frame, &state, 0)).unwrap();
+
+        clear_for_report(&mut terminal).unwrap();
+        terminal.backend_mut().assert_cursor_position((0, 0));
+        assert!(
+            terminal
+                .backend()
+                .buffer()
+                .content()
+                .iter()
+                .all(|cell| cell.symbol() == " ")
+        );
+    }
+
+    #[test]
+    fn progress_only_runs_in_an_interactive_terminal() {
+        assert!(enabled_for(false, false, true, false));
+        assert!(!enabled_for(true, false, true, false));
+        assert!(!enabled_for(false, true, true, false));
+        assert!(!enabled_for(false, false, false, false));
+        assert!(!enabled_for(false, false, true, true));
+    }
+
+    #[test]
+    fn elapsed_time_is_stable() {
+        assert_eq!(format_elapsed(Duration::from_secs(131)), "02:11");
+    }
+}

--- a/src/report.rs
+++ b/src/report.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Write as _, fs, path::Path};
+use std::{fmt::Write as _, fs, path::Path, time::Duration};
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
@@ -425,58 +425,223 @@ impl Report {
         self.human_styled(verbose, &Style::plain())
     }
 
+    #[cfg_attr(not(feature = "cloud-demo"), allow(dead_code))]
     pub fn human_styled(&self, verbose: bool, style: &Style) -> String {
-        let label = match self.status {
-            Status::Pass => style.good("PASS"),
-            Status::Findings => style.bad("FINDINGS"),
-            Status::Incomplete => style.warn("INCOMPLETE"),
-            Status::ExecutionFailure => style.bad("EXECUTION FAILURE"),
+        self.human_styled_inner(verbose, style, None)
+    }
+
+    pub fn human_styled_with_elapsed(
+        &self,
+        verbose: bool,
+        style: &Style,
+        elapsed: Duration,
+    ) -> String {
+        self.human_styled_inner(verbose, style, Some(elapsed))
+    }
+
+    fn human_styled_inner(
+        &self,
+        verbose: bool,
+        style: &Style,
+        elapsed: Option<Duration>,
+    ) -> String {
+        let dry_run = self.notices.iter().any(|notice| notice.code == "dry_run");
+        let heading = match (self.status, dry_run) {
+            (Status::Pass, true) => style.good("✓ Validation plan ready"),
+            (Status::Pass, false) => style.good("✓ Safe to continue"),
+            (Status::Findings, _) => style.bad("× Findings need review"),
+            (Status::Incomplete, _) => style.warn("! Review incomplete"),
+            (Status::ExecutionFailure, _) => style.bad("× Review stopped"),
         };
-        let mut output = format!(
-            "embrasure: {label}\n{} selected · {} built · {} compared · {} query checks run · {} findings · {} coverage gaps\n{} impacted · {} validated · {} not validated\n",
-            self.summary.models_selected,
-            self.summary.models_built,
-            self.summary.models_compared,
-            self.summary.query_checks_run,
-            self.summary.findings,
-            self.summary.coverage_gaps,
-            self.validation_scope.impacted_models,
-            self.validation_scope.validated_models.len(),
-            self.validation_scope.skipped_models.len(),
-        );
-        self.write_human_findings(&mut output, verbose);
-        for gap in &self.coverage_gaps {
+        let explanation = match (self.status, dry_run) {
+            (Status::Pass, true) => "No schemas were created and no warehouse data was queried.",
+            (Status::Pass, false) if self.summary.models_selected == 0 => {
+                "No affected dbt models needed validation."
+            }
+            (Status::Pass, false) => "The change passed across every selected dbt model.",
+            (Status::Findings, _) => "Review the findings below before you merge.",
+            (Status::Incomplete, _) => "Some affected models or checks could not be validated.",
+            (Status::ExecutionFailure, _) => "The review stopped before validation finished.",
+        };
+        let mut output = format!("{heading}\n\n{explanation}\n");
+        let has_review_data = self.validation_scope.impacted_models > 0
+            || self.summary.models_selected > 0
+            || self.summary.query_checks_configured > 0
+            || !self.ci_schemas.is_empty();
+        if self.status != Status::ExecutionFailure || has_review_data {
+            output.push_str("\nScope\n");
             let _ = writeln!(
                 output,
-                "- [unknown:{}] {}: {}",
-                gap.check, gap.scope, gap.reason
+                "  {} affected model{}",
+                self.validation_scope.impacted_models,
+                plural(self.validation_scope.impacted_models)
             );
+            let _ = writeln!(
+                output,
+                "  {} selected for validation",
+                self.summary.models_selected
+            );
+            if !self.impact.dbt_exposures.is_empty() {
+                let _ = writeln!(
+                    output,
+                    "  {} downstream exposure{}",
+                    self.impact.dbt_exposures.len(),
+                    plural(self.impact.dbt_exposures.len())
+                );
+            }
+            if !self.impact.metabase_dashboards.is_empty() {
+                let _ = writeln!(
+                    output,
+                    "  {} Metabase dashboard{}",
+                    self.impact.metabase_dashboards.len(),
+                    plural(self.impact.metabase_dashboards.len())
+                );
+            }
+
+            output.push_str(if dry_run { "\nPlan\n" } else { "\nEvidence\n" });
+            if dry_run {
+                let _ = writeln!(
+                    output,
+                    "  {} model build{} planned",
+                    self.summary.models_selected,
+                    plural(self.summary.models_selected)
+                );
+                if self.summary.query_checks_configured > 0 {
+                    let _ = writeln!(
+                        output,
+                        "  {} query check{} planned",
+                        self.summary.query_checks_configured,
+                        plural(self.summary.query_checks_configured)
+                    );
+                }
+            } else {
+                let _ = writeln!(
+                    output,
+                    "  {} / {} models built · {} compared with production",
+                    self.summary.models_built,
+                    self.summary.models_selected,
+                    self.summary.models_compared
+                );
+                let candidate_rows = self
+                    .models
+                    .iter()
+                    .filter_map(|model| model.comparison.as_ref())
+                    .map(|comparison| comparison.ci_row_count)
+                    .fold(0u64, u64::saturating_add);
+                if self.summary.models_compared > 0 {
+                    let _ = writeln!(
+                        output,
+                        "  {} candidate rows evaluated",
+                        format_count(candidate_rows)
+                    );
+                    output.push_str(
+                        "  Schema, row counts, nulls, cardinality, and distributions checked\n",
+                    );
+                    let primary_keys = self
+                        .models
+                        .iter()
+                        .filter_map(|model| model.comparison.as_ref())
+                        .filter(|comparison| comparison.primary_key.is_some())
+                        .count();
+                    if primary_keys > 0 {
+                        let _ = writeln!(
+                            output,
+                            "  {} primary key{} checked",
+                            primary_keys,
+                            plural(primary_keys)
+                        );
+                    }
+                }
+                if self.summary.query_checks_configured > 0 {
+                    let _ = writeln!(
+                        output,
+                        "  {} / {} query checks passed",
+                        self.summary.query_checks_passed, self.summary.query_checks_configured
+                    );
+                }
+                let _ = writeln!(
+                    output,
+                    "  {} finding{} · {} unvalidated model{}",
+                    self.summary.findings,
+                    plural(self.summary.findings),
+                    self.validation_scope.skipped_models.len(),
+                    plural(self.validation_scope.skipped_models.len())
+                );
+                if !self.ci_schemas.is_empty() {
+                    let cleaned = self
+                        .ci_schemas
+                        .iter()
+                        .filter(|schema| schema.cleaned_up)
+                        .count();
+                    if cleaned == self.ci_schemas.len() {
+                        let _ = writeln!(
+                            output,
+                            "  Temporary Snowflake schema{} removed",
+                            plural(self.ci_schemas.len())
+                        );
+                    } else {
+                        let _ = writeln!(
+                            output,
+                            "  {cleaned} / {} temporary Snowflake schemas removed",
+                            self.ci_schemas.len()
+                        );
+                    }
+                }
+            }
+        }
+
+        if !self.findings.is_empty() {
+            output.push_str("\nFindings\n");
+            self.write_human_findings(&mut output, verbose);
+        }
+        if !self.coverage_gaps.is_empty() {
+            output.push_str("\nScope limitations\n");
+        }
+        for gap in &self.coverage_gaps {
+            let _ = writeln!(output, "  [{}] {}: {}", gap.check, gap.scope, gap.reason);
+        }
+        if !self.execution_errors.is_empty() {
+            output.push_str("\nErrors\n");
         }
         for error in &self.execution_errors {
-            let _ = writeln!(output, "- [error] {error}");
+            let _ = writeln!(output, "  {error}");
         }
-        for check in &self.query_checks {
-            let _ = writeln!(
-                output,
-                "- [query:{:?}] {} ({}): {}",
-                check.status,
-                check.name,
-                check.account,
-                check.reason.as_deref().unwrap_or("comparison complete")
-            );
+        let visible_query_checks = self.query_checks.iter().filter(|check| {
+            verbose
+                || !matches!(
+                    check.status,
+                    QueryCheckStatus::Pass | QueryCheckStatus::Skipped
+                )
+        });
+        let query_checks = visible_query_checks.collect::<Vec<_>>();
+        if !query_checks.is_empty() {
+            output.push_str("\nQuery checks\n");
+            for check in query_checks {
+                let _ = writeln!(
+                    output,
+                    "  [{:?}] {} ({}): {}",
+                    check.status,
+                    check.name,
+                    check.account,
+                    check.reason.as_deref().unwrap_or("comparison complete")
+                );
+            }
         }
         let visible_notices = if verbose { self.notices.len() } else { 3 };
+        if visible_notices > 0 && !self.notices.is_empty() {
+            output.push_str("\nNotes\n");
+        }
         for notice in self.notices.iter().take(visible_notices) {
             let _ = writeln!(
                 output,
-                "- [note:{}] {}: {}",
+                "  [{}] {}: {}",
                 notice.code, notice.scope, notice.message
             );
         }
         if self.notices.len() > visible_notices {
             let _ = writeln!(
                 output,
-                "- {} more notices; rerun with --verbose",
+                "  {} more notices; rerun with --verbose",
                 self.notices.len() - visible_notices
             );
         }
@@ -484,7 +649,7 @@ impl Report {
             for skipped in &self.validation_scope.skipped_models {
                 let _ = writeln!(
                     output,
-                    "- [not-validated] {}: {}",
+                    "  [not-validated] {}: {}",
                     skipped.id, skipped.reason
                 );
             }
@@ -494,7 +659,7 @@ impl Report {
                 if let Some(comparison) = &model.comparison {
                     let _ = writeln!(
                         output,
-                        "- [evidence] {}: {} CI rows vs {} production rows across {} columns",
+                        "  [model] {}: {} candidate rows vs {} production rows across {} columns",
                         model.unique_id,
                         comparison.ci_row_count,
                         comparison.production_row_count,
@@ -503,7 +668,10 @@ impl Report {
                 }
             }
         }
-        self.write_human_lineage(&mut output, verbose);
+        if !self.impact.dbt_models.is_empty() || !self.impact.dbt_exposures.is_empty() {
+            output.push('\n');
+            self.write_human_lineage(&mut output, verbose);
+        }
         if !self.impact.dbt_lineage_changes.is_empty() {
             output.push_str("Lineage changes\n");
             for change in &self.impact.dbt_lineage_changes {
@@ -547,14 +715,13 @@ impl Report {
             }
         }
         for asset in &self.impact.metabase_dashboards {
-            let _ = writeln!(output, "- [impact:metabase] {}", asset.name);
+            let _ = writeln!(output, "  Metabase: {}", asset.name);
         }
         for edge in &self.impact.cross_account_dependencies {
-            let _ = writeln!(
-                output,
-                "- [impact:cross-account] {} -> {}",
-                edge.from, edge.to
-            );
+            let _ = writeln!(output, "  Cross-account: {} -> {}", edge.from, edge.to);
+        }
+        if let Some(elapsed) = elapsed {
+            let _ = writeln!(output, "\nCompleted in {}", format_duration(elapsed));
         }
         output
     }
@@ -1215,6 +1382,42 @@ fn markdown_option(value: Option<&str>) -> String {
     value.map(markdown_cell).unwrap_or_else(|| "—".into())
 }
 
+fn plural(count: usize) -> &'static str {
+    if count == 1 { "" } else { "s" }
+}
+
+fn format_count(value: u64) -> String {
+    let digits = value.to_string();
+    let mut output = String::with_capacity(digits.len() + digits.len() / 3);
+    let first_group = digits.len() % 3;
+    if first_group > 0 {
+        output.push_str(&digits[..first_group]);
+    }
+    for chunk in digits.as_bytes()[first_group..].chunks(3) {
+        if !output.is_empty() {
+            output.push(',');
+        }
+        output.push_str(std::str::from_utf8(chunk).expect("decimal digits are valid UTF-8"));
+    }
+    output
+}
+
+fn format_duration(duration: Duration) -> String {
+    let seconds = duration.as_secs();
+    if seconds < 60 {
+        format!("{seconds}s")
+    } else if seconds < 3_600 {
+        format!("{}m{:02}s", seconds / 60, seconds % 60)
+    } else {
+        format!(
+            "{}h{:02}m{:02}s",
+            seconds / 3_600,
+            (seconds % 3_600) / 60,
+            seconds % 60
+        )
+    }
+}
+
 fn optional_number(value: Option<f64>) -> String {
     value
         .map(|number| format!("{number:.6}"))
@@ -1345,6 +1548,56 @@ mod tests {
         });
         report.finalize();
         assert_eq!(report.exit_code, EXIT_FINDINGS);
+    }
+
+    #[test]
+    fn human_report_leads_with_proof_and_omits_unconfigured_query_checks() {
+        let mut report = Report::empty("main".into(), Thresholds::default());
+        report.validation_scope.impacted_models = 1;
+        report.validation_scope.requested_models = 1;
+        report
+            .validation_scope
+            .validated_models
+            .push("primary:model.project.orders".into());
+        report.models.push(ModelReport {
+            unique_id: "model.project.orders".into(),
+            name: "orders".into(),
+            account: "primary".into(),
+            ci_relation: "DB.CI.ORDERS".into(),
+            production_relation: Some("DB.PROD.ORDERS".into()),
+            dbt_build: "passed".into(),
+            build_strategy: "standard".into(),
+            comparison: Some(ModelComparison {
+                ci_row_count: 150_410_994,
+                production_row_count: 150_410_994,
+                row_count_relative_change: 0.0,
+                columns: vec![],
+                primary_key: None,
+            }),
+        });
+        report.finalize();
+
+        let output = report.human(false);
+        assert!(output.starts_with("✓ Safe to continue"));
+        assert!(output.contains("1 / 1 models built · 1 compared with production"));
+        assert!(output.contains("150,410,994 candidate rows evaluated"));
+        assert!(!output.contains("query check"));
+    }
+
+    #[test]
+    fn dry_run_is_described_as_a_plan_not_a_pass() {
+        let mut report = Report::empty("main".into(), Thresholds::default());
+        report.notices.push(Notice {
+            scope: "validation".into(),
+            code: "dry_run".into(),
+            message: "planned validation without querying warehouse data".into(),
+        });
+        report.finalize();
+
+        let output = report.human(false);
+        assert!(output.starts_with("✓ Validation plan ready"));
+        assert!(output.contains("No schemas were created and no warehouse data was queried."));
+        assert!(!output.contains("Safe to continue"));
     }
 
     #[test]

--- a/src/run.rs
+++ b/src/run.rs
@@ -17,6 +17,7 @@ use crate::{
     },
     dbt::{self, DbtContext, Manifest, ManifestNode},
     git, lineage, metabase,
+    progress::{Phase, Reporter as ProgressReporter},
     query::{QueryDiffInput, QueryTemplate, RefTarget, run_query_diff},
     report::{
         CiSchema, ColumnLineageGap, CoverageGap, Finding, ModelReport, Notice, QueryCheckReport,
@@ -94,6 +95,7 @@ pub struct CheckOptions {
     pub critical_tags: Option<Vec<String>>,
     pub incremental_mode: Option<IncrementalMode>,
     pub select: Vec<String>,
+    pub progress: Option<ProgressReporter>,
 }
 
 async fn execute(
@@ -103,6 +105,9 @@ async fn execute(
     dry_run: bool,
     report: &mut Report,
 ) -> Result<()> {
+    if let Some(progress) = &options.progress {
+        progress.phase(Phase::Setup);
+    }
     dbt::verify_executable(&config.dbt.command)?;
     let resolved_auth = if dry_run {
         config
@@ -129,6 +134,9 @@ async fn execute(
     let main_result = {
         let main = async {
             if !dry_run {
+                if let Some(progress) = &options.progress {
+                    progress.phase(Phase::Schema);
+                }
                 for account in &config.accounts {
                     let client = SnowflakeClient::new(
                         account,
@@ -147,21 +155,32 @@ async fn execute(
                         schema: schema.clone(),
                         cleaned_up: false,
                     });
-                    client
+                    clients.push(client);
+                    clients
+                        .last()
+                        .context("Snowflake client disappeared before schema creation")?
                         .create_schema(&account.database, &schema)
                         .await
                         .with_context(|| {
                             format!("could not create CI schema for account {}", account.name)
                         })?;
-                    clients.push(client);
                 }
             }
 
+            if let Some(progress) = &options.progress {
+                progress.phase(Phase::Impact);
+            }
             let mut context = dbt::prepare(config, &resolved_auth, base, &schema, &query_tag)?;
             let query_check_changes =
                 query_check_changes(config, base, &context.repo_root, report)?;
             let selections =
                 plan_selections(config, &context, options, &query_check_changes, report)?;
+            if let Some(progress) = &options.progress {
+                progress.scope(
+                    report.validation_scope.impacted_models,
+                    report.validation_scope.requested_models,
+                );
+            }
             if dry_run {
                 report.notices.push(Notice {
                     scope: "validation".into(),
@@ -177,8 +196,16 @@ async fn execute(
                     plan_query_reports(config, &context, &selections, report);
                     Ok(())
                 } else {
-                    execute_with_dbt(config, &mut context, &clients, &schema, &selections, report)
-                        .await
+                    execute_with_dbt(
+                        config,
+                        &mut context,
+                        &clients,
+                        &schema,
+                        &selections,
+                        report,
+                        options.progress.as_ref(),
+                    )
+                    .await
                 }
             } else {
                 Ok(())
@@ -201,9 +228,16 @@ async fn execute(
     };
 
     if let Err(error) = main_result {
+        if let Some(progress) = &options.progress {
+            progress.fail_current();
+        }
         report.execution_errors.push(format!("{error:#}"));
     }
-    cleanup_schemas(config, &clients, &schema, report).await;
+    if let Some(progress) = &options.progress {
+        progress.phase(Phase::Cleanup);
+        progress.cleanup(0, report.ci_schemas.len());
+    }
+    cleanup_schemas(config, &clients, &schema, report, options.progress.as_ref()).await;
     Ok(())
 }
 
@@ -744,9 +778,15 @@ async fn execute_with_dbt(
     ci_schema: &str,
     selections: &[AccountSelection],
     report: &mut Report,
+    progress: Option<&ProgressReporter>,
 ) -> Result<()> {
     let removed_production_relations =
         plan_model_reports(config, context, selections, "pending", report)?;
+    let mut models_built = 0usize;
+    if let Some(progress) = progress {
+        progress.phase(Phase::Build);
+        progress.built(0);
+    }
     let mut all_selected = BTreeSet::new();
     for selection in selections {
         all_selected.extend(selection.removed.iter().cloned());
@@ -942,6 +982,9 @@ async fn execute_with_dbt(
         )
         .with_context(|| format!("could not execute dbt build for account {}", account.name))?;
         if !build.passed {
+            if let Some(progress) = progress {
+                progress.fail_current();
+            }
             for id in selected {
                 if let Some(model) = find_model_mut(report, id, &account.name) {
                     model.dbt_build = "failed".into();
@@ -959,6 +1002,10 @@ async fn execute_with_dbt(
                 });
             }
             continue;
+        }
+        models_built += selected.len();
+        if let Some(progress) = progress {
+            progress.built(models_built);
         }
 
         match context.build_manifest(&account.name).and_then(|compiled| {
@@ -1045,6 +1092,11 @@ async fn execute_with_dbt(
         &baseline_relations,
         report,
     );
+    let comparison_total = comparison_jobs.len() + query_jobs.len();
+    if let Some(progress) = progress {
+        progress.phase(Phase::Compare);
+        progress.comparisons(0, comparison_total);
+    }
     let (completed, completed_queries) = timeout(
         Duration::from_secs(config.comparison.timeout_seconds),
         async {
@@ -1053,9 +1105,19 @@ async fn execute_with_dbt(
                 config.comparison.concurrency,
                 config.comparison.mode,
                 config.safety.clone(),
+                progress,
+                comparison_total,
             )
             .await?;
-            let queries = run_query_comparisons(query_jobs, config.comparison.concurrency).await?;
+            let model_count = models.len();
+            let queries = run_query_comparisons(
+                query_jobs,
+                config.comparison.concurrency,
+                progress,
+                model_count,
+                comparison_total,
+            )
+            .await?;
             Ok::<_, anyhow::Error>((models, queries))
         },
     )
@@ -1108,6 +1170,11 @@ async fn execute_with_dbt(
                 });
             }
         }
+    }
+    if !report.execution_errors.is_empty()
+        && let Some(progress) = progress
+    {
+        progress.fail_current();
     }
 
     if let Some(metabase_config) = &config.metabase {
@@ -1446,6 +1513,9 @@ fn query_scope(name: &str) -> String {
 async fn run_query_comparisons(
     jobs: Vec<QueryComparisonJob>,
     concurrency: usize,
+    progress: Option<&ProgressReporter>,
+    offset: usize,
+    total: usize,
 ) -> Result<Vec<CompletedQueryComparison>> {
     let mut pending = jobs.into_iter();
     let mut running = JoinSet::new();
@@ -1456,6 +1526,9 @@ async fn run_query_comparisons(
     }
     while let Some(result) = running.join_next().await {
         completed.push(result.context("query-comparison worker stopped unexpectedly")?);
+        if let Some(progress) = progress {
+            progress.comparisons(offset + completed.len(), total);
+        }
         if let Some(job) = pending.next() {
             spawn_query_comparison(&mut running, job);
         }
@@ -1502,6 +1575,8 @@ async fn run_comparisons(
     concurrency: usize,
     mode: ComparisonMode,
     safety: SafetyConfig,
+    progress: Option<&ProgressReporter>,
+    total: usize,
 ) -> Result<Vec<CompletedComparison>> {
     let mut pending = jobs.into_iter();
     let mut running = JoinSet::new();
@@ -1513,6 +1588,9 @@ async fn run_comparisons(
     }
     while let Some(result) = running.join_next().await {
         completed.push(result.context("comparison worker stopped unexpectedly")?);
+        if let Some(progress) = progress {
+            progress.comparisons(completed.len(), total);
+        }
         if let Some(job) = pending.next() {
             spawn_comparison(&mut running, job, mode, safety.clone());
         }
@@ -1561,6 +1639,7 @@ async fn cleanup_schemas(
     clients: &[SnowflakeClient],
     run_schema: &str,
     report: &mut Report,
+    progress: Option<&ProgressReporter>,
 ) {
     let cleanup_targets = report
         .ci_schemas
@@ -1575,6 +1654,8 @@ async fn cleanup_schemas(
             )
         })
         .collect::<Vec<_>>();
+    let total = cleanup_targets.len();
+    let mut completed = 0usize;
     for (record_index, account_name, database, target_schema) in cleanup_targets.into_iter().rev() {
         let Some(account_index) = config
             .accounts
@@ -1584,9 +1665,23 @@ async fn cleanup_schemas(
             report.execution_errors.push(format!(
                 "could not map CI schema {database}.{target_schema} back to its account for cleanup"
             ));
+            completed += 1;
+            if let Some(progress) = progress {
+                progress.cleanup(completed, total);
+            }
             continue;
         };
-        match clients[account_index]
+        let Some(client) = clients.get(account_index) else {
+            report.execution_errors.push(format!(
+                "could not recover the Snowflake connection needed to clean up {database}.{target_schema}; run `embrasure clean` or remove it manually"
+            ));
+            completed += 1;
+            if let Some(progress) = progress {
+                progress.cleanup(completed, total);
+            }
+            continue;
+        };
+        match client
             .drop_schema(&database, &target_schema, run_schema)
             .await
         {
@@ -1599,6 +1694,10 @@ async fn cleanup_schemas(
                 "CI schema cleanup failed for {}.{}; run `embrasure clean` or remove it manually: {error:#}",
                 database, target_schema,
             )),
+        }
+        completed += 1;
+        if let Some(progress) = progress {
+            progress.cleanup(completed, total);
         }
     }
 }

--- a/src/snowflake.rs
+++ b/src/snowflake.rs
@@ -250,19 +250,7 @@ impl SnowflakeClient {
         if !is_managed_schema(schema, run_schema) {
             bail!("refusing to drop schema {schema}: it is not owned by this run ({run_schema})");
         }
-        let ownership = self
-            .execute(&format!(
-                "SELECT COMMENT FROM {}.INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = {}",
-                quote_identifier(database),
-                quote_string(schema),
-            ))
-            .await?;
-        let Some(comment) = ownership
-            .rows
-            .first()
-            .and_then(|row| row.first())
-            .and_then(Option::as_deref)
-        else {
+        let Some(comment) = self.schema_comment(database, schema).await? else {
             return Ok(());
         };
         let expected = self.schema_ownership_marker();
@@ -271,13 +259,7 @@ impl SnowflakeClient {
                 "refusing to drop schema {database}.{schema}: its ownership marker does not match this run"
             );
         }
-        self.execute(&format!(
-            "DROP SCHEMA IF EXISTS {}.{}",
-            quote_identifier(database),
-            quote_identifier(schema),
-        ))
-        .await?;
-        Ok(())
+        self.drop_schema_restricted(database, schema).await
     }
 
     pub async fn drop_marked_schema(
@@ -289,6 +271,18 @@ impl SnowflakeClient {
         if !crate::clean::is_managed_prefix(schema, prefix) {
             bail!("refusing to drop schema {schema}: it is outside the managed prefix {prefix}");
         }
+        let Some(comment) = self.schema_comment(database, schema).await? else {
+            return Ok(());
+        };
+        if crate::clean::parse_ownership_marker(&comment).is_none() {
+            bail!(
+                "refusing to drop schema {database}.{schema}: its Embrasure ownership marker is invalid"
+            );
+        }
+        self.drop_schema_restricted(database, schema).await
+    }
+
+    async fn schema_comment(&self, database: &str, schema: &str) -> Result<Option<String>> {
         let ownership = self
             .execute(&format!(
                 "SELECT COMMENT FROM {}.INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = {}",
@@ -296,25 +290,25 @@ impl SnowflakeClient {
                 quote_string(schema),
             ))
             .await?;
-        let Some(comment) = ownership
+        Ok(ownership
             .rows
             .first()
             .and_then(|row| row.first())
-            .and_then(Option::as_deref)
-        else {
-            return Ok(());
-        };
-        if crate::clean::parse_ownership_marker(comment).is_none() {
+            .cloned()
+            .flatten())
+    }
+
+    /// Snowflake defaults `DROP SCHEMA` to `CASCADE`, which also drops foreign keys elsewhere that
+    /// reference the schema. `RESTRICT` leaves those references intact but only warns, so the drop
+    /// is confirmed before the schema is reported as removed.
+    async fn drop_schema_restricted(&self, database: &str, schema: &str) -> Result<()> {
+        self.execute(&drop_schema_statement(database, schema))
+            .await?;
+        if self.schema_comment(database, schema).await?.is_some() {
             bail!(
-                "refusing to drop schema {database}.{schema}: its Embrasure ownership marker is invalid"
+                "could not drop schema {database}.{schema}: foreign keys outside the schema still reference it; drop those constraints or the schema manually"
             );
         }
-        self.execute(&format!(
-            "DROP SCHEMA IF EXISTS {}.{}",
-            quote_identifier(database),
-            quote_identifier(schema),
-        ))
-        .await?;
         Ok(())
     }
 
@@ -350,6 +344,14 @@ impl SnowflakeClient {
 
 fn clone_table_statement(source: &Relation, target: &Relation) -> String {
     format!("CREATE TABLE {} CLONE {}", target.sql(), source.sql())
+}
+
+fn drop_schema_statement(database: &str, schema: &str) -> String {
+    format!(
+        "DROP SCHEMA IF EXISTS {}.{} RESTRICT",
+        quote_identifier(database),
+        quote_identifier(schema),
+    )
 }
 
 fn statement_body(
@@ -554,6 +556,14 @@ mod tests {
             }
             .sql(),
             "\"D\".\"S\".\"T\""
+        );
+    }
+
+    #[test]
+    fn cleanup_never_cascades_into_objects_outside_the_schema() {
+        assert_eq!(
+            drop_schema_statement("ANALYTICS", "EMBRASURE_CHECK_RUN"),
+            "DROP SCHEMA IF EXISTS \"ANALYTICS\".\"EMBRASURE_CHECK_RUN\" RESTRICT"
         );
     }
 

--- a/src/style.rs
+++ b/src/style.rs
@@ -21,7 +21,12 @@ impl Style {
 
     fn new(is_terminal: bool) -> Self {
         Self {
-            enabled: is_terminal && std::env::var_os("NO_COLOR").is_none(),
+            enabled: enabled_for(
+                is_terminal,
+                std::env::var_os("NO_COLOR").is_some(),
+                std::env::var_os("CI").is_some(),
+                std::env::var("TERM").is_ok_and(|term| term.eq_ignore_ascii_case("dumb")),
+            ),
         }
     }
 
@@ -50,9 +55,13 @@ impl Style {
     }
 }
 
+const fn enabled_for(is_terminal: bool, no_color: bool, ci: bool, dumb_terminal: bool) -> bool {
+    is_terminal && !no_color && !ci && !dumb_terminal
+}
+
 #[cfg(feature = "cloud-demo")]
 pub fn animation_enabled() -> bool {
-    std::io::stderr().is_terminal() && std::env::var_os("NO_COLOR").is_none()
+    Style::stderr().enabled
 }
 
 #[cfg(test)]
@@ -67,5 +76,14 @@ mod tests {
         assert_eq!(styled.bad("FAIL"), "\x1b[31mFAIL\x1b[0m");
         assert_eq!(styled.warn("WARN"), "\x1b[33mWARN\x1b[0m");
         assert_eq!(styled.bold("READY"), "\x1b[1mREADY\x1b[0m");
+    }
+
+    #[test]
+    fn styling_only_runs_in_an_interactive_terminal() {
+        assert!(enabled_for(true, false, false, false));
+        assert!(!enabled_for(false, false, false, false));
+        assert!(!enabled_for(true, true, false, false));
+        assert!(!enabled_for(true, false, true, false));
+        assert!(!enabled_for(true, false, false, true));
     }
 }

--- a/src/update.rs
+++ b/src/update.rs
@@ -69,18 +69,18 @@ pub async fn doctor_notice() -> Option<String> {
     {
         return None;
     }
-    if let Ok(cache) = read_cache() {
-        if cache_is_fresh(&cache.checked_at) {
-            return is_newer(&cache.latest, env!("CARGO_PKG_VERSION"))
-                .ok()
-                .filter(|newer| *newer)
-                .map(|_| {
-                    format!(
-                        "Embrasure {} is available; run `embrasure update`.",
-                        cache.latest
-                    )
-                });
-        }
+    if let Ok(cache) = read_cache()
+        && cache_is_fresh(&cache.checked_at)
+    {
+        return is_newer(&cache.latest, env!("CARGO_PKG_VERSION"))
+            .ok()
+            .filter(|newer| *newer)
+            .map(|_| {
+                format!(
+                    "Embrasure {} is available; run `embrasure update`.",
+                    cache.latest
+                )
+            });
     }
     let latest = latest_version().await.ok()?;
     let _ = write_cache(&UpdateCache {


### PR DESCRIPTION
## What changed

- Show a compact live review board automatically in interactive terminals.
- Keep JSON, CI, pipes, `NO_COLOR`, dumb terminals, and dry runs deterministic.
- Replace the dense final summary with clear Scope, Evidence, findings, lineage, cleanup, and elapsed-time sections.
- Report only real counters and omit unconfigured query checks.
- Keep cleanup safe if initial Snowflake schema creation fails.
- Drop temporary schemas with `RESTRICT` instead of the Snowflake `CASCADE` default, and confirm the drop before reporting the schema as removed.
- Use current Ratatui with a clean RustSec audit and update the MSRV to Rust 1.88.
- Update the README example output and documented MSRV to match.

## Verified

- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked`
- `cargo test --locked --all-features`
- `cargo +1.88 check --locked --all-targets`
- `cargo package --locked`
- `cargo audit`
- release build and interactive terminal smoke test
- JSON and redirected-output smoke tests
- README example regenerated from the real report renderer, not written by hand