### PR TITLE
Add extensible warehouse providers and Databricks support

### DIFF
--- a/.github/embrasure.rb.template
+++ b/.github/embrasure.rb.template
@@ -1,5 +1,5 @@
 class Embrasure < Formula
-  desc "Validate dbt changes against production Snowflake data"
+  desc "Validate dbt changes against production warehouse data"
   homepage "https://embrasure.ai"
   version "@VERSION@"
   license "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,12 +4,12 @@ version = "0.5.3"
 edition = "2024"
 rust-version = "1.88"
 build = "build.rs"
-description = "Embrasure CLI for validating dbt changes against production Snowflake data"
+description = "Embrasure CLI for validating dbt changes against production warehouse data"
 license = "Apache-2.0"
 repository = "https://github.com/EmbrasureAI/embrasure-cli"
 homepage = "https://embrasure.ai"
 readme = "README.md"
-keywords = ["dbt", "snowflake", "data-quality", "cli"]
+keywords = ["dbt", "snowflake", "databricks", "data-quality", "cli"]
 categories = ["command-line-utilities", "development-tools::testing"]
 
 [[bin]]
@@ -60,7 +60,7 @@ strip = true
 
 [package.metadata.winresource]
 ProductName = "Embrasure"
-FileDescription = "Validate dbt changes against production Snowflake data"
+FileDescription = "Validate dbt changes against production warehouse data"
 CompanyName = "Embrasure, Inc."
 LegalCopyright = "Copyright 2026 Embrasure, Inc."
 OriginalFilename = "embrasure.exe"

--- a/README.md
+++ b/README.md
@@ -13,17 +13,17 @@
 
 <p align="center"><strong>Catch unexpected data changes before a dbt PR is reviewed.</strong></p>
 
-Embrasure is open-source, local dbt PR validation for Snowflake:
+Embrasure is open-source, local dbt PR validation for Snowflake and Databricks:
 
 - Builds changed models and critical downstream paths in temporary schemas, then cleans them up.
 - Runs dbt tests and compares schema, row counts, null rates, cardinality, ranges, and primary keys with production.
 - Shows affected downstream models and columns.
-- Connects directly to Snowflake, with no Embrasure account or data sent to Embrasure.
+- Connects directly to your warehouse, with no Embrasure account or data sent to Embrasure.
 - Includes a [`verify`](.agents/skills/verify/SKILL.md) skill that runs the agent check-and-fix loop.
 
-`embrasure auth login` uses Snowflake OAuth. Your role needs warehouse access, production read access, and permission to create and remove temporary schemas.
+`embrasure auth login` uses Snowflake OAuth. Databricks uses a token supplied through the configured environment variable. The warehouse identity needs production read access and permission to create and remove temporary schemas.
 
-## Quickstart
+## Snowflake quickstart
 
 From your existing Snowflake dbt Core project directory, create or activate its Python environment:
 
@@ -52,6 +52,36 @@ By default, `check` compares your branch with `origin/main`.
 Embrasure uses the dbt Core and Snowflake adapter versions already installed by your project. Activate the project's normal environment, or set `dbt.command` in `embrasure-check.yml` to the wrapper your project uses.
 
 </details>
+
+## Databricks
+
+Install the Databricks dbt adapter instead of `dbt-snowflake`:
+
+```sh
+python -m pip install "dbt-core>=1.5,<2" "dbt-databricks>=1.5,<2" "sqlglot>=30,<31"
+```
+
+Use a version 2 configuration with a typed provider block:
+
+```yaml
+version: 2
+dbt:
+  project_dir: .
+  profile: analytics
+accounts:
+  - name: primary
+    provider:
+      type: databricks
+      host: https://your-workspace.cloud.databricks.com
+      http_path: /sql/1.0/warehouses/your-warehouse-id
+      catalog: analytics
+      production_schema: prod
+      auth:
+        type: token
+        token_env: DATABRICKS_TOKEN
+```
+
+The integration uses a Databricks SQL warehouse and Unity Catalog. Set `DATABRICKS_TOKEN`, then run `embrasure doctor` and `embrasure check`. Incremental baselines currently require managed Delta tables and use Unity Catalog shallow clones; `doctor` verifies that a suitable table and grants are available.
 
 If you do not use Homebrew, use the installer:
 
@@ -101,9 +131,9 @@ winget install --id EmbrasureAI.Embrasure --exact
 
 </details>
 
-Use Embrasure from an existing Snowflake dbt project whose unchanged production models are already materialized. Embrasure uses those existing relations as the comparison baseline.
+Use Embrasure from an existing Snowflake or Databricks dbt project whose unchanged production models are already materialized. Embrasure uses those existing relations as the comparison baseline.
 
-`init` reads the active dbt profile and asks only for missing values. Use `--config <path>` before or after any subcommand to choose another config file.
+For Snowflake, `init` reads the active dbt profile and asks only for missing values. Databricks uses the version 2 configuration shown above. Use `--config <path>` before or after any subcommand to choose another config file.
 
 Continue only when `embrasure doctor` reports `READY`. Embrasure generates a temporary dbt profile for its own runs; it does not modify your existing profile or production models.
 
@@ -126,7 +156,7 @@ Evidence
   Schema, row counts, nulls, cardinality, and distributions checked
   1 primary key checked
   0 findings · 3 unvalidated models
-  Temporary Snowflake schema removed
+  Temporary warehouse schema removed
 
 Lineage impact
   fct_orders
@@ -160,7 +190,7 @@ embrasure check --dry-run
 embrasure check --dry-run --json
 ```
 
-Dry runs use local dbt parsing but do not resolve credentials, create Snowflake schemas, or query warehouse data.
+Dry runs use local dbt parsing but do not resolve credentials, create warehouse schemas, or query warehouse data.
 
 ## Reports and exit codes
 
@@ -282,7 +312,7 @@ Your `generate_schema_name` macro must preserve the complete target schema. Make
 
 ### Incremental relation cannot be cloned
 
-Snowflake zero-copy `CREATE TABLE ... CLONE` supports tables, not every relation type. Use `--incremental-mode full-refresh` when a full rebuild is acceptable, or exclude the model from this validation path.
+Every existing incremental model needs a stable baseline copy, including in `full-refresh` mode. Snowflake supports tables that can be zero-copy cloned; Databricks currently supports managed Delta tables that can be shallow cloned. Use another materialization or exclude an unsupported relation from this validation path.
 
 ### Incremental candidate seeding fails
 
@@ -294,13 +324,13 @@ Use `--config <path>` before or after any subcommand to choose another config fi
 
 See the [example configuration](embrasure-check.example.yml) and [enterprise setup guide](docs/enterprise.md) for service credentials, multiple accounts, model policies, filters, thresholds, concurrency, external changes, cross-account dependencies, Metabase, and grants.
 
-Every temporary schema has a unique name and ownership marker. Query results are materialized in a dedicated run-owned schema so they cannot collide with dbt model aliases. Embrasure checks ownership before removal and treats cleanup failures as execution failures. Use a dedicated role that can read and clone only the production tables under test and create temporary schemas in the required databases. SQL validation is not a side-effect sandbox, so the role must not be able to call unsafe procedures, functions, or external integrations.
+Every temporary schema has a unique name and ownership marker. Query results are materialized in a dedicated run-owned schema so they cannot collide with dbt model aliases. Embrasure checks ownership before removal and treats cleanup failures as execution failures. Use a dedicated identity that can read and clone only the production tables under test and create temporary schemas in the required databases or catalogs. SQL validation is not a side-effect sandbox, so the identity must not be able to call unsafe procedures, functions, or external integrations.
 
 [Security and data flow](docs/security-and-data-flow.md) documents network connections, local files, returned data, credentials, cleanup, updates, and release verification.
 
 ## Current limits
 
-- Snowflake is the only supported warehouse.
+- Databricks support requires a Unity Catalog SQL warehouse and environment-supplied token authentication.
 - Native Windows support requires 64-bit Windows 11 or Windows Server 2022+. Windows 10, Windows on Arm, and machine-wide installation are not supported.
 - Column lineage covers compiled dbt SQL that SQLGlot can resolve. Wildcards without an input schema and dynamic SQL are reported as unresolved.
 - Dashboard column lineage is not inferred from model lineage.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,15 @@ Embrasure is open-source, local dbt PR validation for Snowflake:
 
 ## Quickstart
 
-From an existing Snowflake dbt Core project where `dbt` already runs, install Embrasure on macOS or Linux:
+From your existing Snowflake dbt Core project directory, create or activate its Python environment:
+
+```sh
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install "dbt-core>=1.5,<2" "dbt-snowflake>=1.5,<2" "sqlglot>=30,<31"
+```
+
+Then install Embrasure on macOS or Linux with Homebrew:
 
 ```sh
 brew install embrasureai/tap/embrasure
@@ -39,7 +47,7 @@ embrasure check
 By default, `check` compares your branch with `origin/main`.
 
 <details>
-<summary>If dbt is not available</summary>
+<summary>If dbt is managed by your project</summary>
 
 Embrasure uses the dbt Core and Snowflake adapter versions already installed by your project. Activate the project's normal environment, or set `dbt.command` in `embrasure-check.yml` to the wrapper your project uses.
 
@@ -50,6 +58,8 @@ If you do not use Homebrew, use the installer:
 ```sh
 curl -fsSL https://raw.githubusercontent.com/EmbrasureAI/embrasure-cli/main/install.sh | sh
 ```
+
+The installer writes to `/usr/local/bin` when writable, otherwise `~/.local/bin`. Set `EMBRASURE_INSTALL_DIR` to choose another directory.
 
 <details>
 <summary><strong>Installing on Windows (Windows 11 or Windows Server 2022+)</strong></summary>
@@ -93,7 +103,11 @@ winget install --id EmbrasureAI.Embrasure --exact
 
 Use Embrasure from an existing Snowflake dbt project whose unchanged production models are already materialized. Embrasure uses those existing relations as the comparison baseline.
 
-`init` reads the active dbt profile and asks only for missing values. Continue when `embrasure doctor` reports `READY`.
+`init` reads the active dbt profile and asks only for missing values. Use `--config <path>` before or after any subcommand to choose another config file.
+
+Continue only when `embrasure doctor` reports `READY`. Embrasure generates a temporary dbt profile for its own runs; it does not modify your existing profile or production models.
+
+If dbt is installed in `.venv`, run `source .venv/bin/activate` in each new shell before using Embrasure.
 
 Example result:
 

--- a/docs/provider-api.md
+++ b/docs/provider-api.md
@@ -1,0 +1,135 @@
+# Warehouse provider API
+
+## Goal
+
+Keep Snowflake and Databricks behind a small internal warehouse API so another SQL warehouse can be added without branching the validation pipeline or copying comparison logic.
+
+This is an internal Rust API, not a dynamic plugin ABI. Providers are compiled into the CLI and selected from configuration.
+
+## Boundaries
+
+The provider boundary owns the behavior that changes by warehouse:
+
+- executing SQL and decoding result metadata;
+- quoting and normalizing identifiers;
+- rendering the few SQL fragments that are not portable;
+- creating, cloning, and safely removing temporary schemas and relations;
+- generating the provider-specific dbt profile output;
+- resolving credentials and running provider-specific doctor and cleanup checks;
+- choosing the SQLGlot dialect used for compiled SQL.
+
+Git inspection, dbt artifact parsing, model selection, thresholds, findings, report contracts, concurrency, and progress remain provider-neutral.
+
+## Core API
+
+Common value types move out of `snowflake.rs`:
+
+```rust
+pub struct Relation {
+    pub database: String,
+    pub schema: String,
+    pub identifier: String,
+}
+
+pub struct QueryResult {
+    pub columns: Vec<ResultColumn>,
+    pub rows: Vec<Vec<Option<String>>>,
+}
+
+pub struct ResultColumn {
+    pub name: String,
+    pub data_type: String,
+}
+```
+
+Read-only SQL consumers depend on a narrow executor:
+
+```rust
+pub trait QueryExecutor: Send + Sync {
+    fn dialect(&self) -> SqlDialect;
+    fn execute<'a>(&'a self, statement: &'a str) -> ProviderFuture<'a, QueryResult>;
+}
+
+pub type ProviderFuture<'a, T> =
+    Pin<Box<dyn Future<Output = anyhow::Result<T>> + Send + 'a>>;
+```
+
+The validation runner additionally needs temporary-object lifecycle operations:
+
+```rust
+pub trait WarehouseProvider: QueryExecutor {
+    fn create_schema<'a>(&'a self, database: &'a str, schema: &'a str)
+        -> ProviderFuture<'a, ()>;
+    fn copy_table<'a>(
+        &'a self,
+        source: &'a Relation,
+        target: &'a Relation,
+    ) -> ProviderFuture<'a, ()>;
+    fn seed_table<'a>(
+        &'a self,
+        source: &'a Relation,
+        target: &'a Relation,
+    ) -> ProviderFuture<'a, ()>;
+    fn drop_schema<'a>(
+        &'a self,
+        database: &'a str,
+        schema: &'a str,
+        run_schema: &'a str,
+    ) -> ProviderFuture<'a, ()>;
+}
+```
+
+The runner stores `Arc<dyn WarehouseProvider>`, which keeps concurrent jobs cheap to clone without requiring a second abstraction or an async-trait dependency.
+
+`SqlDialect` is a small copyable enum. It renders the warehouse differences already present in the shared SQL: identifier quoting and normalization, create-table-as, text/numeric casts, null-safe equality, conditionals and conditional counts, approximate distinct counts and percentiles, stable row hashes, and type classification. It also supplies the SQLGlot dialect name. Prefer portable SQL expressions when supported providers agree. Common query construction stays in `compare.rs` and `query.rs`; the enum should grow only when a real provider proves another fragment is different. Databricks complex and geospatial values retain schema evidence but skip column metrics that the warehouse cannot compare reliably; query diffs require an explicit scalar cast.
+
+`Relation::sql(dialect)` renders a fully qualified name. A relation does not remember a global or implicit dialect.
+
+## Provider selection and configuration
+
+One factory converts an account's provider configuration and resolved credential into `Arc<dyn WarehouseProvider>`. The runner does not construct provider clients directly. The typed configuration enum and dialect provide the only dispatch needed.
+
+Version 1 Snowflake configuration remains backward compatible. Version 2 uses a tagged provider enum rather than adding optional fields to `AccountConfig`:
+
+```yaml
+accounts:
+  - name: primary
+    selector: tag:primary
+    provider:
+      type: databricks
+      host: https://example.cloud.databricks.com
+      http_path: /sql/1.0/warehouses/...
+      catalog: analytics
+      production_schema: prod
+      auth:
+        type: token
+        token_env: DATABRICKS_TOKEN
+```
+
+Each provider owns a typed configuration structure. There is no string-keyed property map and no common credential enum containing every provider's fields.
+
+Provider-specific entry points for auth, dbt profile generation, `doctor`, and `clean` are dispatched by the same tagged configuration. They do not belong on `WarehouseProvider` because the validation runner does not need them.
+
+## Incremental models and capabilities
+
+The runner asks the provider to copy a production table into a stable baseline for every existing incremental model. Snowflake implements the semantic operation with a zero-copy clone and Databricks uses a Unity Catalog shallow clone of a managed Delta table. `incremental_mode: clone` additionally seeds the candidate from that baseline. Snowflake can clone again; Databricks uses CTAS because Unity Catalog does not permit a shallow clone of another shallow clone. `full_refresh` skips only candidate seeding, not the stable baseline. A provider may reject an unsupported relation with an actionable error. Provider-specific `doctor` checks are the authoritative preflight; there is no general capability registry.
+
+Another provider may implement the stable copy with an equivalent snapshot operation or reject incremental models until it can preserve a stable baseline.
+
+## Implementation sequence
+
+1. Add the common provider types, dialect descriptor, executor trait, and lifecycle trait.
+2. Implement them for `SnowflakeClient` and `DatabricksClient`, selected by one factory.
+3. Change the runner and comparison/query code to depend on trait objects and explicit dialect rendering, including identifier normalization and type classification.
+4. Pass each account's provider dialect through SQLGlot parsing, lineage, rendering, and output-name normalization, and into provider-specific dbt profile generation.
+5. Keep version 1 behavior and configuration unchanged, add the tagged version 2 shape, and use only focused provider-contract tests.
+
+## Acceptance criteria
+
+- The validation pipeline contains no direct `SnowflakeClient` dependency.
+- Comparison and query-diff code does not import from `snowflake.rs`.
+- Common relation/result types live in the provider module.
+- SQLGlot receives the selected dialect per account instead of assuming Snowflake.
+- Snowflake output, cleanup safety, report contracts, and CLI behavior remain unchanged.
+- Snowflake and Databricks share the same validation runner.
+- No dynamic loading, generic property bags, speculative capability matrices, or duplicate Snowflake wrappers are introduced.

--- a/docs/security-and-data-flow.md
+++ b/docs/security-and-data-flow.md
@@ -9,7 +9,7 @@ Local Git repository + local dbt + Embrasure CLI
                          |
                          | SQL and authentication
                          v
-                 Your Snowflake account
+              Your configured warehouse
                          |
                          | Aggregate metrics and optional key examples
                          v
@@ -18,25 +18,26 @@ Local terminal or report
 Optional: Embrasure reads metadata from your configured Metabase URL.
 ```
 
-Validation SQL runs in Snowflake. Embrasure does not upload warehouse data, dbt artifacts, reports, credentials, or usage information to Embrasure.
+Validation SQL runs in Snowflake or Databricks. Embrasure does not upload warehouse data, dbt artifacts, reports, credentials, or usage information to Embrasure.
 
 ## Outbound connections
 
 The CLI itself makes only these connections:
 
 - `https://<account>.snowflakecomputing.com` for browser authentication and Snowflake SQL API requests.
+- The configured Databricks workspace host for Statement Execution API requests.
 - The configured Metabase URL when the optional Metabase integration is enabled.
 - `https://api.github.com/repos/EmbrasureAI/embrasure-cli/releases/latest` for `embrasure update --check`, `embrasure update`, and the gated doctor notice.
 - `https://github.com/EmbrasureAI/embrasure-cli/releases/download/...` when `embrasure update` downloads a release and its checksums.
 
-There is no telemetry or analytics SDK. `embrasure update` is opt-in. Human, interactive `embrasure doctor` output may check for a release at most once every 24 hours. The notice is disabled for JSON output, piped stderr, `CI`, or `NO_UPDATE_NOTIFIER`, and network failures are silent. The local `dbt` process may connect to Snowflake or download packages according to the dbt project's own configuration. Normal local validation does not contact Embrasure.
+There is no telemetry or analytics SDK. `embrasure update` is opt-in. Human, interactive `embrasure doctor` output may check for a release at most once every 24 hours. The notice is disabled for JSON output, piped stderr, `CI`, or `NO_UPDATE_NOTIFIER`, and network failures are silent. The local `dbt` process may connect to the configured warehouse or download packages according to the dbt project's own configuration. Normal local validation does not contact Embrasure.
 
 ## Data returned to the local process
 
-Snowflake returns the comparison evidence used in the local report:
+The configured warehouse returns the comparison evidence used in the local report:
 
 - Database, schema, table, and column names
-- Snowflake types
+- Warehouse column types
 - Row counts, null rates, cardinality, min/max values, averages, and percentiles
 - Counts of primary-key values found on only one side, duplicate rows, and null-key rows
 - Optional stably ordered primary-key and duplicate-key examples, up to `safety.primary_key_sample_limit`
@@ -44,12 +45,13 @@ Snowflake returns the comparison evidence used in the local report:
 
 Set `primary_key_sample_limit: 0` when key or query-diff example values must not appear in process memory or JSON output. Reports are written to stdout unless `--markdown <path>` is provided.
 
-Query checks accept a single read-only query expression, but syntax validation is not a side-effect sandbox for functions invoked by that query. Use a least-privilege Snowflake role that cannot call unsafe procedures, user-defined functions, or external integrations. Query materializations use a dedicated run-owned schema and follow the same ownership-checked cleanup path as model schemas.
+Query checks accept a single read-only query expression, but syntax validation is not a side-effect sandbox for functions invoked by that query. Use a least-privilege warehouse identity that cannot call unsafe procedures, user-defined functions, or external integrations. Query materializations use a dedicated run-owned schema and follow the same ownership-checked cleanup path as model schemas.
 
 ## Credentials and local files
 
-- The configuration file contains Snowflake identifiers and environment-variable names, not secret values.
+- The configuration file contains warehouse identifiers and environment-variable names, not secret values.
 - Programmatic access tokens and external OAuth tokens are read from environment variables.
+- Databricks tokens are read from the configured environment variable and sent only to the configured workspace host and the temporary dbt profile.
 - RSA private keys are read from the configured local path.
 - Browser OAuth sessions are cached under `~/.config/embrasure-check/oauth/` by default on Unix, with owner-only file and directory permissions. Windows sessions are encrypted for the current user with DPAPI and stored under `%APPDATA%\embrasure-check\oauth\`. Run `embrasure auth logout` to remove a cached session.
 - Temporary dbt profiles, manifests, target directories, and the detached base worktree live under an operating-system temporary directory and are removed after the process exits normally.
@@ -69,11 +71,13 @@ The [enterprise setup guide](enterprise.md) contains example grants. `embrasure 
 
 Incremental baselines use Snowflake table-level zero-copy clones. Embrasure never seeds them with CTAS, `INSERT`, or a local data copy. Clone metadata remains in Snowflake; only aggregate comparison results and bounded examples return to the local process.
 
+For Databricks, use a Unity Catalog SQL warehouse. The identity needs `USE CATALOG`, production schema/table read access, and permission to create schemas and tables in the configured catalog. Incremental baselines currently use managed Delta shallow clones; candidate seeding uses CTAS so it does not create an unsupported nested shallow clone.
+
 ## Schema cleanup
 
 Each run uses unique candidate and baseline schema names and writes an ownership marker to every schema. Cleanup requires both the exact run namespace and matching marker. The CLI refuses to drop a schema that fails either check.
 
-Schemas are dropped with `RESTRICT` instead of the Snowflake `CASCADE` default, so cleanup never removes foreign keys held by objects outside the schema. Because `RESTRICT` only warns, the CLI confirms the schema is gone before reporting it as removed.
+Snowflake schemas are dropped with `RESTRICT` instead of the Snowflake `CASCADE` default, so cleanup never removes foreign keys held by objects outside the schema. Databricks schemas are dropped with `CASCADE` only after both the run namespace and ownership marker are verified; the cascade is limited to objects inside that temporary Unity Catalog schema.
 
 Cleanup is attempted after success, findings, execution failures, Ctrl-C, and normal termination signals. No process can clean up after `SIGKILL`, a machine crash, or power loss. `embrasure clean` lists old marked schemas by default and removes them only with `--yes`. It searches only each configured account database and verifies both the configured prefix and an Embrasure ownership marker before removal.
 

--- a/packaging/windows/Test-PeMetadata.ps1
+++ b/packaging/windows/Test-PeMetadata.ps1
@@ -17,7 +17,7 @@ $expected = @{
     ProductVersion = $Version
     FileVersion = $Version
     CompanyName = 'Embrasure, Inc.'
-    FileDescription = 'Validate dbt changes against production Snowflake data'
+    FileDescription = 'Validate dbt changes against production warehouse data'
     OriginalFilename = 'embrasure.exe'
     LegalCopyright = 'Copyright 2026 Embrasure, Inc.'
 }

--- a/packaging/windows/scoop/embrasure.json.template
+++ b/packaging/windows/scoop/embrasure.json.template
@@ -1,6 +1,6 @@
 {
     "version": "@VERSION@",
-    "description": "Validate dbt changes against production Snowflake data",
+    "description": "Validate dbt changes against production warehouse data",
     "homepage": "https://github.com/EmbrasureAI/embrasure-cli",
     "license": "Apache-2.0",
     "architecture": {

--- a/packaging/windows/winget/EmbrasureAI.Embrasure.locale.en-US.yaml.template
+++ b/packaging/windows/winget/EmbrasureAI.Embrasure.locale.en-US.yaml.template
@@ -12,7 +12,7 @@ PackageUrl: https://github.com/EmbrasureAI/embrasure-cli
 License: Apache-2.0
 LicenseUrl: https://github.com/EmbrasureAI/embrasure-cli/blob/main/LICENSE
 Copyright: Copyright 2026 Embrasure, Inc.
-ShortDescription: Validate dbt changes against production Snowflake data
+ShortDescription: Validate dbt changes against production warehouse data
 Description: >-
   Embrasure is an open-source CLI that builds changed dbt models in temporary
   Snowflake schemas and compares them with production before a pull request is reviewed.

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -14,7 +14,9 @@ use tokio::net::TcpListener;
 use url::Url;
 
 use crate::{
-    config::{AccountConfig, AuthConfig, Config},
+    config::{
+        AccountConfig, AuthConfig, Config, DatabricksAuthConfig, ProviderConfig, SnowflakeConfig,
+    },
     loopback, update,
 };
 
@@ -22,6 +24,12 @@ const LOCAL_CLIENT_ID: &str = "LOCAL_APPLICATION";
 
 #[derive(Debug, Clone)]
 pub enum ResolvedAuth {
+    Snowflake(SnowflakeResolvedAuth),
+    Databricks(DatabricksResolvedAuth),
+}
+
+#[derive(Debug, Clone)]
+pub enum SnowflakeResolvedAuth {
     OAuth {
         token: String,
     },
@@ -32,6 +40,11 @@ pub enum ResolvedAuth {
     ProgrammaticAccessToken {
         token: String,
     },
+}
+
+#[derive(Debug, Clone)]
+pub enum DatabricksResolvedAuth {
+    Token { token: String },
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -67,8 +80,39 @@ pub async fn resolve_all(config: &Config) -> Result<BTreeMap<String, ResolvedAut
     Ok(result)
 }
 
+pub fn placeholder(account: &AccountConfig) -> ResolvedAuth {
+    match &account.provider {
+        ProviderConfig::Snowflake(_) => {
+            ResolvedAuth::Snowflake(SnowflakeResolvedAuth::ProgrammaticAccessToken {
+                token: "dry-run-not-used".into(),
+            })
+        }
+        ProviderConfig::Databricks(_) => ResolvedAuth::Databricks(DatabricksResolvedAuth::Token {
+            token: "dry-run-not-used".into(),
+        }),
+    }
+}
+
 pub async fn resolve(account: &AccountConfig) -> Result<ResolvedAuth> {
-    match &account.auth {
+    match &account.provider {
+        ProviderConfig::Snowflake(config) => Ok(ResolvedAuth::Snowflake(
+            resolve_snowflake(account, config).await?,
+        )),
+        ProviderConfig::Databricks(config) => match &config.auth {
+            DatabricksAuthConfig::Token { token_env } => {
+                Ok(ResolvedAuth::Databricks(DatabricksResolvedAuth::Token {
+                    token: required_env(token_env, "Databricks token")?,
+                }))
+            }
+        },
+    }
+}
+
+async fn resolve_snowflake(
+    account: &AccountConfig,
+    config: &SnowflakeConfig,
+) -> Result<SnowflakeResolvedAuth> {
+    match &config.auth {
         AuthConfig::OauthLocal => {
             let token = load_or_refresh_local_token(account).await.with_context(|| {
                 format!(
@@ -76,20 +120,20 @@ pub async fn resolve(account: &AccountConfig) -> Result<ResolvedAuth> {
                     account.name, account.name
                 )
             })?;
-            Ok(ResolvedAuth::OAuth { token })
+            Ok(SnowflakeResolvedAuth::OAuth { token })
         }
-        AuthConfig::Oauth { token_env } => Ok(ResolvedAuth::OAuth {
+        AuthConfig::Oauth { token_env } => Ok(SnowflakeResolvedAuth::OAuth {
             token: required_env(token_env, "OAuth token")?,
         }),
         AuthConfig::ProgrammaticAccessToken { token_env } => {
-            Ok(ResolvedAuth::ProgrammaticAccessToken {
+            Ok(SnowflakeResolvedAuth::ProgrammaticAccessToken {
                 token: required_env(token_env, "Snowflake PAT")?,
             })
         }
         AuthConfig::KeyPair {
             private_key_path,
             passphrase_env,
-        } => Ok(ResolvedAuth::KeyPair {
+        } => Ok(SnowflakeResolvedAuth::KeyPair {
             private_key_path: private_key_path.clone(),
             passphrase: passphrase_env
                 .as_ref()
@@ -103,11 +147,14 @@ pub async fn login_from_config(config_path: &Path, requested: Option<&str>) -> R
     let mut config = Config::load(config_path)?;
     config.resolve_from(config_path)?;
     let account = select_account(&config, requested)?;
-    if !matches!(account.auth, AuthConfig::OauthLocal) {
+    let snowflake = account
+        .snowflake()
+        .context("browser login is only available for Snowflake accounts")?;
+    if !matches!(snowflake.auth, AuthConfig::OauthLocal) {
         bail!(
             "account {} uses {}; browser login requires `auth: {{ type: oauth_local }}`",
             account.name,
-            method_name(&account.auth)
+            method_name(&snowflake.auth)
         );
     }
     login(account).await?;
@@ -118,7 +165,10 @@ pub fn logout_from_config(config_path: &Path, requested: Option<&str>) -> Result
     let mut config = Config::load(config_path)?;
     config.resolve_from(config_path)?;
     let account = select_account(&config, requested)?;
-    if !matches!(account.auth, AuthConfig::OauthLocal) {
+    let snowflake = account
+        .snowflake()
+        .context("browser logout is only available for Snowflake accounts")?;
+    if !matches!(snowflake.auth, AuthConfig::OauthLocal) {
         bail!("account {} does not use browser login", account.name);
     }
     let path = token_path(account)?;
@@ -136,7 +186,25 @@ pub fn status_from_config(config_path: &Path) -> Result<Vec<AuthStatus>> {
 }
 
 pub fn status(account: &AccountConfig) -> Result<AuthStatus> {
-    let (method, ready, message) = match &account.auth {
+    let (method, ready, message) = match &account.provider {
+        ProviderConfig::Snowflake(config) => snowflake_status(account, config)?,
+        ProviderConfig::Databricks(config) => match &config.auth {
+            DatabricksAuthConfig::Token { token_env } => env_status("token", token_env),
+        },
+    };
+    Ok(AuthStatus {
+        account: account.name.clone(),
+        method,
+        ready,
+        status: message,
+    })
+}
+
+fn snowflake_status(
+    account: &AccountConfig,
+    config: &SnowflakeConfig,
+) -> Result<(&'static str, bool, String)> {
+    let status = match &config.auth {
         AuthConfig::OauthLocal => match load_cached(account) {
             Ok(token) if token.expires_at > now()? => ("oauth_local", true, "signed in".into()),
             Ok(token) if token.refresh_token.is_some() => (
@@ -176,12 +244,7 @@ pub fn status(account: &AccountConfig) -> Result<AuthStatus> {
             ("key_pair", ready, message)
         }
     };
-    Ok(AuthStatus {
-        account: account.name.clone(),
-        method,
-        ready,
-        status: message,
-    })
+    Ok(status)
 }
 
 fn env_status(method: &'static str, name: &str) -> (&'static str, bool, String) {
@@ -216,6 +279,7 @@ fn select_account<'a>(config: &'a Config, requested: Option<&str>) -> Result<&'a
 }
 
 async fn login(account: &AccountConfig) -> Result<String> {
+    let snowflake = snowflake(account)?;
     let listener = TcpListener::bind(("127.0.0.1", 0))
         .await
         .context("could not start the local OAuth callback listener")?;
@@ -226,10 +290,10 @@ async fn login(account: &AccountConfig) -> Result<String> {
     let redirect_uri = format!("http://127.0.0.1:{port}");
     let (verifier, challenge) = loopback::pkce_pair();
     let state = loopback::random_string(32);
-    let scope = format!("refresh_token session:role:{}", account.role);
+    let scope = format!("refresh_token session:role:{}", snowflake.role);
     let mut authorize = Url::parse(&format!(
         "https://{}/oauth/authorize",
-        account_host(&account.account)
+        account_host(&snowflake.account)
     ))?;
     authorize
         .query_pairs_mut()
@@ -326,10 +390,11 @@ async fn load_or_refresh_local_token(account: &AccountConfig) -> Result<String> 
 }
 
 async fn token_request(account: &AccountConfig, form: &[(&str, &str)]) -> Result<TokenResponse> {
+    let snowflake = snowflake(account)?;
     let response = update::http_client()?
         .post(format!(
             "https://{}/oauth/token-request",
-            account_host(&account.account)
+            account_host(&snowflake.account)
         ))
         .form(form)
         .send()
@@ -350,6 +415,7 @@ async fn token_request(account: &AccountConfig, form: &[(&str, &str)]) -> Result
 }
 
 fn load_cached(account: &AccountConfig) -> Result<CachedToken> {
+    let snowflake = snowflake(account)?;
     let path = token_path(account)?;
     let bytes = fs::read(&path)
         .with_context(|| format!("no cached Snowflake session at {}", path.display()))?;
@@ -357,20 +423,21 @@ fn load_cached(account: &AccountConfig) -> Result<CachedToken> {
         .with_context(|| format!("could not decrypt Snowflake session at {}", path.display()))?;
     let token: CachedToken = serde_json::from_slice(&bytes)
         .with_context(|| format!("invalid cached Snowflake session at {}", path.display()))?;
-    if token.account != account.account || !token.user.eq_ignore_ascii_case(&account.user) {
+    if token.account != snowflake.account || !token.user.eq_ignore_ascii_case(&snowflake.user) {
         bail!("cached Snowflake session belongs to a different account or user");
     }
     Ok(token)
 }
 
 fn save_cached(account: &AccountConfig, response: &TokenResponse) -> Result<()> {
+    let snowflake = snowflake(account)?;
     let path = token_path(account)?;
     let parent = path.parent().context("OAuth cache path has no parent")?;
     fs::create_dir_all(parent)?;
     restrict_directory(parent)?;
     let token = CachedToken {
-        account: account.account.clone(),
-        user: account.user.clone(),
+        account: snowflake.account.clone(),
+        user: snowflake.user.clone(),
         access_token: response.access_token.clone(),
         refresh_token: response.refresh_token.clone(),
         expires_at: now()?.saturating_add(response.expires_in.saturating_sub(30)),
@@ -380,12 +447,17 @@ fn save_cached(account: &AccountConfig, response: &TokenResponse) -> Result<()> 
 }
 
 fn token_path(account: &AccountConfig) -> Result<PathBuf> {
+    let snowflake = snowflake(account)?;
     let root = if let Some(value) = env::var_os("EMBRASURE_CHECK_CONFIG_DIR") {
         PathBuf::from(value)
     } else {
         default_config_root()?
     };
-    let identity = format!("{}:{}", account.account, account.user.to_ascii_uppercase());
+    let identity = format!(
+        "{}:{}",
+        snowflake.account,
+        snowflake.user.to_ascii_uppercase()
+    );
     let digest = Sha256::digest(identity.as_bytes());
     let name = digest
         .iter()
@@ -546,6 +618,12 @@ fn method_name(auth: &AuthConfig) -> &'static str {
         AuthConfig::ProgrammaticAccessToken { .. } => "programmatic_access_token",
         AuthConfig::KeyPair { .. } => "key_pair",
     }
+}
+
+fn snowflake(account: &AccountConfig) -> Result<&SnowflakeConfig> {
+    account
+        .snowflake()
+        .context("Snowflake authentication was requested for a different provider")
 }
 
 pub fn account_host(account: &str) -> String {

--- a/src/clean.rs
+++ b/src/clean.rs
@@ -6,7 +6,9 @@ use uuid::Uuid;
 
 use crate::{
     auth,
-    config::Config,
+    config::{Config, ProviderConfig},
+    databricks::DatabricksClient,
+    provider::{QueryResult, dialect},
     snowflake::{SnowflakeClient, quote_identifier},
 };
 
@@ -53,50 +55,66 @@ async fn run_inner(
     let resolved = auth::resolve_all(&config).await?;
     for account in &config.accounts {
         let result = async {
-            let client = SnowflakeClient::new(
-                account,
-                resolved
-                    .get(&account.name)
-                    .context("resolved Snowflake credential was not retained")?,
-                format!("embrasure:clean:{}", Uuid::new_v4()),
-                config.safety.statement_timeout_seconds,
-            )?;
-            let prefix = config.safety.schema_prefix.to_ascii_uppercase();
-            let query = format!(
-                "SELECT SCHEMA_NAME, COMMENT, TO_VARCHAR(CREATED) FROM {}.INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME LIKE {} ESCAPE '!' AND COMMENT LIKE 'Temporary schema managed by Embrasure;%' AND CREATED < DATEADD('hour', -{}, CURRENT_TIMESTAMP()) ORDER BY CREATED, SCHEMA_NAME",
-                quote_identifier(&account.database),
-                quote_string(&format!("{prefix}!_%")),
-                older_than_hours,
-            );
-            let rows = client.execute(&query).await?;
-            for row in rows.rows {
-                let Some(schema) = row.first().and_then(Option::as_deref) else {
-                    continue;
-                };
-                let Some(comment) = row.get(1).and_then(Option::as_deref) else {
-                    continue;
-                };
-                let created = row
-                    .get(2)
-                    .and_then(Option::as_deref)
-                    .unwrap_or("unknown")
-                    .to_owned();
-                if !is_managed_prefix(schema, &prefix) || parse_ownership_marker(comment).is_none()
-                {
-                    continue;
+            let credential = resolved
+                .get(&account.name)
+                .context("resolved warehouse credential was not retained")?;
+            let query_tag = format!("embrasure:clean:{}", Uuid::new_v4());
+            let prefix = dialect(account)
+                .normalize_identifier(&config.safety.schema_prefix, None);
+            match &account.provider {
+                ProviderConfig::Snowflake(provider) => {
+                    let client = SnowflakeClient::new(
+                        account,
+                        credential,
+                        query_tag,
+                        config.safety.statement_timeout_seconds,
+                    )?;
+                    let query = format!(
+                        "SELECT SCHEMA_NAME, COMMENT, TO_VARCHAR(CREATED) FROM {}.INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME LIKE {} ESCAPE '!' AND COMMENT LIKE 'Temporary schema managed by Embrasure;%' AND CREATED < DATEADD('hour', -{}, CURRENT_TIMESTAMP()) ORDER BY CREATED, SCHEMA_NAME",
+                        quote_identifier(&provider.database),
+                        quote_string(&format!("{prefix}!_%")),
+                        older_than_hours,
+                    );
+                    for candidate in managed_candidates(client.execute(&query).await?, &prefix) {
+                        if remove {
+                            client
+                                .drop_marked_schema(&provider.database, &candidate.schema, &prefix)
+                                .await?;
+                        }
+                        report.candidates.push(candidate.finish(
+                            &account.name,
+                            &provider.database,
+                            remove,
+                        ));
+                    }
                 }
-                if remove {
-                    client
-                        .drop_marked_schema(&account.database, schema, &prefix)
+                ProviderConfig::Databricks(provider) => {
+                    let client = DatabricksClient::new(
+                        account,
+                        credential,
+                        query_tag,
+                        config.safety.statement_timeout_seconds,
+                    )?;
+                    let rows = client
+                        .stale_managed_schemas(
+                            &provider.catalog,
+                            &prefix,
+                            older_than_hours,
+                        )
                         .await?;
+                    for candidate in managed_candidates(rows, &prefix) {
+                        if remove {
+                            client
+                                .drop_marked_schema(&provider.catalog, &candidate.schema, &prefix)
+                                .await?;
+                        }
+                        report.candidates.push(candidate.finish(
+                            &account.name,
+                            &provider.catalog,
+                            remove,
+                        ));
+                    }
                 }
-                report.candidates.push(CleanedSchema {
-                    account: account.name.clone(),
-                    database: account.database.clone(),
-                    schema: schema.to_owned(),
-                    created,
-                    removed: remove,
-                });
             }
             Ok::<(), anyhow::Error>(())
         }
@@ -108,6 +126,45 @@ async fn run_inner(
         }
     }
     Ok(())
+}
+
+struct ManagedCandidate {
+    schema: String,
+    created: String,
+}
+
+impl ManagedCandidate {
+    fn finish(self, account: &str, database: &str, removed: bool) -> CleanedSchema {
+        CleanedSchema {
+            account: account.to_owned(),
+            database: database.to_owned(),
+            schema: self.schema,
+            created: self.created,
+            removed,
+        }
+    }
+}
+
+fn managed_candidates(result: QueryResult, prefix: &str) -> Vec<ManagedCandidate> {
+    result
+        .rows
+        .into_iter()
+        .filter_map(|row| {
+            let schema = row.first()?.as_deref()?;
+            let comment = row.get(1)?.as_deref()?;
+            if !is_managed_prefix(schema, prefix) || parse_ownership_marker(comment).is_none() {
+                return None;
+            }
+            Some(ManagedCandidate {
+                schema: schema.to_owned(),
+                created: row
+                    .get(2)
+                    .and_then(Option::as_deref)
+                    .unwrap_or("unknown")
+                    .to_owned(),
+            })
+        })
+        .collect()
 }
 
 pub(crate) fn parse_ownership_marker(comment: &str) -> Option<Uuid> {

--- a/src/compare.rs
+++ b/src/compare.rs
@@ -4,17 +4,18 @@ use anyhow::{Context, Result, bail};
 
 use crate::{
     config::{ComparisonMode, KeyPolicy, SafetyConfig, Thresholds},
+    provider::{QueryExecutor, Relation, ResultColumn, SqlDialect},
     report::{ColumnComparison, ColumnMetrics, Finding, ModelComparison, PrimaryKeyComparison},
-    snowflake::{Relation, ResultColumn, SnowflakeClient, quote_identifier},
 };
 
-pub async fn compare_model(
-    client: &SnowflakeClient,
+pub async fn compare_model<E: QueryExecutor + ?Sized>(
+    client: &E,
     model_id: &str,
     ci: &Relation,
     production: &Relation,
     options: CompareOptions<'_>,
 ) -> Result<(ModelComparison, Vec<Finding>)> {
+    let dialect = client.dialect();
     let CompareOptions {
         primary_key,
         where_clause,
@@ -25,10 +26,15 @@ pub async fn compare_model(
     } = options;
     let ci_columns = relation_columns(client, ci)
         .await
-        .with_context(|| format!("could not inspect CI relation {}", ci.sql()))?;
+        .with_context(|| format!("could not inspect CI relation {}", ci.sql(dialect)))?;
     let production_columns = relation_columns(client, production)
         .await
-        .with_context(|| format!("could not inspect production relation {}", production.sql()))?;
+        .with_context(|| {
+            format!(
+                "could not inspect production relation {}",
+                production.sql(dialect)
+            )
+        })?;
     let ci_map = column_map(&ci_columns);
     let production_map = column_map(&production_columns);
     let all_names = ci_map
@@ -129,8 +135,8 @@ pub async fn compare_model(
                     ci_value.cardinality, prod_value.cardinality, cardinality_change, cardinality_threshold,
                 )));
             }
-            let numeric = ci_column.is_some_and(|column| is_numeric(&column.data_type))
-                && prod_column.is_some_and(|column| is_numeric(&column.data_type));
+            let numeric = ci_column.is_some_and(|column| dialect.is_numeric(&column.data_type))
+                && prod_column.is_some_and(|column| dialect.is_numeric(&column.data_type));
             for (metric, ci_number, prod_number) in [
                 ("average", ci_value.average, prod_value.average),
                 ("p05", ci_value.p05, prod_value.p05),
@@ -182,57 +188,76 @@ pub async fn compare_model(
         });
     }
 
+    let resolved_primary_key = primary_key
+        .iter()
+        .map(|key| {
+            let ci_name = resolve_column(&ci_map, key)?;
+            let production_name = resolve_column(&production_map, key)?;
+            (ci_name == production_name).then_some(ci_name)
+        })
+        .collect::<Option<Vec<_>>>();
     let primary_key = if primary_key.is_empty() {
         None
-    } else if primary_key.iter().all(|key| {
-        matches!(
-            (resolve_column(&ci_map, key), resolve_column(&production_map, key)),
-            (Some(ci_name), Some(production_name)) if ci_name == production_name
-        )
-    }) {
-        let resolved_primary_key = primary_key
-            .iter()
-            .filter_map(|key| resolve_column(&ci_map, key))
-            .collect::<Vec<_>>();
-        let comparison = compare_primary_key(
-            client,
-            ci,
-            production,
-            &resolved_primary_key,
-            safety.primary_key_sample_limit,
-            where_clause,
-        )
-        .await?;
-        if comparison.ci_only_count > 0 || comparison.production_only_count > 0 {
+    } else if let Some(resolved_primary_key) = resolved_primary_key {
+        let unsupported_key = resolved_primary_key.iter().find_map(|key| {
+            [&ci_map, &production_map].into_iter().find_map(|columns| {
+                columns.get(key).and_then(|column| {
+                    dialect
+                        .is_unsupported_value(&column.data_type)
+                        .then_some((key, column.data_type.as_str()))
+                })
+            })
+        });
+        if let Some((key, data_type)) = unsupported_key {
             findings.push(finding(
                 model_id,
                 "primary_key",
                 format!(
-                    "{} primary-key values exist only in CI and {} only in production",
-                    comparison.ci_only_count, comparison.production_only_count,
+                    "primary-key column {key} has unsupported type {data_type}; configure a scalar key"
                 ),
             ));
+            None
+        } else {
+            let comparison = compare_primary_key(
+                client,
+                ci,
+                production,
+                &resolved_primary_key,
+                safety.primary_key_sample_limit,
+                where_clause,
+            )
+            .await?;
+            if comparison.ci_only_count > 0 || comparison.production_only_count > 0 {
+                findings.push(finding(
+                    model_id,
+                    "primary_key",
+                    format!(
+                        "{} primary-key values exist only in CI and {} only in production",
+                        comparison.ci_only_count, comparison.production_only_count,
+                    ),
+                ));
+            }
+            if key_integrity_fails(&comparison, key_policy) {
+                findings.push(finding(
+                    model_id,
+                    "primary_key",
+                    format!(
+                        "CI has {} duplicate keys ({} extra rows) and {} null-key rows vs {} ({} extra rows) and {} in production ({})",
+                        comparison.ci_duplicate_key_count,
+                        comparison.ci_duplicate_rows,
+                        comparison.ci_null_key_rows,
+                        comparison.production_duplicate_key_count,
+                        comparison.production_duplicate_rows,
+                        comparison.production_null_key_rows,
+                        match key_policy {
+                            KeyPolicy::Regression => "regressions fail",
+                            KeyPolicy::Strict => "strict policy requires zero",
+                        }
+                    ),
+                ));
+            }
+            Some(comparison)
         }
-        if key_integrity_fails(&comparison, key_policy) {
-            findings.push(finding(
-                model_id,
-                "primary_key",
-                format!(
-                    "CI has {} duplicate keys ({} extra rows) and {} null-key rows vs {} ({} extra rows) and {} in production ({})",
-                    comparison.ci_duplicate_key_count,
-                    comparison.ci_duplicate_rows,
-                    comparison.ci_null_key_rows,
-                    comparison.production_duplicate_key_count,
-                    comparison.production_duplicate_rows,
-                    comparison.production_null_key_rows,
-                    match key_policy {
-                        KeyPolicy::Regression => "regressions fail",
-                        KeyPolicy::Strict => "strict policy requires zero",
-                    }
-                ),
-            ));
-        }
-        Some(comparison)
     } else {
         findings.push(finding(
             model_id,
@@ -276,12 +301,13 @@ pub struct CompareOptions<'a> {
     pub thresholds: Thresholds,
 }
 
-async fn relation_columns(
-    client: &SnowflakeClient,
+async fn relation_columns<E: QueryExecutor + ?Sized>(
+    client: &E,
     relation: &Relation,
 ) -> Result<Vec<ResultColumn>> {
+    let dialect = client.dialect();
     Ok(client
-        .execute(&format!("SELECT * FROM {} LIMIT 0", relation.sql()))
+        .execute(&format!("SELECT * FROM {} LIMIT 0", relation.sql(dialect)))
         .await?
         .columns)
 }
@@ -292,47 +318,50 @@ struct RelationMetrics {
     columns: BTreeMap<String, ColumnMetrics>,
 }
 
-async fn relation_metrics(
-    client: &SnowflakeClient,
+async fn relation_metrics<E: QueryExecutor + ?Sized>(
+    client: &E,
     relation: &Relation,
     names: &[String],
     types: &BTreeMap<String, ResultColumn>,
     where_clause: Option<&str>,
     mode: ComparisonMode,
 ) -> Result<RelationMetrics> {
+    let dialect = client.dialect();
     let mut expressions = vec!["COUNT(*)".to_owned()];
     for name in names {
-        let column = quote_identifier(name);
-        expressions.push(format!("COUNT_IF({column} IS NULL)"));
+        let column = dialect.quote_identifier(name);
+        let data_type = types
+            .get(name)
+            .map(|value| value.data_type.as_str())
+            .unwrap_or_default();
+        if !dialect.supports_column_metrics(data_type) {
+            continue;
+        }
+        expressions.push(dialect.count_if(&format!("{column} IS NULL")));
         expressions.push(match mode {
-            ComparisonMode::Quick => format!("APPROX_COUNT_DISTINCT({column})"),
+            ComparisonMode::Quick => dialect.approximate_distinct(&column),
             ComparisonMode::Deep => format!("COUNT(DISTINCT {column})"),
         });
-        if types
-            .get(name)
-            .is_some_and(|value| is_orderable(&value.data_type))
-        {
-            expressions.push(format!("MIN({column})::VARCHAR"));
-            expressions.push(format!("MAX({column})::VARCHAR"));
+        if !data_type.is_empty() && dialect.is_orderable(data_type) {
+            expressions.push(dialect.cast_text(&format!("MIN({column})")));
+            expressions.push(dialect.cast_text(&format!("MAX({column})")));
         } else {
-            expressions.push("NULL::VARCHAR".into());
-            expressions.push("NULL::VARCHAR".into());
+            expressions.push(dialect.cast_text("NULL"));
+            expressions.push(dialect.cast_text("NULL"));
         }
         if types
             .get(name)
-            .is_some_and(|value| is_numeric(&value.data_type))
+            .is_some_and(|value| dialect.is_numeric(&value.data_type))
         {
-            expressions.push(format!("AVG({column})::DOUBLE"));
+            expressions.push(dialect.cast_float(&format!("AVG({column})")));
             if mode == ComparisonMode::Deep {
-                expressions.extend([
-                    format!("APPROX_PERCENTILE({column}, 0.05)::DOUBLE"),
-                    format!("APPROX_PERCENTILE({column}, 0.50)::DOUBLE"),
-                    format!("APPROX_PERCENTILE({column}, 0.95)::DOUBLE"),
-                ]);
+                expressions.extend(["0.05", "0.50", "0.95"].map(|percentile| {
+                    dialect.cast_float(&dialect.approximate_percentile(&column, percentile))
+                }));
             }
         }
     }
-    let source = filtered_relation(relation, where_clause);
+    let source = filtered_relation(dialect, relation, where_clause);
     let result = client
         .execute(&format!(
             "SELECT {} FROM {}",
@@ -343,11 +372,18 @@ async fn relation_metrics(
     let row = result
         .rows
         .first()
-        .context("Snowflake aggregate returned no row")?;
+        .context("warehouse aggregate returned no row")?;
     let row_count = parse_u64(row.first().and_then(Option::as_deref))?;
     let mut index = 1;
     let mut columns = BTreeMap::new();
     for name in names {
+        let data_type = types
+            .get(name)
+            .map(|value| value.data_type.as_str())
+            .unwrap_or_default();
+        if !dialect.supports_column_metrics(data_type) {
+            continue;
+        }
         let null_count = parse_u64(row.get(index).and_then(Option::as_deref))?;
         let cardinality = parse_u64(row.get(index + 1).and_then(Option::as_deref))?;
         let min = row.get(index + 2).cloned().flatten();
@@ -367,7 +403,7 @@ async fn relation_metrics(
         };
         if types
             .get(name)
-            .is_some_and(|value| is_numeric(&value.data_type))
+            .is_some_and(|value| dialect.is_numeric(&value.data_type))
         {
             metrics.average = parse_optional_f64(row.get(index).and_then(Option::as_deref))?;
             index += 1;
@@ -383,21 +419,22 @@ async fn relation_metrics(
     Ok(RelationMetrics { row_count, columns })
 }
 
-async fn compare_primary_key(
-    client: &SnowflakeClient,
+async fn compare_primary_key<E: QueryExecutor + ?Sized>(
+    client: &E,
     ci: &Relation,
     production: &Relation,
     keys: &[String],
     sample_limit: usize,
     where_clause: Option<&str>,
 ) -> Result<PrimaryKeyComparison> {
+    let dialect = client.dialect();
     let selected = keys
         .iter()
-        .map(|key| quote_identifier(key))
+        .map(|key| dialect.quote_identifier(key))
         .collect::<Vec<_>>()
         .join(", ");
-    let ci_source = filtered_relation(ci, where_clause);
-    let production_source = filtered_relation(production, where_clause);
+    let ci_source = filtered_relation(dialect, ci, where_clause);
+    let production_source = filtered_relation(dialect, production, where_clause);
     let ci_keys = format!(
         "SELECT {selected}, COUNT(*) AS KEY_ROWS, 1 AS PRESENT FROM {ci_source} GROUP BY {selected}"
     );
@@ -407,37 +444,63 @@ async fn compare_primary_key(
     let join = keys
         .iter()
         .map(|key| {
-            let key = quote_identifier(key);
-            format!("EQUAL_NULL(C.{key}, P.{key})")
+            let key = dialect.quote_identifier(key);
+            dialect.null_safe_equal(&format!("C.{key}"), &format!("P.{key}"))
         })
         .collect::<Vec<_>>()
         .join(" AND ");
     let ci_null = keys
         .iter()
-        .map(|key| format!("C.{} IS NULL", quote_identifier(key)))
+        .map(|key| format!("C.{} IS NULL", dialect.quote_identifier(key)))
         .collect::<Vec<_>>()
         .join(" OR ");
     let production_null = keys
         .iter()
-        .map(|key| format!("P.{} IS NULL", quote_identifier(key)))
+        .map(|key| format!("P.{} IS NULL", dialect.quote_identifier(key)))
         .collect::<Vec<_>>()
         .join(" OR ");
     let ci_null_unqualified = keys
         .iter()
-        .map(|key| format!("{} IS NULL", quote_identifier(key)))
+        .map(|key| format!("{} IS NULL", dialect.quote_identifier(key)))
         .collect::<Vec<_>>()
         .join(" OR ");
+    let ci_duplicate_rows = dialect.conditional(
+        &format!("C.PRESENT IS NOT NULL AND NOT ({ci_null})"),
+        "GREATEST(C.KEY_ROWS - 1, 0)",
+        "0",
+    );
+    let production_duplicate_rows = dialect.conditional(
+        &format!("P.PRESENT IS NOT NULL AND NOT ({production_null})"),
+        "GREATEST(P.KEY_ROWS - 1, 0)",
+        "0",
+    );
+    let ci_null_rows = dialect.conditional(
+        &format!("C.PRESENT IS NOT NULL AND ({ci_null})"),
+        "C.KEY_ROWS",
+        "0",
+    );
+    let production_null_rows = dialect.conditional(
+        &format!("P.PRESENT IS NOT NULL AND ({production_null})"),
+        "P.KEY_ROWS",
+        "0",
+    );
     let counts = client
         .execute(&format!(
             "WITH CI_KEYS AS ({ci_keys}), PRODUCTION_KEYS AS ({production_keys}) \
-             SELECT COUNT_IF(P.PRESENT IS NULL), COUNT_IF(C.PRESENT IS NULL), \
-             COUNT_IF(C.PRESENT IS NOT NULL AND NOT ({ci_null}) AND C.KEY_ROWS > 1), \
-             COUNT_IF(P.PRESENT IS NOT NULL AND NOT ({production_null}) AND P.KEY_ROWS > 1), \
-             COALESCE(SUM(IFF(C.PRESENT IS NOT NULL AND NOT ({ci_null}), GREATEST(C.KEY_ROWS - 1, 0), 0)), 0), \
-             COALESCE(SUM(IFF(P.PRESENT IS NOT NULL AND NOT ({production_null}), GREATEST(P.KEY_ROWS - 1, 0), 0)), 0), \
-             COALESCE(SUM(IFF(C.PRESENT IS NOT NULL AND ({ci_null}), C.KEY_ROWS, 0)), 0), \
-             COALESCE(SUM(IFF(P.PRESENT IS NOT NULL AND ({production_null}), P.KEY_ROWS, 0)), 0) \
-             FROM CI_KEYS C FULL OUTER JOIN PRODUCTION_KEYS P ON {join}"
+             SELECT {}, {}, {}, {}, \
+             COALESCE(SUM({ci_duplicate_rows}), 0), \
+             COALESCE(SUM({production_duplicate_rows}), 0), \
+             COALESCE(SUM({ci_null_rows}), 0), \
+             COALESCE(SUM({production_null_rows}), 0) \
+             FROM CI_KEYS C FULL OUTER JOIN PRODUCTION_KEYS P ON {join}",
+            dialect.count_if("P.PRESENT IS NULL"),
+            dialect.count_if("C.PRESENT IS NULL"),
+            dialect.count_if(&format!(
+                "C.PRESENT IS NOT NULL AND NOT ({ci_null}) AND C.KEY_ROWS > 1"
+            )),
+            dialect.count_if(&format!(
+                "P.PRESENT IS NOT NULL AND NOT ({production_null}) AND P.KEY_ROWS > 1"
+            )),
         ))
         .await?;
     let row = counts
@@ -454,12 +517,12 @@ async fn compare_primary_key(
     let production_null_key_rows = parse_u64(row.get(7).and_then(Option::as_deref))?;
     let ci_selected = keys
         .iter()
-        .map(|key| format!("C.{}", quote_identifier(key)))
+        .map(|key| format!("C.{}", dialect.quote_identifier(key)))
         .collect::<Vec<_>>()
         .join(", ");
     let production_selected = keys
         .iter()
-        .map(|key| format!("P.{}", quote_identifier(key)))
+        .map(|key| format!("P.{}", dialect.quote_identifier(key)))
         .collect::<Vec<_>>()
         .join(", ");
     let ci_examples = if ci_only_count == 0 {
@@ -515,10 +578,14 @@ async fn compare_primary_key(
     })
 }
 
-fn filtered_relation(relation: &Relation, where_clause: Option<&str>) -> String {
+fn filtered_relation(
+    dialect: SqlDialect,
+    relation: &Relation,
+    where_clause: Option<&str>,
+) -> String {
     match where_clause {
-        Some(predicate) => format!("{} WHERE ({predicate})", relation.sql()),
-        None => relation.sql(),
+        Some(predicate) => format!("{} WHERE ({predicate})", relation.sql(dialect)),
+        None => relation.sql(dialect),
     }
 }
 
@@ -544,38 +611,6 @@ fn resolve_column(columns: &BTreeMap<String, ResultColumn>, configured: &str) ->
     }
 }
 
-fn is_numeric(data_type: &str) -> bool {
-    let normalized = data_type.to_ascii_lowercase();
-    normalized.starts_with("number(")
-        || normalized.starts_with("numeric(")
-        || normalized.starts_with("decimal(")
-        || matches!(
-            normalized.as_str(),
-            "fixed"
-                | "real"
-                | "number"
-                | "numeric"
-                | "decimal"
-                | "float"
-                | "double"
-                | "int"
-                | "integer"
-                | "bigint"
-                | "smallint"
-        )
-}
-
-fn is_orderable(data_type: &str) -> bool {
-    !matches!(
-        data_type
-            .to_ascii_uppercase()
-            .split('(')
-            .next()
-            .unwrap_or_default(),
-        "ARRAY" | "OBJECT" | "VARIANT" | "BINARY" | "GEOGRAPHY" | "GEOMETRY"
-    )
-}
-
 fn relative_change(current: f64, production: f64) -> f64 {
     if current == production {
         0.0
@@ -586,7 +621,7 @@ fn relative_change(current: f64, production: f64) -> f64 {
 
 fn effective_cardinality_threshold(mode: ComparisonMode, thresholds: Thresholds) -> f64 {
     match mode {
-        // Snowflake's HLL estimate is fast but should not be treated as sub-percent precision.
+        // Approximate distinct counts should not be treated as sub-percent precision.
         ComparisonMode::Quick => thresholds.cardinality_relative.max(0.02),
         ComparisonMode::Deep => thresholds.cardinality_relative,
     }
@@ -594,9 +629,9 @@ fn effective_cardinality_threshold(mode: ComparisonMode, thresholds: Thresholds)
 
 fn parse_u64(value: Option<&str>) -> Result<u64> {
     value
-        .context("Snowflake returned NULL for an integer metric")?
+        .context("warehouse returned NULL for an integer metric")?
         .parse()
-        .context("Snowflake returned an invalid integer metric")
+        .context("warehouse returned an invalid integer metric")
 }
 
 fn parse_optional_f64(value: Option<&str>) -> Result<Option<f64>> {
@@ -604,9 +639,9 @@ fn parse_optional_f64(value: Option<&str>) -> Result<Option<f64>> {
         .map(|value| {
             let parsed: f64 = value
                 .parse()
-                .context("Snowflake returned an invalid numeric metric")?;
+                .context("warehouse returned an invalid numeric metric")?;
             if !parsed.is_finite() {
-                bail!("Snowflake returned a non-finite numeric metric: {value}");
+                bail!("warehouse returned a non-finite numeric metric: {value}");
             }
             Ok(parsed)
         })
@@ -646,7 +681,11 @@ mod tests {
             identifier: "ORDERS".into(),
         };
         assert_eq!(
-            filtered_relation(&relation, Some("ORDER_DATE >= CURRENT_DATE - 30")),
+            filtered_relation(
+                SqlDialect::Snowflake,
+                &relation,
+                Some("ORDER_DATE >= CURRENT_DATE - 30")
+            ),
             r#""D"."S"."ORDERS" WHERE (ORDER_DATE >= CURRENT_DATE - 30)"#
         );
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -212,17 +212,106 @@ impl Default for Thresholds {
 }
 
 #[derive(Debug, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
+#[serde(from = "AccountConfigWire")]
 pub struct AccountConfig {
     pub name: String,
+    pub selector: Option<String>,
+    pub provider: ProviderConfig,
+    pub(crate) legacy: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+enum AccountConfigWire {
+    Tagged(TaggedAccountConfig),
+    Legacy(LegacySnowflakeAccountConfig),
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct TaggedAccountConfig {
+    name: String,
+    selector: Option<String>,
+    provider: ProviderConfig,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct LegacySnowflakeAccountConfig {
+    name: String,
+    account: String,
+    user: String,
+    role: String,
+    database: String,
+    warehouse: String,
+    production_schema: String,
+    selector: Option<String>,
+    auth: AuthConfig,
+}
+
+impl From<AccountConfigWire> for AccountConfig {
+    fn from(value: AccountConfigWire) -> Self {
+        match value {
+            AccountConfigWire::Tagged(value) => Self {
+                name: value.name,
+                selector: value.selector,
+                provider: value.provider,
+                legacy: false,
+            },
+            AccountConfigWire::Legacy(value) => Self {
+                name: value.name,
+                selector: value.selector,
+                provider: ProviderConfig::Snowflake(SnowflakeConfig {
+                    account: value.account,
+                    user: value.user,
+                    role: value.role,
+                    database: value.database,
+                    warehouse: value.warehouse,
+                    production_schema: value.production_schema,
+                    auth: value.auth,
+                }),
+                legacy: true,
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+pub enum ProviderConfig {
+    Snowflake(SnowflakeConfig),
+    Databricks(DatabricksConfig),
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SnowflakeConfig {
     pub account: String,
     pub user: String,
     pub role: String,
     pub database: String,
     pub warehouse: String,
     pub production_schema: String,
-    pub selector: Option<String>,
     pub auth: AuthConfig,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DatabricksConfig {
+    pub host: String,
+    pub http_path: String,
+    pub catalog: String,
+    pub production_schema: String,
+    pub auth: DatabricksAuthConfig,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+pub enum DatabricksAuthConfig {
+    Token {
+        #[serde(default = "default_databricks_token_env")]
+        token_env: String,
+    },
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -242,6 +331,60 @@ pub enum AuthConfig {
         private_key_path: PathBuf,
         passphrase_env: Option<String>,
     },
+}
+
+impl AccountConfig {
+    pub fn database(&self) -> &str {
+        match &self.provider {
+            ProviderConfig::Snowflake(config) => &config.database,
+            ProviderConfig::Databricks(config) => &config.catalog,
+        }
+    }
+
+    pub fn production_schema(&self) -> &str {
+        match &self.provider {
+            ProviderConfig::Snowflake(config) => &config.production_schema,
+            ProviderConfig::Databricks(config) => &config.production_schema,
+        }
+    }
+
+    pub fn snowflake(&self) -> Option<&SnowflakeConfig> {
+        match &self.provider {
+            ProviderConfig::Snowflake(config) => Some(config),
+            ProviderConfig::Databricks(_) => None,
+        }
+    }
+
+    pub fn databricks(&self) -> Option<&DatabricksConfig> {
+        match &self.provider {
+            ProviderConfig::Snowflake(_) => None,
+            ProviderConfig::Databricks(config) => Some(config),
+        }
+    }
+}
+
+impl DatabricksConfig {
+    pub fn workspace_url(&self) -> String {
+        let host = self.host.trim_end_matches('/');
+        if host.starts_with("https://") {
+            host.to_owned()
+        } else {
+            format!("https://{host}")
+        }
+    }
+
+    pub fn dbt_host(&self) -> &str {
+        self.host
+            .strip_prefix("https://")
+            .unwrap_or(&self.host)
+            .trim_end_matches('/')
+    }
+
+    pub fn warehouse_id(&self) -> &str {
+        self.http_path
+            .strip_prefix("/sql/1.0/warehouses/")
+            .unwrap_or_default()
+    }
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -335,11 +478,20 @@ impl Config {
     }
 
     pub fn validate(&self) -> Result<()> {
-        if self.version != 1 {
-            bail!("unsupported config version {}; expected 1", self.version);
+        if !matches!(self.version, 1 | 2) {
+            bail!(
+                "unsupported config version {}; expected 1 or 2",
+                self.version
+            );
         }
         if self.accounts.is_empty() {
-            bail!("at least one Snowflake account is required");
+            bail!("at least one warehouse account is required");
+        }
+        if self.version == 1 && self.accounts.iter().any(|account| !account.legacy) {
+            bail!("config version 1 requires the legacy Snowflake account shape");
+        }
+        if self.version == 2 && self.accounts.iter().any(|account| account.legacy) {
+            bail!("config version 2 requires a tagged provider block for every account");
         }
         if self.dbt.profile.trim().is_empty() || self.dbt.command.trim().is_empty() {
             bail!("dbt profile and command must not be empty");
@@ -375,7 +527,7 @@ impl Config {
             bail!("statement timeout must be greater than zero");
         }
         if self.safety.statement_timeout_seconds > 604_800 {
-            bail!("statement timeout must not exceed Snowflake's 604800-second maximum");
+            bail!("statement timeout must not exceed 604800 seconds");
         }
         if self.comparison.concurrency == 0 || self.comparison.concurrency > 32 {
             bail!("comparison.concurrency must be between 1 and 32");
@@ -422,37 +574,7 @@ impl Config {
                 );
             }
             if !account_names.insert(account.name.to_ascii_lowercase()) {
-                bail!("Snowflake account names must be unique");
-            }
-            for (field, value) in [
-                ("name", &account.name),
-                ("account", &account.account),
-                ("user", &account.user),
-                ("role", &account.role),
-                ("database", &account.database),
-                ("warehouse", &account.warehouse),
-                ("production_schema", &account.production_schema),
-            ] {
-                if value.trim().is_empty() {
-                    bail!("account {} has an empty {field}", account.name);
-                }
-            }
-            if account.account.len() > 255
-                || account.account.starts_with(['.', '-'])
-                || account.account.ends_with(['.', '-'])
-                || account
-                    .account
-                    .to_ascii_lowercase()
-                    .ends_with(".snowflakecomputing.com")
-                || !account.account.chars().all(|character| {
-                    character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.')
-                })
-                || account.account.contains("..")
-            {
-                bail!(
-                    "account identifier {} is invalid; use the identifier only, without https:// or .snowflakecomputing.com",
-                    account.account
-                );
+                bail!("account names must be unique");
             }
             if account
                 .selector
@@ -461,28 +583,9 @@ impl Config {
             {
                 bail!("account {} has an empty dbt selector", account.name);
             }
-            match &account.auth {
-                AuthConfig::OauthLocal => {}
-                AuthConfig::Oauth { token_env }
-                | AuthConfig::ProgrammaticAccessToken { token_env } => {
-                    if token_env.trim().is_empty() {
-                        bail!("account {} has an empty token_env", account.name);
-                    }
-                }
-                AuthConfig::KeyPair {
-                    private_key_path,
-                    passphrase_env,
-                } => {
-                    if private_key_path.as_os_str().is_empty() {
-                        bail!("account {} has an empty private_key_path", account.name);
-                    }
-                    if passphrase_env
-                        .as_ref()
-                        .is_some_and(|value| value.trim().is_empty())
-                    {
-                        bail!("account {} has an empty passphrase_env", account.name);
-                    }
-                }
+            match &account.provider {
+                ProviderConfig::Snowflake(config) => validate_snowflake(account, config)?,
+                ProviderConfig::Databricks(config) => validate_databricks(account, config)?,
             }
         }
         let mut check_names = BTreeSet::new();
@@ -573,9 +676,13 @@ impl Config {
             self.dbt.state_dir = Some(absolute_from(root, path)?);
         }
         for account in &mut self.accounts {
-            if let AuthConfig::KeyPair {
-                private_key_path, ..
-            } = &mut account.auth
+            if let ProviderConfig::Snowflake(SnowflakeConfig {
+                auth:
+                    AuthConfig::KeyPair {
+                        private_key_path, ..
+                    },
+                ..
+            }) = &mut account.provider
             {
                 let expanded = expand_home(private_key_path)?;
                 *private_key_path = if expanded.is_absolute() {
@@ -587,6 +694,108 @@ impl Config {
         }
         Ok(())
     }
+}
+
+fn validate_snowflake(account: &AccountConfig, config: &SnowflakeConfig) -> Result<()> {
+    for (field, value) in [
+        ("account", &config.account),
+        ("user", &config.user),
+        ("role", &config.role),
+        ("database", &config.database),
+        ("warehouse", &config.warehouse),
+        ("production_schema", &config.production_schema),
+    ] {
+        if value.trim().is_empty() {
+            bail!("account {} has an empty {field}", account.name);
+        }
+    }
+    if config.account.len() > 255
+        || config.account.starts_with(['.', '-'])
+        || config.account.ends_with(['.', '-'])
+        || config
+            .account
+            .to_ascii_lowercase()
+            .ends_with(".snowflakecomputing.com")
+        || !config.account.chars().all(|character| {
+            character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.')
+        })
+        || config.account.contains("..")
+    {
+        bail!(
+            "account identifier {} is invalid; use the identifier only, without https:// or .snowflakecomputing.com",
+            config.account
+        );
+    }
+    match &config.auth {
+        AuthConfig::OauthLocal => {}
+        AuthConfig::Oauth { token_env } | AuthConfig::ProgrammaticAccessToken { token_env } => {
+            if token_env.trim().is_empty() {
+                bail!("account {} has an empty token_env", account.name);
+            }
+        }
+        AuthConfig::KeyPair {
+            private_key_path,
+            passphrase_env,
+        } => {
+            if private_key_path.as_os_str().is_empty() {
+                bail!("account {} has an empty private_key_path", account.name);
+            }
+            if passphrase_env
+                .as_ref()
+                .is_some_and(|value| value.trim().is_empty())
+            {
+                bail!("account {} has an empty passphrase_env", account.name);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_databricks(account: &AccountConfig, config: &DatabricksConfig) -> Result<()> {
+    for (field, value) in [
+        ("host", &config.host),
+        ("http_path", &config.http_path),
+        ("catalog", &config.catalog),
+        ("production_schema", &config.production_schema),
+    ] {
+        if value.trim().is_empty() {
+            bail!("account {} has an empty {field}", account.name);
+        }
+    }
+    let workspace_url = url::Url::parse(&config.workspace_url())
+        .with_context(|| format!("account {} has an invalid Databricks host", account.name))?;
+    if workspace_url.scheme() != "https"
+        || workspace_url.host_str().is_none()
+        || !workspace_url.username().is_empty()
+        || workspace_url.password().is_some()
+        || workspace_url.path() != "/"
+        || workspace_url.query().is_some()
+        || workspace_url.fragment().is_some()
+    {
+        bail!(
+            "account {} Databricks host must be an HTTPS workspace hostname without a path",
+            account.name
+        );
+    }
+    let warehouse_id = config.warehouse_id();
+    if warehouse_id.is_empty()
+        || warehouse_id.contains('/')
+        || !warehouse_id
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || matches!(character, '-' | '_'))
+    {
+        bail!(
+            "account {} http_path must be /sql/1.0/warehouses/<warehouse-id>",
+            account.name
+        );
+    }
+    match &config.auth {
+        DatabricksAuthConfig::Token { token_env } if token_env.trim().is_empty() => {
+            bail!("account {} has an empty token_env", account.name)
+        }
+        DatabricksAuthConfig::Token { .. } => {}
+    }
+    Ok(())
 }
 
 fn absolute_from(root: &Path, path: &Path) -> Result<PathBuf> {
@@ -671,6 +880,9 @@ fn default_oauth_env() -> String {
 }
 fn default_pat_env() -> String {
     "SNOWFLAKE_PROGRAMMATIC_ACCESS_TOKEN".into()
+}
+fn default_databricks_token_env() -> String {
+    "DATABRICKS_TOKEN".into()
 }
 fn default_metabase_env() -> String {
     "METABASE_API_KEY".into()
@@ -800,6 +1012,39 @@ accounts:
     }
 
     #[test]
+    fn version_two_accepts_a_typed_databricks_provider() {
+        let yaml = r#"
+version: 2
+accounts:
+  - name: lakehouse
+    provider:
+      type: databricks
+      host: https://example.cloud.databricks.com
+      http_path: /sql/1.0/warehouses/abc123
+      catalog: analytics
+      production_schema: prod
+      auth: { type: token, token_env: DATABRICKS_TOKEN }
+"#;
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        config.validate().unwrap();
+        assert_eq!(config.accounts[0].database(), "analytics");
+        assert!(matches!(
+            config.accounts[0].provider,
+            ProviderConfig::Databricks(_)
+        ));
+
+        let invalid = yaml.replace("/sql/1.0/warehouses/abc123", "/sql/protocolv1/o/cluster");
+        let config: Config = serde_yaml::from_str(&invalid).unwrap();
+        assert!(
+            config
+                .validate()
+                .unwrap_err()
+                .to_string()
+                .contains("http_path")
+        );
+    }
+
+    #[test]
     fn rejects_account_names_that_can_escape_temporary_paths() {
         let yaml = r#"
 version: 1
@@ -848,9 +1093,12 @@ accounts:
         .unwrap();
         let mut config = Config::load(&config_path).unwrap();
         config.resolve_from(&config_path).unwrap();
-        let AuthConfig::KeyPair {
-            private_key_path, ..
-        } = &config.accounts[0].auth
+        let ProviderConfig::Snowflake(SnowflakeConfig {
+            auth: AuthConfig::KeyPair {
+                private_key_path, ..
+            },
+            ..
+        }) = &config.accounts[0].provider
         else {
             panic!("expected key-pair auth");
         };

--- a/src/databricks.rs
+++ b/src/databricks.rs
@@ -1,0 +1,489 @@
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result, bail};
+use reqwest::{Client, StatusCode, header};
+use serde::Deserialize;
+use serde_json::{Value, json};
+use tokio::time::{sleep, timeout};
+
+use crate::{
+    auth::{DatabricksResolvedAuth, ResolvedAuth},
+    clean,
+    config::{AccountConfig, DatabricksConfig},
+    provider::{
+        ProviderFuture, QueryExecutor, QueryResult, Relation, ResultColumn, SqlDialect,
+        WarehouseProvider, is_managed_schema,
+    },
+};
+
+#[derive(Clone)]
+pub struct DatabricksClient {
+    http: Client,
+    workspace_url: String,
+    endpoint: String,
+    token: String,
+    account: DatabricksConfig,
+    query_tag: String,
+    timeout_seconds: u64,
+}
+
+impl DatabricksClient {
+    pub fn new(
+        account: &AccountConfig,
+        auth: &ResolvedAuth,
+        query_tag: String,
+        timeout_seconds: u64,
+    ) -> Result<Self> {
+        let account = account
+            .databricks()
+            .context("Databricks client requires Databricks account configuration")?;
+        let ResolvedAuth::Databricks(DatabricksResolvedAuth::Token { token }) = auth else {
+            bail!("Databricks client received credentials for another provider");
+        };
+        let workspace_url = account.workspace_url();
+        Ok(Self {
+            http: Client::builder()
+                .timeout(Duration::from_secs(timeout_seconds + 30))
+                .build()?,
+            endpoint: format!("{workspace_url}/api/2.0/sql/statements"),
+            workspace_url,
+            token: token.clone(),
+            account: account.clone(),
+            query_tag,
+            timeout_seconds,
+        })
+    }
+
+    pub async fn execute(&self, statement: &str) -> Result<QueryResult> {
+        timeout(Duration::from_secs(self.timeout_seconds + 30), async {
+            let started = Instant::now();
+            let response = self
+                .http
+                .post(&self.endpoint)
+                .headers(self.headers()?)
+                .json(&json!({
+                    "statement": format!("/* {} */\n{statement}", self.query_tag),
+                    "warehouse_id": self.account.warehouse_id(),
+                    "catalog": self.account.catalog,
+                    "schema": self.account.production_schema,
+                    "format": "JSON_ARRAY",
+                    "disposition": "INLINE",
+                    "wait_timeout": "0s",
+                    "on_wait_timeout": "CONTINUE"
+                }))
+                .send()
+                .await
+                .context("Databricks Statement Execution request failed")?;
+            let mut body = parse_response(response).await?;
+            loop {
+                match body.status.state.as_str() {
+                    "PENDING" | "RUNNING" => {
+                        let statement_id = body
+                            .statement_id
+                            .as_deref()
+                            .context("Databricks response omitted statement_id")?;
+                        if started.elapsed() >= Duration::from_secs(self.timeout_seconds) {
+                            let _ = self
+                                .http
+                                .post(format!("{}/{statement_id}/cancel", self.endpoint))
+                                .headers(self.headers()?)
+                                .send()
+                                .await;
+                            bail!(
+                                "Databricks statement exceeded {} seconds; cancellation was requested",
+                                self.timeout_seconds
+                            );
+                        }
+                        sleep(Duration::from_millis(500)).await;
+                        body = parse_response(
+                            self.http
+                                .get(format!("{}/{}", self.endpoint, statement_id))
+                                .headers(self.headers()?)
+                                .send()
+                                .await
+                                .context("Databricks statement polling failed")?,
+                        )
+                        .await?;
+                    }
+                    "SUCCEEDED" => return self.result(body).await,
+                    "FAILED" | "CANCELED" | "CLOSED" => {
+                        let error = body.status.error.as_ref();
+                        bail!(
+                            "Databricks statement {}: {}",
+                            body.status.state.to_ascii_lowercase(),
+                            error
+                                .and_then(|value| value.message.as_deref())
+                                .or(body.message.as_deref())
+                                .unwrap_or("unknown error")
+                        );
+                    }
+                    state => bail!("Databricks returned unknown statement state {state}"),
+                }
+            }
+        })
+        .await
+        .with_context(|| {
+            format!(
+                "Databricks statement exceeded {} seconds",
+                self.timeout_seconds + 30
+            )
+        })?
+    }
+
+    async fn result(&self, body: StatementResponse) -> Result<QueryResult> {
+        let columns = body
+            .manifest
+            .and_then(|manifest| manifest.schema)
+            .map(|schema| {
+                schema
+                    .columns
+                    .into_iter()
+                    .map(|column| ResultColumn {
+                        name: column.name,
+                        data_type: column.type_text.or(column.type_name).unwrap_or_default(),
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        let mut chunk = body.result.unwrap_or_default();
+        let mut rows = parse_rows(std::mem::take(&mut chunk.data_array));
+        while let Some(link) = chunk.next_chunk_internal_link.take() {
+            if !link.starts_with("/api/2.0/sql/statements/") {
+                bail!("Databricks returned an unsafe result chunk link");
+            }
+            let response = self
+                .http
+                .get(format!("{}{}", self.workspace_url, link))
+                .headers(self.headers()?)
+                .send()
+                .await
+                .context("Databricks result chunk request failed")?;
+            let status = response.status();
+            if !status.is_success() {
+                bail!("Databricks result chunk failed (HTTP {status})");
+            }
+            chunk = response
+                .json()
+                .await
+                .context("Databricks returned an invalid result chunk")?;
+            rows.extend(parse_rows(std::mem::take(&mut chunk.data_array)));
+        }
+        Ok(QueryResult { columns, rows })
+    }
+
+    pub async fn create_schema(&self, catalog: &str, schema: &str) -> Result<()> {
+        let dialect = SqlDialect::Databricks;
+        self.execute(&format!(
+            "CREATE SCHEMA {}.{} COMMENT {}",
+            dialect.quote_identifier(catalog),
+            dialect.quote_identifier(schema),
+            quote_string(&self.schema_ownership_marker())
+        ))
+        .await?;
+        Ok(())
+    }
+
+    pub async fn copy_table(&self, source: &Relation, target: &Relation) -> Result<()> {
+        self.execute(&copy_table_statement(source, target)).await?;
+        Ok(())
+    }
+
+    pub async fn seed_table(&self, source: &Relation, target: &Relation) -> Result<()> {
+        self.execute(&seed_table_statement(source, target)).await?;
+        Ok(())
+    }
+
+    pub async fn drop_schema(&self, catalog: &str, schema: &str, run_schema: &str) -> Result<()> {
+        if !is_managed_schema(SqlDialect::Databricks, schema, run_schema) {
+            bail!("refusing to drop schema {schema}: it is not owned by this run ({run_schema})");
+        }
+        let Some(comment) = self.schema_comment(catalog, schema).await? else {
+            return Ok(());
+        };
+        if comment != self.schema_ownership_marker() {
+            bail!(
+                "refusing to drop schema {catalog}.{schema}: its ownership marker does not match this run"
+            );
+        }
+        self.drop_schema_cascade(catalog, schema).await
+    }
+
+    pub async fn stale_managed_schemas(
+        &self,
+        catalog: &str,
+        prefix: &str,
+        older_than_hours: u64,
+    ) -> Result<QueryResult> {
+        let dialect = SqlDialect::Databricks;
+        self.execute(&format!(
+            "SELECT SCHEMA_NAME, COMMENT, CAST(CREATED AS STRING) FROM {}.INFORMATION_SCHEMA.SCHEMATA \
+             WHERE SCHEMA_NAME LIKE {} ESCAPE '!' \
+             AND COMMENT LIKE 'Temporary schema managed by Embrasure;%' \
+             AND CREATED < CURRENT_TIMESTAMP() - INTERVAL {older_than_hours} HOURS \
+             ORDER BY CREATED, SCHEMA_NAME",
+            dialect.quote_identifier(catalog),
+            quote_string(&format!("{prefix}!_%"))
+        ))
+        .await
+    }
+
+    pub async fn drop_marked_schema(
+        &self,
+        catalog: &str,
+        schema: &str,
+        prefix: &str,
+    ) -> Result<()> {
+        if !clean::is_managed_prefix(schema, prefix) {
+            bail!("refusing to drop schema {schema}: it is outside the managed prefix {prefix}");
+        }
+        let Some(comment) = self.schema_comment(catalog, schema).await? else {
+            return Ok(());
+        };
+        if clean::parse_ownership_marker(&comment).is_none() {
+            bail!(
+                "refusing to drop schema {catalog}.{schema}: its Embrasure ownership marker is invalid"
+            );
+        }
+        self.drop_schema_cascade(catalog, schema).await
+    }
+
+    async fn schema_comment(&self, catalog: &str, schema: &str) -> Result<Option<String>> {
+        let dialect = SqlDialect::Databricks;
+        let result = self
+            .execute(&format!(
+                "SELECT COMMENT FROM {}.INFORMATION_SCHEMA.SCHEMATA WHERE CATALOG_NAME = {} AND SCHEMA_NAME = {}",
+                dialect.quote_identifier(catalog),
+                quote_string(&dialect.normalize_identifier(catalog, None)),
+                quote_string(&dialect.normalize_identifier(schema, None))
+            ))
+            .await?;
+        Ok(result
+            .rows
+            .first()
+            .and_then(|row| row.first())
+            .cloned()
+            .flatten())
+    }
+
+    async fn drop_schema_cascade(&self, catalog: &str, schema: &str) -> Result<()> {
+        let dialect = SqlDialect::Databricks;
+        self.execute(&format!(
+            "DROP SCHEMA IF EXISTS {}.{} CASCADE",
+            dialect.quote_identifier(catalog),
+            dialect.quote_identifier(schema)
+        ))
+        .await?;
+        Ok(())
+    }
+
+    fn schema_ownership_marker(&self) -> String {
+        format!("Temporary schema managed by Embrasure; {}", self.query_tag)
+    }
+
+    fn headers(&self) -> Result<header::HeaderMap> {
+        let mut headers = header::HeaderMap::new();
+        headers.insert(
+            header::AUTHORIZATION,
+            format!("Bearer {}", self.token).parse()?,
+        );
+        headers.insert(
+            header::ACCEPT,
+            header::HeaderValue::from_static("application/json"),
+        );
+        headers.insert(
+            header::CONTENT_TYPE,
+            header::HeaderValue::from_static("application/json"),
+        );
+        headers.insert(
+            header::USER_AGENT,
+            header::HeaderValue::from_static(concat!("embrasure/", env!("CARGO_PKG_VERSION"))),
+        );
+        Ok(headers)
+    }
+}
+
+impl QueryExecutor for DatabricksClient {
+    fn dialect(&self) -> SqlDialect {
+        SqlDialect::Databricks
+    }
+
+    fn execute<'a>(&'a self, statement: &'a str) -> ProviderFuture<'a, QueryResult> {
+        Box::pin(DatabricksClient::execute(self, statement))
+    }
+}
+
+impl WarehouseProvider for DatabricksClient {
+    fn create_schema<'a>(&'a self, catalog: &'a str, schema: &'a str) -> ProviderFuture<'a, ()> {
+        Box::pin(DatabricksClient::create_schema(self, catalog, schema))
+    }
+
+    fn copy_table<'a>(
+        &'a self,
+        source: &'a Relation,
+        target: &'a Relation,
+    ) -> ProviderFuture<'a, ()> {
+        Box::pin(DatabricksClient::copy_table(self, source, target))
+    }
+
+    fn seed_table<'a>(
+        &'a self,
+        source: &'a Relation,
+        target: &'a Relation,
+    ) -> ProviderFuture<'a, ()> {
+        Box::pin(DatabricksClient::seed_table(self, source, target))
+    }
+
+    fn drop_schema<'a>(
+        &'a self,
+        catalog: &'a str,
+        schema: &'a str,
+        run_schema: &'a str,
+    ) -> ProviderFuture<'a, ()> {
+        Box::pin(DatabricksClient::drop_schema(
+            self, catalog, schema, run_schema,
+        ))
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct StatementResponse {
+    statement_id: Option<String>,
+    #[serde(default)]
+    status: StatementStatus,
+    manifest: Option<Manifest>,
+    result: Option<ResultChunk>,
+    message: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct StatementStatus {
+    #[serde(default)]
+    state: String,
+    error: Option<StatementError>,
+}
+
+#[derive(Debug, Deserialize)]
+struct StatementError {
+    message: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Manifest {
+    schema: Option<ResultSchema>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ResultSchema {
+    #[serde(default)]
+    columns: Vec<ApiColumn>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiColumn {
+    name: String,
+    type_text: Option<String>,
+    type_name: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct ResultChunk {
+    #[serde(default)]
+    data_array: Vec<Vec<Value>>,
+    next_chunk_internal_link: Option<String>,
+}
+
+async fn parse_response(response: reqwest::Response) -> Result<StatementResponse> {
+    let status = response.status();
+    let body: StatementResponse = response
+        .json()
+        .await
+        .context("Databricks returned invalid JSON")?;
+    if status != StatusCode::OK {
+        bail!(
+            "Databricks Statement Execution request failed (HTTP {status}): {}",
+            body.message.as_deref().unwrap_or("unknown error")
+        );
+    }
+    Ok(body)
+}
+
+fn parse_rows(rows: Vec<Vec<Value>>) -> Vec<Vec<Option<String>>> {
+    rows.into_iter()
+        .map(|row| {
+            row.into_iter()
+                .map(|value| match value {
+                    Value::Null => None,
+                    Value::String(value) => Some(value),
+                    other => Some(other.to_string()),
+                })
+                .collect()
+        })
+        .collect()
+}
+
+fn quote_string(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
+}
+
+fn copy_table_statement(source: &Relation, target: &Relation) -> String {
+    let dialect = SqlDialect::Databricks;
+    format!(
+        "CREATE TABLE {} SHALLOW CLONE {}",
+        target.sql(dialect),
+        source.sql(dialect)
+    )
+}
+
+fn seed_table_statement(source: &Relation, target: &Relation) -> String {
+    let dialect = SqlDialect::Databricks;
+    dialect.create_table_as(target, &format!("SELECT * FROM {}", source.sql(dialect)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn response_rows_and_identifiers_match_the_api_contract() {
+        let body: StatementResponse = serde_json::from_value(json!({
+            "statement_id": "01abc",
+            "status": { "state": "SUCCEEDED" },
+            "manifest": {
+                "schema": {
+                    "columns": [{ "name": "id", "type_name": "LONG", "type_text": "BIGINT" }]
+                }
+            },
+            "result": { "data_array": [["1"], [null]] }
+        }))
+        .unwrap();
+        assert_eq!(body.status.state, "SUCCEEDED");
+        assert_eq!(
+            body.manifest.unwrap().schema.unwrap().columns[0]
+                .type_text
+                .as_deref(),
+            Some("BIGINT")
+        );
+        assert_eq!(
+            parse_rows(body.result.unwrap().data_array),
+            vec![vec![Some("1".into())], vec![None]]
+        );
+        let relation = Relation {
+            database: "main".into(),
+            schema: "ci".into(),
+            identifier: "orders".into(),
+        };
+        assert_eq!(relation.sql(SqlDialect::Databricks), "`main`.`ci`.`orders`");
+        let target = Relation {
+            identifier: "candidate".into(),
+            ..relation.clone()
+        };
+        assert_eq!(
+            copy_table_statement(&relation, &target),
+            "CREATE TABLE `main`.`ci`.`candidate` SHALLOW CLONE `main`.`ci`.`orders`"
+        );
+        assert_eq!(
+            seed_table_statement(&relation, &target),
+            "CREATE TABLE `main`.`ci`.`candidate` AS SELECT * FROM `main`.`ci`.`orders`"
+        );
+    }
+}

--- a/src/dbt.rs
+++ b/src/dbt.rs
@@ -14,9 +14,9 @@ use tempfile::TempDir;
 use uuid::Uuid;
 
 use crate::{
-    auth::ResolvedAuth,
-    config::{AccountConfig, Config},
-    git,
+    auth::{DatabricksResolvedAuth, ResolvedAuth, SnowflakeResolvedAuth},
+    config::{AccountConfig, Config, ProviderConfig},
+    git, provider,
     report::{ImpactReport, ImpactedAsset, LineageChange, LineageChangeKind, LineageEdge},
 };
 
@@ -29,7 +29,7 @@ fn verify_executable_for_shell(command: &str, shell: &str) -> Result<String> {
         Ok(output) => output,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
             bail!(
-                "dbt executable `{command}` was not found (detected shell: {shell}). Install dbt Core and dbt-snowflake with your project's package manager and activate that environment, or {}. Verify with `{command} --version`.",
+                "dbt executable `{command}` was not found (detected shell: {shell}). Install dbt Core and the adapter for your configured warehouse with your project's package manager and activate that environment, or {}. Verify with `{command} --version`.",
                 path_instruction(shell),
             );
         }
@@ -201,7 +201,14 @@ struct Profile {
 }
 
 #[derive(Debug, Clone, Serialize)]
-struct ProfileOutput {
+#[serde(untagged)]
+enum ProfileOutput {
+    Snowflake(SnowflakeProfileOutput),
+    Databricks(DatabricksProfileOutput),
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct SnowflakeProfileOutput {
     #[serde(rename = "type")]
     kind: &'static str,
     account: String,
@@ -223,6 +230,18 @@ struct ProfileOutput {
     private_key_passphrase: Option<String>,
     query_tag: String,
     session_parameters: BTreeMap<String, Value>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct DatabricksProfileOutput {
+    #[serde(rename = "type")]
+    kind: &'static str,
+    host: String,
+    http_path: String,
+    catalog: String,
+    schema: String,
+    token: String,
+    threads: u16,
 }
 
 impl Manifest {
@@ -618,7 +637,7 @@ pub fn prepare(
             config,
             auth,
             &base_profiles,
-            |account| account.production_schema.clone(),
+            |account| account.production_schema().to_owned(),
             query_tag,
         )?;
         maybe_dbt_deps(config, &base_project, &base_profiles)?;
@@ -1058,54 +1077,73 @@ fn write_profiles(
 ) -> Result<()> {
     let mut outputs = BTreeMap::new();
     for account in &config.accounts {
-        let mut session_parameters = BTreeMap::new();
-        session_parameters.insert("QUERY_TAG".to_owned(), Value::String(query_tag.to_owned()));
-        session_parameters.insert(
-            "STATEMENT_TIMEOUT_IN_SECONDS".to_owned(),
-            Value::from(config.safety.statement_timeout_seconds),
-        );
         let resolved = auth
             .get(&account.name)
             .with_context(|| format!("resolved auth is missing for account {}", account.name))?;
-        let (authenticator, token, password, private_key_path, private_key_passphrase) =
-            match resolved {
-                ResolvedAuth::OAuth { token } => {
-                    (Some("oauth"), Some(token.clone()), None, None, None)
-                }
-                ResolvedAuth::KeyPair {
+        let output = match (&account.provider, resolved) {
+            (ProviderConfig::Snowflake(snowflake), ResolvedAuth::Snowflake(resolved)) => {
+                let mut session_parameters = BTreeMap::new();
+                session_parameters
+                    .insert("QUERY_TAG".to_owned(), Value::String(query_tag.to_owned()));
+                session_parameters.insert(
+                    "STATEMENT_TIMEOUT_IN_SECONDS".to_owned(),
+                    Value::from(config.safety.statement_timeout_seconds),
+                );
+                let (authenticator, token, password, private_key_path, private_key_passphrase) =
+                    match resolved {
+                        SnowflakeResolvedAuth::OAuth { token } => {
+                            (Some("oauth"), Some(token.clone()), None, None, None)
+                        }
+                        SnowflakeResolvedAuth::KeyPair {
+                            private_key_path,
+                            passphrase,
+                        } => (
+                            None,
+                            None,
+                            None,
+                            Some(private_key_path.to_string_lossy().into_owned()),
+                            passphrase.clone(),
+                        ),
+                        SnowflakeResolvedAuth::ProgrammaticAccessToken { token } => {
+                            (None, None, Some(token.clone()), None, None)
+                        }
+                    };
+                ProfileOutput::Snowflake(SnowflakeProfileOutput {
+                    kind: provider::dialect(account).dbt_adapter_name(),
+                    account: snowflake.account.clone(),
+                    user: snowflake.user.clone(),
+                    role: snowflake.role.clone(),
+                    database: snowflake.database.clone(),
+                    warehouse: snowflake.warehouse.clone(),
+                    schema: schema(account),
+                    threads: config.dbt.threads,
+                    authenticator,
+                    token,
+                    password,
                     private_key_path,
-                    passphrase,
-                } => (
-                    None,
-                    None,
-                    None,
-                    Some(private_key_path.to_string_lossy().into_owned()),
-                    passphrase.clone(),
-                ),
-                ResolvedAuth::ProgrammaticAccessToken { token } => {
-                    (None, None, Some(token.clone()), None, None)
-                }
-            };
-        outputs.insert(
-            account.name.clone(),
-            ProfileOutput {
-                kind: "snowflake",
-                account: account.account.clone(),
-                user: account.user.clone(),
-                role: account.role.clone(),
-                database: account.database.clone(),
-                warehouse: account.warehouse.clone(),
-                schema: schema(account),
-                threads: config.dbt.threads,
-                authenticator,
-                token,
-                password,
-                private_key_path,
-                private_key_passphrase,
-                query_tag: query_tag.to_owned(),
-                session_parameters,
-            },
-        );
+                    private_key_passphrase,
+                    query_tag: query_tag.to_owned(),
+                    session_parameters,
+                })
+            }
+            (ProviderConfig::Databricks(databricks), ResolvedAuth::Databricks(resolved)) => {
+                let DatabricksResolvedAuth::Token { token } = resolved;
+                ProfileOutput::Databricks(DatabricksProfileOutput {
+                    kind: provider::dialect(account).dbt_adapter_name(),
+                    host: databricks.dbt_host().to_owned(),
+                    http_path: databricks.http_path.clone(),
+                    catalog: databricks.catalog.clone(),
+                    schema: schema(account),
+                    token: token.clone(),
+                    threads: config.dbt.threads,
+                })
+            }
+            _ => bail!(
+                "resolved auth provider does not match account {}",
+                account.name
+            ),
+        };
+        outputs.insert(account.name.clone(), output);
     }
     let file = ProfileFile {
         profiles: BTreeMap::from([(
@@ -1466,7 +1504,7 @@ mod tests {
             .to_string();
         assert!(error.contains(&format!("dbt executable `{command}` was not found")));
         assert!(error.contains("detected shell: zsh"));
-        assert!(error.contains("Install dbt Core and dbt-snowflake"));
+        assert!(error.contains("Install dbt Core and the adapter"));
         assert!(error.contains("~/.zshrc"));
         assert!(error.contains(&format!("{command} --version")));
         assert!(!error.contains("No such file or directory"));
@@ -1547,14 +1585,47 @@ accounts:
         let config: Config = serde_yaml::from_str(yaml).unwrap();
         let auth = BTreeMap::from([(
             "ci".into(),
-            ResolvedAuth::ProgrammaticAccessToken {
+            ResolvedAuth::Snowflake(SnowflakeResolvedAuth::ProgrammaticAccessToken {
                 token: "secret-pat".into(),
-            },
+            }),
         )]);
         let dir = tempfile::tempdir().unwrap();
         write_profiles(&config, &auth, dir.path(), |_| "CHECK".into(), "tag").unwrap();
         let profile = fs::read_to_string(dir.path().join("profiles.yml")).unwrap();
         assert!(profile.contains("password: secret-pat"));
         assert!(!profile.contains("authenticator:"));
+    }
+
+    #[test]
+    fn databricks_profile_uses_the_typed_provider_fields() {
+        let yaml = r#"
+version: 2
+accounts:
+  - name: lakehouse
+    provider:
+      type: databricks
+      host: https://example.cloud.databricks.com
+      http_path: /sql/1.0/warehouses/abc123
+      catalog: analytics
+      production_schema: prod
+      auth: { type: token }
+"#;
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        config.validate().unwrap();
+        let auth = BTreeMap::from([(
+            "lakehouse".into(),
+            ResolvedAuth::Databricks(DatabricksResolvedAuth::Token {
+                token: "secret-token".into(),
+            }),
+        )]);
+        let dir = tempfile::tempdir().unwrap();
+        write_profiles(&config, &auth, dir.path(), |_| "check".into(), "tag").unwrap();
+        let profile = fs::read_to_string(dir.path().join("profiles.yml")).unwrap();
+        assert!(profile.contains("type: databricks"));
+        assert!(profile.contains("host: example.cloud.databricks.com"));
+        assert!(profile.contains("http_path: /sql/1.0/warehouses/abc123"));
+        assert!(profile.contains("catalog: analytics"));
+        assert!(profile.contains("token: secret-token"));
+        assert!(!profile.contains("warehouse:"));
     }
 }

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -6,9 +6,11 @@ use uuid::Uuid;
 
 use crate::{
     auth,
-    config::Config,
+    config::{Config, DatabricksConfig, ProviderConfig, SnowflakeConfig},
+    databricks::DatabricksClient,
     dbt, lineage, metabase,
-    snowflake::{QueryResult, Relation, SnowflakeClient, quote_identifier},
+    provider::{QueryResult, Relation, SqlDialect, WarehouseProvider, dialect},
+    snowflake::{SnowflakeClient, quote_identifier},
     style::Style,
 };
 
@@ -59,7 +61,7 @@ pub async fn run(config_path: &Path, write_test: bool) -> DoctorReport {
     }
 
     for account in &config.accounts {
-        let scope = format!("snowflake:{}", account.name);
+        let scope = format!("{}:{}", dialect(account).dbt_adapter_name(), account.name);
         let auth_status = match auth::status(account) {
             Ok(status) => status,
             Err(error) => {
@@ -85,152 +87,49 @@ pub async fn run(config_path: &Path, write_test: bool) -> DoctorReport {
             }
         };
         let query_tag = format!("embrasure:doctor:{}", Uuid::new_v4());
-        let client = match SnowflakeClient::new(
-            account,
-            &resolved,
-            query_tag,
-            config.safety.statement_timeout_seconds,
-        ) {
-            Ok(client) => client,
-            Err(error) => {
-                report.fail(&scope, "authentication", format!("{error:#}"));
-                continue;
-            }
-        };
-        match client
-            .execute("SELECT CURRENT_ACCOUNT(), CURRENT_USER(), CURRENT_ROLE(), CURRENT_WAREHOUSE(), CURRENT_DATABASE()")
-            .await
-        {
-            Ok(result) => match verify_session(account, &result) {
-                Ok(identity) => report.pass(&scope, "session", identity),
-                Err(error) => {
-                    report.fail(&scope, "session", format!("{error:#}"));
-                    continue;
-                }
-            },
-            Err(error) => {
-                report.fail(&scope, "session", format!("{error:#}"));
-                continue;
-            }
-        }
-        let mut clone_source = None;
-        let production = format!(
-            "SHOW TABLES IN SCHEMA {}.{}",
-            quote_identifier(&account.database),
-            quote_identifier(&account.production_schema)
-        );
-        match client.execute(&production).await {
-            Ok(tables) => {
-                let mut relations = relation_names(&tables);
-                clone_source = relations.first().cloned();
-                let views = format!(
-                    "SHOW VIEWS IN SCHEMA {}.{}",
-                    quote_identifier(&account.database),
-                    quote_identifier(&account.production_schema)
-                );
-                match client.execute(&views).await {
-                    Ok(views) => relations.extend(relation_names(&views)),
-                    Err(error) => {
-                        report.fail(&scope, "production_read", format!("{error:#}"));
-                        continue;
-                    }
-                }
-                relations.sort();
-                relations.dedup();
-                if let Some(relation) = relations.first() {
-                    let sample = format!(
-                        "SELECT * FROM {}.{}.{} LIMIT 0",
-                        quote_identifier(&account.database),
-                        quote_identifier(&account.production_schema),
-                        quote_identifier(relation)
-                    );
-                    match client.execute(&sample).await {
-                        Ok(_) => report.pass(
+        match &account.provider {
+            ProviderConfig::Snowflake(provider) => {
+                match SnowflakeClient::new(
+                    account,
+                    &resolved,
+                    query_tag,
+                    config.safety.statement_timeout_seconds,
+                ) {
+                    Ok(client) => {
+                        check_snowflake(
+                            &client,
+                            provider,
                             &scope,
-                            "production_read",
-                            format!(
-                                "can read production; {} visible table(s) or view(s)",
-                                relations.len()
-                            ),
-                        ),
-                        Err(error) => report.fail(&scope, "production_read", format!("{error:#}")),
-                    }
-                } else {
-                    report.pass(
-                        &scope,
-                        "production_read",
-                        "production schema is visible but contains no tables or views",
-                    );
-                }
-            }
-            Err(error) => report.fail(&scope, "production_read", format!("{error:#}")),
-        }
-
-        if write_test {
-            let schema = format!(
-                "{}_DOCTOR_{}",
-                config.safety.schema_prefix.to_ascii_uppercase(),
-                Uuid::new_v4().simple()
-            );
-            match client.create_schema(&account.database, &schema).await {
-                Ok(()) => {
-                    if let Some(identifier) = clone_source {
-                        let source = Relation {
-                            database: account.database.clone(),
-                            schema: account.production_schema.clone(),
-                            identifier,
-                        };
-                        let target = Relation {
-                            database: account.database.clone(),
-                            schema: schema.clone(),
-                            identifier: "EMBRASURE_CLONE_CHECK".into(),
-                        };
-                        match client.clone_table(&source, &target).await {
-                            Ok(()) => report.pass(
-                                &scope,
-                                "incremental_clone",
-                                "can zero-copy clone a production table",
-                            ),
-                            Err(error) => report.fail(
-                                &scope,
-                                "incremental_clone",
-                                format!(
-                                    "cannot clone a production table: {error:#}; confirm the relation type and update grants"
-                                ),
-                            ),
-                        }
-                    } else {
-                        report.skip(
-                            &scope,
-                            "incremental_clone",
-                            "no production table was available to test (views cannot be cloned)",
-                        );
-                    }
-                    match client
-                        .drop_schema(&account.database, &schema, &schema)
+                            &config.safety.schema_prefix,
+                            write_test,
+                            &mut report,
+                        )
                         .await
-                    {
-                        Ok(()) => report.pass(
-                            &scope,
-                            "ci_schema_lifecycle",
-                            "created and removed a temporary schema",
-                        ),
-                        Err(error) => report.fail(
-                            &scope,
-                            "ci_schema_lifecycle",
-                            format!("created {schema}, but cleanup failed: {error:#}"),
-                        ),
                     }
+                    Err(error) => report.fail(&scope, "authentication", format!("{error:#}")),
                 }
-                Err(error) => report.fail(
-                    &scope,
-                    "ci_schema_lifecycle",
-                    format!("could not create a temporary schema: {error:#}"),
-                ),
             }
-        } else {
-            report.skip(&scope, "ci_schema_lifecycle", "skipped by --read-only");
-            report.skip(&scope, "incremental_clone", "skipped by --read-only");
+            ProviderConfig::Databricks(provider) => {
+                match DatabricksClient::new(
+                    account,
+                    &resolved,
+                    query_tag,
+                    config.safety.statement_timeout_seconds,
+                ) {
+                    Ok(client) => {
+                        check_databricks(
+                            &client,
+                            provider,
+                            &scope,
+                            &config.safety.schema_prefix,
+                            write_test,
+                            &mut report,
+                        )
+                        .await
+                    }
+                    Err(error) => report.fail(&scope, "authentication", format!("{error:#}")),
+                }
+            }
         }
     }
 
@@ -249,7 +148,272 @@ pub async fn run(config_path: &Path, write_test: bool) -> DoctorReport {
     report
 }
 
-fn verify_session(account: &crate::config::AccountConfig, result: &QueryResult) -> Result<String> {
+async fn check_snowflake(
+    client: &SnowflakeClient,
+    account: &SnowflakeConfig,
+    scope: &str,
+    schema_prefix: &str,
+    write_test: bool,
+    report: &mut DoctorReport,
+) {
+    match client
+        .execute("SELECT CURRENT_ACCOUNT(), CURRENT_USER(), CURRENT_ROLE(), CURRENT_WAREHOUSE(), CURRENT_DATABASE()")
+        .await
+    {
+        Ok(result) => match verify_snowflake_session(account, &result) {
+            Ok(identity) => report.pass(scope, "session", identity),
+            Err(error) => {
+                report.fail(scope, "session", format!("{error:#}"));
+                return;
+            }
+        },
+        Err(error) => {
+            report.fail(scope, "session", format!("{error:#}"));
+            return;
+        }
+    }
+    let mut clone_source = None;
+    let production = format!(
+        "SHOW TABLES IN SCHEMA {}.{}",
+        quote_identifier(&account.database),
+        quote_identifier(&account.production_schema)
+    );
+    match client.execute(&production).await {
+        Ok(tables) => {
+            let mut relations = relation_names(&tables);
+            clone_source = relations.first().cloned();
+            let views = format!(
+                "SHOW VIEWS IN SCHEMA {}.{}",
+                quote_identifier(&account.database),
+                quote_identifier(&account.production_schema)
+            );
+            match client.execute(&views).await {
+                Ok(views) => relations.extend(relation_names(&views)),
+                Err(error) => {
+                    report.fail(scope, "production_read", format!("{error:#}"));
+                    return;
+                }
+            }
+            relations.sort();
+            relations.dedup();
+            check_readable_relation(
+                client,
+                SqlDialect::Snowflake,
+                &account.database,
+                &account.production_schema,
+                &relations,
+                scope,
+                report,
+            )
+            .await;
+        }
+        Err(error) => report.fail(scope, "production_read", format!("{error:#}")),
+    }
+    check_schema_lifecycle(
+        client,
+        SqlDialect::Snowflake,
+        &account.database,
+        &account.production_schema,
+        schema_prefix,
+        clone_source,
+        scope,
+        write_test,
+        report,
+    )
+    .await;
+}
+
+async fn check_databricks(
+    client: &DatabricksClient,
+    account: &DatabricksConfig,
+    scope: &str,
+    schema_prefix: &str,
+    write_test: bool,
+    report: &mut DoctorReport,
+) {
+    match client
+        .execute("SELECT CURRENT_USER(), CURRENT_CATALOG(), CURRENT_SCHEMA()")
+        .await
+    {
+        Ok(result) => match verify_databricks_session(account, &result) {
+            Ok(identity) => report.pass(scope, "session", identity),
+            Err(error) => {
+                report.fail(scope, "session", format!("{error:#}"));
+                return;
+            }
+        },
+        Err(error) => {
+            report.fail(scope, "session", format!("{error:#}"));
+            return;
+        }
+    }
+    let dialect = SqlDialect::Databricks;
+    let tables = client
+        .execute(&format!(
+            "SELECT TABLE_NAME, TABLE_TYPE, DATA_SOURCE_FORMAT FROM {}.INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = '{}' ORDER BY TABLE_NAME",
+            dialect.quote_identifier(&account.catalog),
+            dialect
+                .normalize_identifier(&account.production_schema, None)
+                .replace('\'', "''")
+        ))
+        .await;
+    let mut clone_source = None;
+    match tables {
+        Ok(tables) => {
+            let relations = tables
+                .rows
+                .iter()
+                .filter_map(|row| row.first().and_then(|value| value.clone()))
+                .collect::<Vec<_>>();
+            clone_source = tables.rows.iter().find_map(|row| {
+                let kind = row.get(1)?.as_deref()?;
+                let format = row.get(2)?.as_deref()?;
+                (kind.eq_ignore_ascii_case("MANAGED") && format.eq_ignore_ascii_case("DELTA"))
+                    .then(|| row.first().and_then(|value| value.clone()))
+                    .flatten()
+            });
+            check_readable_relation(
+                client,
+                dialect,
+                &account.catalog,
+                &account.production_schema,
+                &relations,
+                scope,
+                report,
+            )
+            .await;
+        }
+        Err(error) => report.fail(scope, "production_read", format!("{error:#}")),
+    }
+    check_schema_lifecycle(
+        client,
+        dialect,
+        &account.catalog,
+        &account.production_schema,
+        schema_prefix,
+        clone_source,
+        scope,
+        write_test,
+        report,
+    )
+    .await;
+}
+
+async fn check_readable_relation<E: crate::provider::QueryExecutor + ?Sized>(
+    client: &E,
+    dialect: SqlDialect,
+    database: &str,
+    production_schema: &str,
+    relations: &[String],
+    scope: &str,
+    report: &mut DoctorReport,
+) {
+    if let Some(identifier) = relations.first() {
+        let relation = Relation {
+            database: database.to_owned(),
+            schema: production_schema.to_owned(),
+            identifier: identifier.clone(),
+        };
+        match client
+            .execute(&format!("SELECT * FROM {} LIMIT 0", relation.sql(dialect)))
+            .await
+        {
+            Ok(_) => report.pass(
+                scope,
+                "production_read",
+                format!(
+                    "can read production; {} visible table(s) or view(s)",
+                    relations.len()
+                ),
+            ),
+            Err(error) => report.fail(scope, "production_read", format!("{error:#}")),
+        }
+    } else {
+        report.pass(
+            scope,
+            "production_read",
+            "production schema is visible but contains no tables or views",
+        );
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn check_schema_lifecycle<P: WarehouseProvider + ?Sized>(
+    client: &P,
+    dialect: SqlDialect,
+    database: &str,
+    production_schema: &str,
+    schema_prefix: &str,
+    clone_source: Option<String>,
+    scope: &str,
+    write_test: bool,
+    report: &mut DoctorReport,
+) {
+    if !write_test {
+        report.skip(scope, "ci_schema_lifecycle", "skipped by --read-only");
+        report.skip(scope, "incremental_clone", "skipped by --read-only");
+        return;
+    }
+    let schema = dialect.normalize_identifier(
+        &format!("{schema_prefix}_DOCTOR_{}", Uuid::new_v4().simple()),
+        None,
+    );
+    match client.create_schema(database, &schema).await {
+        Ok(()) => {
+            if let Some(identifier) = clone_source {
+                let source = Relation {
+                    database: database.to_owned(),
+                    schema: production_schema.to_owned(),
+                    identifier,
+                };
+                let target = Relation {
+                    database: database.to_owned(),
+                    schema: schema.clone(),
+                    identifier: dialect.normalize_identifier("EMBRASURE_CLONE_CHECK", None),
+                };
+                match client.copy_table(&source, &target).await {
+                    Ok(()) => report.pass(
+                        scope,
+                        "incremental_clone",
+                        "can create an isolated snapshot copy of a production table",
+                    ),
+                    Err(error) => report.fail(
+                        scope,
+                        "incremental_clone",
+                        format!(
+                            "cannot copy a production table: {error:#}; confirm the relation type and update grants"
+                        ),
+                    ),
+                }
+            } else {
+                report.skip(
+                    scope,
+                    "incremental_clone",
+                    "no supported production table was available to test",
+                );
+            }
+            match client.drop_schema(database, &schema, &schema).await {
+                Ok(()) => report.pass(
+                    scope,
+                    "ci_schema_lifecycle",
+                    "created and removed a temporary schema",
+                ),
+                Err(error) => report.fail(
+                    scope,
+                    "ci_schema_lifecycle",
+                    format!("created {schema}, but cleanup failed: {error:#}"),
+                ),
+            }
+        }
+        Err(error) => report.fail(
+            scope,
+            "ci_schema_lifecycle",
+            format!("could not create a temporary schema: {error:#}"),
+        ),
+    }
+}
+
+fn verify_snowflake_session(account: &SnowflakeConfig, result: &QueryResult) -> Result<String> {
     let row = result
         .rows
         .first()
@@ -275,6 +439,36 @@ fn verify_session(account: &crate::config::AccountConfig, result: &QueryResult) 
         if !actual.eq_ignore_ascii_case(expected) {
             bail!(
                 "requested {label} {expected}, but Snowflake activated {actual}; check grants and configuration"
+            );
+        }
+    }
+    Ok(values.join(" / "))
+}
+
+fn verify_databricks_session(account: &DatabricksConfig, result: &QueryResult) -> Result<String> {
+    let row = result
+        .rows
+        .first()
+        .context("Databricks session query returned no rows")?;
+    let values = (0..3)
+        .map(|index| {
+            row.get(index)
+                .and_then(|value| value.as_deref())
+                .with_context(|| {
+                    format!(
+                        "Databricks session query returned NULL at column {}",
+                        index + 1
+                    )
+                })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    for (label, actual, expected) in [
+        ("catalog", values[1], account.catalog.as_str()),
+        ("schema", values[2], account.production_schema.as_str()),
+    ] {
+        if !actual.eq_ignore_ascii_case(expected) {
+            bail!(
+                "requested {label} {expected}, but Databricks activated {actual}; check grants and configuration"
             );
         }
     }
@@ -398,7 +592,7 @@ impl DoctorReport {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{config::AuthConfig, snowflake::ResultColumn};
+    use crate::{config::AuthConfig, provider::ResultColumn};
 
     #[test]
     fn a_failure_makes_the_report_not_ready() {
@@ -415,15 +609,13 @@ mod tests {
 
     #[test]
     fn session_check_rejects_a_role_snowflake_did_not_activate() {
-        let account = crate::config::AccountConfig {
-            name: "one".into(),
+        let account = SnowflakeConfig {
             account: "org-account".into(),
             user: "CI_USER".into(),
             role: "DBT_CI".into(),
             database: "ANALYTICS".into(),
             warehouse: "DBT_CI_WH".into(),
             production_schema: "PROD".into(),
-            selector: None,
             auth: AuthConfig::Oauth {
                 token_env: "TOKEN".into(),
             },
@@ -444,7 +636,7 @@ mod tests {
             ]],
         };
         assert!(
-            verify_session(&account, &result)
+            verify_snowflake_session(&account, &result)
                 .unwrap_err()
                 .to_string()
                 .contains("role")

--- a/src/lineage.rs
+++ b/src/lineage.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     dbt::{Manifest, ManifestNode},
+    provider::SqlDialect,
     report::{ColumnLineageEdge, ColumnLineageGap},
 };
 
@@ -20,6 +21,15 @@ const SCRIPT: &str = include_str!("sqlglot_lineage.py");
 #[derive(Serialize)]
 struct Request<'a> {
     models: Vec<ModelRequest<'a>>,
+}
+
+#[derive(Serialize)]
+struct Invocation<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    dialect: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    unquoted_case: Option<&'static str>,
+    models: &'a [ModelRequest<'a>],
 }
 
 #[derive(Serialize)]
@@ -64,6 +74,7 @@ pub struct Extraction {
 
 pub fn extract(
     account: &str,
+    dialect: SqlDialect,
     current: &Manifest,
     production: &Manifest,
     compiled: &Manifest,
@@ -106,7 +117,7 @@ pub fn extract(
         });
     }
 
-    let response = invoke(&Request { models })?;
+    let response = invoke(&Request { models }, Some(dialect))?;
     let mut edges = Vec::new();
     for model in response.models {
         let Some(target) = current.nodes.get(&model.unique_id) else {
@@ -157,15 +168,15 @@ pub fn extract(
 }
 
 pub fn probe() -> Result<String> {
-    Ok(invoke(&Request { models: vec![] })?.sqlglot_version)
+    Ok(invoke(&Request { models: vec![] }, None)?.sqlglot_version)
 }
 
-fn invoke(request: &Request<'_>) -> Result<Response> {
+fn invoke(request: &Request<'_>, dialect: Option<SqlDialect>) -> Result<Response> {
     let bundled = bundled_sqlglot_path()?;
     let commands = python_commands();
     let mut last_not_found = None;
     for command in commands {
-        match invoke_with(request, bundled.as_deref(), &command) {
+        match invoke_with(request, dialect, bundled.as_deref(), &command) {
             Err(error)
                 if error
                     .downcast_ref::<std::io::Error>()
@@ -188,6 +199,7 @@ struct PythonCommand {
 
 fn invoke_with(
     request: &Request<'_>,
+    dialect: Option<SqlDialect>,
     bundled: Option<&Path>,
     python: &PythonCommand,
 ) -> Result<Response> {
@@ -210,7 +222,11 @@ fn invoke_with(
             .stdin
             .as_mut()
             .context("SQLGlot stdin was not available")?,
-        request,
+        &Invocation {
+            dialect: dialect.map(SqlDialect::sqlglot_name),
+            unquoted_case: dialect.map(SqlDialect::sqlglot_unquoted_case),
+            models: &request.models,
+        },
     )?;
     child
         .stdin
@@ -535,7 +551,7 @@ mod tests {
                 sql: "with orders as (select customer_id, amount from raw.orders) select customer_id, sum(amount) as total from orders group by 1",
             }],
         };
-        let response = invoke(&request).unwrap();
+        let response = invoke(&request, Some(SqlDialect::Snowflake)).unwrap();
         let model = &response.models[0];
         assert!(model.gaps.is_empty());
         assert!(model.edges.iter().any(|edge| {
@@ -547,6 +563,24 @@ mod tests {
             edge.output_column == "TOTAL"
                 && edge.source_relation == "RAW.ORDERS"
                 && edge.source_column == "AMOUNT"
+        }));
+    }
+
+    #[test]
+    fn sqlglot_uses_databricks_identifier_rules() {
+        let request = Request {
+            models: vec![ModelRequest {
+                unique_id: "model.project.summary",
+                sql: "select Customer_ID, cast(Amount as double) as Total from Analytics.Raw.Orders",
+            }],
+        };
+        let response = invoke(&request, Some(SqlDialect::Databricks)).unwrap();
+        let edges = &response.models[0].edges;
+        assert!(response.models[0].gaps.is_empty());
+        assert!(edges.iter().any(|edge| {
+            edge.output_column == "customer_id"
+                && edge.source_relation == "analytics.raw.orders"
+                && edge.source_column == "customer_id"
         }));
     }
 
@@ -572,7 +606,7 @@ mod tests {
                 },
             ],
         };
-        let response = invoke(&request).unwrap();
+        let response = invoke(&request, Some(SqlDialect::Snowflake)).unwrap();
         assert!(response.models.iter().all(|model| model.gaps.is_empty()));
 
         let case_join = response
@@ -629,7 +663,7 @@ mod tests {
                 sql: "select from definitely not valid",
             }],
         };
-        let response = invoke(&request).unwrap();
+        let response = invoke(&request, Some(SqlDialect::Snowflake)).unwrap();
         let gap = &response.models[0].gaps[0];
         assert_eq!(
             gap,
@@ -647,7 +681,7 @@ mod tests {
                 sql: "select * from raw.orders",
             }],
         };
-        let response = invoke(&request).unwrap();
+        let response = invoke(&request, Some(SqlDialect::Snowflake)).unwrap();
         assert!(response.models[0].edges.is_empty());
         assert!(response.models[0].gaps[0].contains("cannot be expanded"));
     }
@@ -660,7 +694,7 @@ mod tests {
                 sql: "select current_timestamp() as loaded_at",
             }],
         };
-        let response = invoke(&request).unwrap();
+        let response = invoke(&request, Some(SqlDialect::Snowflake)).unwrap();
         assert!(response.models[0].edges.is_empty());
         assert!(response.models[0].gaps.is_empty());
     }
@@ -673,7 +707,7 @@ mod tests {
                 sql: "select source.\"CamelCase\" as \"OutputCase\" from raw.orders source",
             }],
         };
-        let response = invoke(&request).unwrap();
+        let response = invoke(&request, Some(SqlDialect::Snowflake)).unwrap();
         assert_eq!(response.models[0].edges[0].source_column, "CamelCase");
         assert_eq!(response.models[0].edges[0].output_column, "OutputCase");
     }
@@ -686,7 +720,7 @@ mod tests {
                 sql: "select id, amount from raw.orders union all select id, amount from raw.archive",
             }],
         };
-        let response = invoke(&request).unwrap();
+        let response = invoke(&request, Some(SqlDialect::Snowflake)).unwrap();
         let output_columns = response.models[0]
             .edges
             .iter()
@@ -714,6 +748,7 @@ mod tests {
 
         let extraction = extract(
             "primary",
+            SqlDialect::Snowflake,
             &current,
             &production,
             &compiled,
@@ -760,6 +795,7 @@ mod tests {
 
         let extraction = extract(
             "primary",
+            SqlDialect::Snowflake,
             &current,
             &production,
             &compiled,
@@ -803,6 +839,7 @@ mod tests {
 
         let extraction = extract(
             "primary",
+            SqlDialect::Snowflake,
             &current,
             &production,
             &compiled,
@@ -841,6 +878,7 @@ mod tests {
 
         let extraction = extract(
             "primary",
+            SqlDialect::Snowflake,
             &current,
             &manifest(vec![]),
             &compiled,

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod clean;
 mod cloud;
 mod compare;
 mod config;
+mod databricks;
 mod dbt;
 mod doctor;
 mod git;
@@ -12,6 +13,7 @@ mod lineage;
 mod loopback;
 mod metabase;
 mod progress;
+mod provider;
 mod query;
 mod report;
 mod run;
@@ -85,7 +87,7 @@ impl From<IncrementalModeArg> for IncrementalMode {
 #[command(
     name = "embrasure",
     version,
-    about = "Validate dbt changes against production Snowflake data"
+    about = "Validate dbt changes against production warehouse data"
 )]
 struct Cli {
     /// Configuration file.
@@ -167,7 +169,7 @@ enum Command {
         #[arg(long, value_name = "PATH", requires = "cloud")]
         context_file: Option<PathBuf>,
     },
-    /// Check local tools, credentials, Snowflake permissions, optional Metabase access, and available updates.
+    /// Check local tools, credentials, warehouse permissions, optional Metabase access, and available updates.
     Doctor {
         /// Skip the temporary schema create/drop permission test.
         #[arg(long)]

--- a/src/metabase.rs
+++ b/src/metabase.rs
@@ -9,8 +9,8 @@ use serde_json::Value;
 
 use crate::{
     config::MetabaseConfig,
+    provider::Relation,
     report::{CoverageGap, ImpactedAsset},
-    snowflake::Relation,
 };
 
 pub async fn find_dashboard_impact(

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -54,11 +54,11 @@ impl Phase {
     const fn label(self) -> &'static str {
         match self {
             Self::Setup => "Verify local setup",
-            Self::Schema => "Create temporary Snowflake schemas",
+            Self::Schema => "Create temporary warehouse schemas",
             Self::Impact => "Map affected models",
             Self::Build => "Build selected models",
             Self::Compare => "Compare results with production",
-            Self::Cleanup => "Remove temporary Snowflake schemas",
+            Self::Cleanup => "Remove temporary warehouse schemas",
         }
     }
 }

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -1,0 +1,338 @@
+use std::{future::Future, pin::Pin, sync::Arc};
+
+use anyhow::Result;
+
+use crate::{
+    auth::ResolvedAuth,
+    config::{AccountConfig, ProviderConfig},
+    databricks::DatabricksClient,
+    snowflake::SnowflakeClient,
+};
+
+pub type ProviderFuture<'a, T> = Pin<Box<dyn Future<Output = Result<T>> + Send + 'a>>;
+
+#[derive(Debug, Clone, Default)]
+pub struct QueryResult {
+    pub columns: Vec<ResultColumn>,
+    pub rows: Vec<Vec<Option<String>>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ResultColumn {
+    pub name: String,
+    pub data_type: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Relation {
+    pub database: String,
+    pub schema: String,
+    pub identifier: String,
+}
+
+impl Relation {
+    pub fn sql(&self, dialect: SqlDialect) -> String {
+        format!(
+            "{}.{}.{}",
+            dialect.quote_identifier(&self.database),
+            dialect.quote_identifier(&self.schema),
+            dialect.quote_identifier(&self.identifier)
+        )
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SqlDialect {
+    Snowflake,
+    Databricks,
+}
+
+impl SqlDialect {
+    pub fn sqlglot_name(self) -> &'static str {
+        match self {
+            Self::Snowflake => "snowflake",
+            Self::Databricks => "databricks",
+        }
+    }
+
+    pub fn sqlglot_unquoted_case(self) -> &'static str {
+        match self {
+            Self::Snowflake => "upper",
+            Self::Databricks => "lower",
+        }
+    }
+
+    pub fn dbt_adapter_name(self) -> &'static str {
+        match self {
+            Self::Snowflake => "snowflake",
+            Self::Databricks => "databricks",
+        }
+    }
+
+    pub fn quote_identifier(self, value: &str) -> String {
+        match self {
+            Self::Snowflake => format!("\"{}\"", value.replace('"', "\"\"")),
+            Self::Databricks => format!("`{}`", value.replace('`', "``")),
+        }
+    }
+
+    pub fn normalize_identifier(self, value: &str, quoted: Option<bool>) -> String {
+        match self {
+            Self::Snowflake if !quoted.unwrap_or(false) => value.to_ascii_uppercase(),
+            Self::Snowflake => value.to_owned(),
+            Self::Databricks if !quoted.unwrap_or(false) => value.to_ascii_lowercase(),
+            Self::Databricks => value.to_owned(),
+        }
+    }
+
+    pub fn create_table_as(self, target: &Relation, query: &str) -> String {
+        match self {
+            Self::Snowflake => {
+                format!("CREATE TRANSIENT TABLE {} AS {query}", target.sql(self))
+            }
+            Self::Databricks => format!("CREATE TABLE {} AS {query}", target.sql(self)),
+        }
+    }
+
+    pub fn cast_text(self, expression: &str) -> String {
+        match self {
+            Self::Snowflake => format!("{expression}::VARCHAR"),
+            Self::Databricks => format!("CAST({expression} AS STRING)"),
+        }
+    }
+
+    pub fn to_text(self, expression: &str) -> String {
+        match self {
+            Self::Snowflake => format!("TO_VARCHAR({expression})"),
+            Self::Databricks => format!("CAST({expression} AS STRING)"),
+        }
+    }
+
+    pub fn cast_float(self, expression: &str) -> String {
+        match self {
+            Self::Snowflake => format!("{expression}::DOUBLE"),
+            Self::Databricks => format!("CAST({expression} AS DOUBLE)"),
+        }
+    }
+
+    pub fn null_safe_equal(self, left: &str, right: &str) -> String {
+        match self {
+            Self::Snowflake => format!("EQUAL_NULL({left}, {right})"),
+            Self::Databricks => format!("{left} <=> {right}"),
+        }
+    }
+
+    pub fn conditional(self, condition: &str, when_true: &str, when_false: &str) -> String {
+        match self {
+            Self::Snowflake => format!("IFF({condition}, {when_true}, {when_false})"),
+            Self::Databricks => {
+                format!("CASE WHEN {condition} THEN {when_true} ELSE {when_false} END")
+            }
+        }
+    }
+
+    pub fn count_if(self, condition: &str) -> String {
+        format!("COUNT_IF({condition})")
+    }
+
+    pub fn approximate_distinct(self, expression: &str) -> String {
+        format!("APPROX_COUNT_DISTINCT({expression})")
+    }
+
+    pub fn supports_column_metrics(self, data_type: &str) -> bool {
+        self != Self::Databricks || !self.is_unsupported_value(data_type)
+    }
+
+    pub fn approximate_percentile(self, expression: &str, percentile: &str) -> String {
+        match self {
+            Self::Snowflake => format!("APPROX_PERCENTILE({expression}, {percentile})"),
+            Self::Databricks => format!("PERCENTILE_APPROX({expression}, {percentile})"),
+        }
+    }
+
+    pub fn stable_hash(self, expressions: &[String]) -> String {
+        format!("HASH({})", expressions.join(", "))
+    }
+
+    pub fn is_numeric(self, data_type: &str) -> bool {
+        match self {
+            Self::Snowflake => {
+                let normalized = data_type.to_ascii_lowercase();
+                normalized.starts_with("number(")
+                    || normalized.starts_with("numeric(")
+                    || normalized.starts_with("decimal(")
+                    || matches!(
+                        normalized.as_str(),
+                        "fixed"
+                            | "real"
+                            | "number"
+                            | "numeric"
+                            | "decimal"
+                            | "float"
+                            | "double"
+                            | "int"
+                            | "integer"
+                            | "bigint"
+                            | "smallint"
+                    )
+            }
+            Self::Databricks => {
+                let normalized = data_type.to_ascii_lowercase();
+                normalized.starts_with("decimal(")
+                    || matches!(
+                        normalized.as_str(),
+                        "byte"
+                            | "tinyint"
+                            | "short"
+                            | "smallint"
+                            | "int"
+                            | "integer"
+                            | "long"
+                            | "bigint"
+                            | "float"
+                            | "double"
+                            | "decimal"
+                    )
+            }
+        }
+    }
+
+    pub fn is_orderable(self, data_type: &str) -> bool {
+        match self {
+            Self::Snowflake => !matches!(
+                data_type
+                    .to_ascii_uppercase()
+                    .split('(')
+                    .next()
+                    .unwrap_or_default(),
+                "ARRAY" | "OBJECT" | "VARIANT" | "BINARY" | "GEOGRAPHY" | "GEOMETRY"
+            ),
+            Self::Databricks => !matches!(
+                data_type
+                    .to_ascii_uppercase()
+                    .split(['(', '<'])
+                    .next()
+                    .unwrap_or_default(),
+                "ARRAY" | "MAP" | "STRUCT" | "VARIANT" | "BINARY" | "GEOGRAPHY" | "GEOMETRY"
+            ),
+        }
+    }
+
+    pub fn is_unsupported_value(self, data_type: &str) -> bool {
+        match self {
+            Self::Snowflake => matches!(
+                data_type
+                    .split(['(', ' '])
+                    .next()
+                    .unwrap_or(data_type)
+                    .to_ascii_uppercase()
+                    .as_str(),
+                "ARRAY" | "OBJECT" | "VARIANT" | "GEOGRAPHY" | "GEOMETRY" | "MAP" | "VECTOR"
+            ),
+            Self::Databricks => matches!(
+                data_type
+                    .split(['(', '<', ' '])
+                    .next()
+                    .unwrap_or(data_type)
+                    .to_ascii_uppercase()
+                    .as_str(),
+                "ARRAY" | "MAP" | "STRUCT" | "VARIANT" | "GEOGRAPHY" | "GEOMETRY"
+            ),
+        }
+    }
+}
+
+pub trait QueryExecutor: Send + Sync {
+    fn dialect(&self) -> SqlDialect;
+
+    fn execute<'a>(&'a self, statement: &'a str) -> ProviderFuture<'a, QueryResult>;
+}
+
+pub trait WarehouseProvider: QueryExecutor {
+    fn create_schema<'a>(&'a self, database: &'a str, schema: &'a str) -> ProviderFuture<'a, ()>;
+
+    fn copy_table<'a>(
+        &'a self,
+        source: &'a Relation,
+        target: &'a Relation,
+    ) -> ProviderFuture<'a, ()>;
+
+    fn seed_table<'a>(
+        &'a self,
+        source: &'a Relation,
+        target: &'a Relation,
+    ) -> ProviderFuture<'a, ()>;
+
+    fn drop_schema<'a>(
+        &'a self,
+        database: &'a str,
+        schema: &'a str,
+        run_schema: &'a str,
+    ) -> ProviderFuture<'a, ()>;
+}
+
+pub fn connect(
+    account: &AccountConfig,
+    auth: &ResolvedAuth,
+    query_tag: String,
+    timeout_seconds: u64,
+) -> Result<Arc<dyn WarehouseProvider>> {
+    match &account.provider {
+        ProviderConfig::Snowflake(_) => Ok(Arc::new(SnowflakeClient::new(
+            account,
+            auth,
+            query_tag,
+            timeout_seconds,
+        )?)),
+        ProviderConfig::Databricks(_) => Ok(Arc::new(DatabricksClient::new(
+            account,
+            auth,
+            query_tag,
+            timeout_seconds,
+        )?)),
+    }
+}
+
+pub fn dialect(account: &AccountConfig) -> SqlDialect {
+    match &account.provider {
+        ProviderConfig::Snowflake(_) => SqlDialect::Snowflake,
+        ProviderConfig::Databricks(_) => SqlDialect::Databricks,
+    }
+}
+
+pub fn is_managed_schema(dialect: SqlDialect, schema: &str, run_schema: &str) -> bool {
+    let schema = dialect.normalize_identifier(schema, None);
+    let run_schema = dialect.normalize_identifier(run_schema, None);
+    schema == run_schema || schema.starts_with(&format!("{run_schema}_"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dialects_render_their_provider_contracts() {
+        let dialect = SqlDialect::Snowflake;
+        let relation = Relation {
+            database: "ANALYTICS".into(),
+            schema: "CI".into(),
+            identifier: "odd\"name".into(),
+        };
+        assert_eq!(relation.sql(dialect), r#""ANALYTICS"."CI"."odd""name""#);
+        assert_eq!(
+            dialect.create_table_as(&relation, "SELECT 1"),
+            r#"CREATE TRANSIENT TABLE "ANALYTICS"."CI"."odd""name" AS SELECT 1"#
+        );
+        assert_eq!(dialect.normalize_identifier("mixed", None), "MIXED");
+        let databricks = SqlDialect::Databricks;
+        assert_eq!(databricks.quote_identifier("odd`name"), "`odd``name`");
+        assert_eq!(databricks.normalize_identifier("Mixed", None), "mixed");
+        assert!(!databricks.supports_column_metrics("MAP<STRING, STRING>"));
+        assert!(!databricks.supports_column_metrics("GEOGRAPHY(4326)"));
+        assert!(databricks.is_unsupported_value("GEOMETRY(ANY)"));
+        assert_eq!(
+            databricks.null_safe_equal("left", "right"),
+            "left <=> right"
+        );
+    }
+}

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,19 +1,18 @@
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    future::Future,
-    pin::Pin,
-};
+use std::collections::{BTreeMap, BTreeSet};
 
 use anyhow::{Context, Result, bail};
 
 use crate::{
     config::SafetyConfig,
+    provider::{QueryExecutor, Relation, ResultColumn, SqlDialect},
     report::{
         QueryCheckReport, QueryCheckStatus, QueryColumnComparison, QueryColumnMismatch,
         QueryComparison, QueryDiffExample,
     },
-    snowflake::{QueryResult, Relation, ResultColumn, SnowflakeClient, quote_identifier},
 };
+
+#[cfg(test)]
+use crate::provider::{ProviderFuture, QueryResult};
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) struct RefTarget {
@@ -406,22 +405,6 @@ fn starts(bytes: &[u8], index: usize, value: &[u8]) -> bool {
     bytes.get(index..index + value.len()) == Some(value)
 }
 
-pub(crate) trait QueryExecutor: Send + Sync {
-    fn execute<'a>(
-        &'a self,
-        statement: &'a str,
-    ) -> Pin<Box<dyn Future<Output = Result<QueryResult>> + Send + 'a>>;
-}
-
-impl QueryExecutor for SnowflakeClient {
-    fn execute<'a>(
-        &'a self,
-        statement: &'a str,
-    ) -> Pin<Box<dyn Future<Output = Result<QueryResult>> + Send + 'a>> {
-        Box::pin(SnowflakeClient::execute(self, statement))
-    }
-}
-
 pub(crate) struct QueryDiffInput<'a> {
     pub name: &'a str,
     pub account: &'a str,
@@ -441,10 +424,11 @@ struct ExampleLimits {
     value_chars: usize,
 }
 
-pub(crate) async fn run_query_diff<E: QueryExecutor>(
+pub(crate) async fn run_query_diff<E: QueryExecutor + ?Sized>(
     executor: &E,
     input: QueryDiffInput<'_>,
 ) -> Result<QueryCheckReport> {
+    let dialect = executor.dialect();
     let mut report = QueryCheckReport {
         name: input.name.into(),
         account: input.account.into(),
@@ -452,8 +436,8 @@ pub(crate) async fn run_query_diff<E: QueryExecutor>(
         current_refs: input.current_refs,
         production_refs: input.production_refs,
         primary_key: input.primary_key.to_vec(),
-        candidate_relation: Some(input.candidate.sql()),
-        production_relation: Some(input.production.sql()),
+        candidate_relation: Some(input.candidate.sql(dialect)),
+        production_relation: Some(input.production.sql(dialect)),
         candidate_row_count: None,
         production_row_count: None,
         columns: vec![],
@@ -464,9 +448,14 @@ pub(crate) async fn run_query_diff<E: QueryExecutor>(
     };
     let candidate_columns = preflight(executor, input.candidate_sql).await?;
     let production_columns = preflight(executor, input.production_sql).await?;
-    report.invalid_primary_key_reason =
-        primary_key_metadata_error(input.primary_key, &candidate_columns, &production_columns);
+    report.invalid_primary_key_reason = primary_key_metadata_error(
+        dialect,
+        input.primary_key,
+        &candidate_columns,
+        &production_columns,
+    );
     if let Some(failure) = validate_preflight(
+        dialect,
         &candidate_columns,
         &production_columns,
         input.safety.max_columns_per_model,
@@ -477,18 +466,16 @@ pub(crate) async fn run_query_diff<E: QueryExecutor>(
     }
 
     executor
-        .execute(&format!(
-            "CREATE TRANSIENT TABLE {} AS SELECT * FROM (\n{}\n)",
-            input.candidate.sql(),
-            input.candidate_sql
+        .execute(&dialect.create_table_as(
+            input.candidate,
+            &format!("SELECT * FROM (\n{}\n)", input.candidate_sql),
         ))
         .await
         .context("could not materialize candidate query")?;
     executor
-        .execute(&format!(
-            "CREATE TRANSIENT TABLE {} AS SELECT * FROM (\n{}\n)",
-            input.production.sql(),
-            input.production_sql
+        .execute(&dialect.create_table_as(
+            input.production,
+            &format!("SELECT * FROM (\n{}\n)", input.production_sql),
         ))
         .await
         .context("could not materialize production query")?;
@@ -604,7 +591,10 @@ pub(crate) async fn run_query_diff<E: QueryExecutor>(
     Ok(report)
 }
 
-async fn preflight<E: QueryExecutor>(executor: &E, sql: &str) -> Result<Vec<ResultColumn>> {
+async fn preflight<E: QueryExecutor + ?Sized>(
+    executor: &E,
+    sql: &str,
+) -> Result<Vec<ResultColumn>> {
     Ok(executor
         .execute(&format!("SELECT * FROM (\n{sql}\n) LIMIT 0"))
         .await?
@@ -612,6 +602,7 @@ async fn preflight<E: QueryExecutor>(executor: &E, sql: &str) -> Result<Vec<Resu
 }
 
 fn validate_preflight(
+    dialect: SqlDialect,
     candidate: &[ResultColumn],
     production: &[ResultColumn],
     max_columns: usize,
@@ -628,7 +619,7 @@ fn validate_preflight(
         }
         let mut names = BTreeSet::new();
         for column in columns {
-            if unsupported_type(&column.data_type) {
+            if dialect.is_unsupported_value(&column.data_type) {
                 return Some(format!(
                     "{side} query column {} has unsupported type {}; cast semi-structured, vector, or geospatial values to a scalar type",
                     column.name, column.data_type
@@ -652,6 +643,7 @@ fn validate_preflight(
 }
 
 fn primary_key_metadata_error(
+    dialect: SqlDialect,
     configured: &[String],
     candidate: &[ResultColumn],
     production: &[ResultColumn],
@@ -675,8 +667,8 @@ fn primary_key_metadata_error(
                         "primary-key column {key} has incompatible types {} and {}",
                         candidate.data_type, production.data_type
                     ))
-                } else if unsupported_type(&candidate.data_type)
-                    || unsupported_type(&production.data_type)
+                } else if dialect.is_unsupported_value(&candidate.data_type)
+                    || dialect.is_unsupported_value(&production.data_type)
                 {
                     Some(format!(
                         "primary-key column {key} has unsupported type {}",
@@ -747,28 +739,17 @@ fn column_map(columns: &[ResultColumn]) -> BTreeMap<String, &ResultColumn> {
         .collect()
 }
 
-fn unsupported_type(data_type: &str) -> bool {
-    matches!(
-        data_type
-            .split(['(', ' '])
-            .next()
-            .unwrap_or(data_type)
-            .to_ascii_uppercase()
-            .as_str(),
-        "ARRAY" | "OBJECT" | "VARIANT" | "GEOGRAPHY" | "GEOMETRY" | "MAP" | "VECTOR"
-    )
-}
-
-async fn row_counts<E: QueryExecutor>(
+async fn row_counts<E: QueryExecutor + ?Sized>(
     executor: &E,
     candidate: &Relation,
     production: &Relation,
 ) -> Result<(u64, u64)> {
+    let dialect = executor.dialect();
     let result = executor
         .execute(&format!(
             "SELECT (SELECT COUNT(*) FROM {}), (SELECT COUNT(*) FROM {})",
-            candidate.sql(),
-            production.sql()
+            candidate.sql(dialect),
+            production.sql(dialect)
         ))
         .await?;
     let row = result
@@ -807,16 +788,17 @@ fn resolve_keys<'a>(
     Ok(resolved)
 }
 
-async fn key_integrity<E: QueryExecutor>(
+async fn key_integrity<E: QueryExecutor + ?Sized>(
     executor: &E,
     relation: &Relation,
     keys: &[ColumnPair<'_>],
     candidate_side: bool,
 ) -> Result<(u64, u64, u64)> {
+    let dialect = executor.dialect();
     let names = keys
         .iter()
         .map(|pair| {
-            quote_identifier(if candidate_side {
+            dialect.quote_identifier(if candidate_side {
                 &pair.0.name
             } else {
                 &pair.1.name
@@ -828,14 +810,22 @@ async fn key_integrity<E: QueryExecutor>(
         .map(|name| format!("{name} IS NULL"))
         .collect::<Vec<_>>()
         .join(" OR ");
+    let duplicate_keys =
+        dialect.conditional(&format!("NOT ({nulls}) AND __EMBRASURE_N > 1"), "1", "0");
+    let duplicate_rows = dialect.conditional(
+        &format!("NOT ({nulls}) AND __EMBRASURE_N > 1"),
+        "__EMBRASURE_N - 1",
+        "0",
+    );
+    let null_rows = dialect.conditional(&format!("({nulls})"), "__EMBRASURE_N", "0");
     let result = executor
         .execute(&format!(
-            "SELECT COALESCE(SUM(IFF(NOT ({nulls}) AND __EMBRASURE_N > 1, 1, 0)), 0), \
-             COALESCE(SUM(IFF(NOT ({nulls}) AND __EMBRASURE_N > 1, __EMBRASURE_N - 1, 0)), 0), \
-             COALESCE(SUM(IFF(({nulls}), __EMBRASURE_N, 0)), 0) \
+            "SELECT COALESCE(SUM({duplicate_keys}), 0), \
+             COALESCE(SUM({duplicate_rows}), 0), \
+             COALESCE(SUM({null_rows}), 0) \
              FROM (SELECT {}, COUNT(*) AS __EMBRASURE_N FROM {} GROUP BY {})",
             names.join(", "),
-            relation.sql(),
+            relation.sql(dialect),
             names.join(", ")
         ))
         .await?;
@@ -850,7 +840,7 @@ async fn key_integrity<E: QueryExecutor>(
     ))
 }
 
-async fn key_integrity_examples<E: QueryExecutor>(
+async fn key_integrity_examples<E: QueryExecutor + ?Sized>(
     executor: &E,
     candidate: &Relation,
     production: &Relation,
@@ -861,17 +851,18 @@ async fn key_integrity_examples<E: QueryExecutor>(
     if limits.rows == 0 {
         return Ok(vec![]);
     }
+    let dialect = executor.dialect();
     let canonical = keys
         .iter()
-        .map(|pair| quote_identifier(&pair.0.name))
+        .map(|pair| dialect.quote_identifier(&pair.0.name))
         .collect::<Vec<_>>();
     let candidate_keys = keys
         .iter()
         .map(|pair| {
             format!(
                 "{} AS {}",
-                quote_identifier(&pair.0.name),
-                quote_identifier(&pair.0.name)
+                dialect.quote_identifier(&pair.0.name),
+                dialect.quote_identifier(&pair.0.name)
             )
         })
         .collect::<Vec<_>>();
@@ -880,8 +871,8 @@ async fn key_integrity_examples<E: QueryExecutor>(
         .map(|pair| {
             format!(
                 "{} AS {}",
-                quote_identifier(&pair.1.name),
-                quote_identifier(&pair.0.name)
+                dialect.quote_identifier(&pair.1.name),
+                dialect.quote_identifier(&pair.0.name)
             )
         })
         .collect::<Vec<_>>();
@@ -892,7 +883,7 @@ async fn key_integrity_examples<E: QueryExecutor>(
         .join(" OR ");
     let values = keys
         .iter()
-        .map(|pair| bounded_value("X", &pair.0.name, limits.value_chars))
+        .map(|pair| bounded_value(dialect, "X", &pair.0.name, limits.value_chars))
         .collect::<Vec<_>>();
     let ordering = canonical
         .iter()
@@ -909,15 +900,16 @@ async fn key_integrity_examples<E: QueryExecutor>(
                UNION ALL \
                SELECT 'production' AS __EMBRASURE_SIDE, * FROM P_KEYS WHERE __EMBRASURE_N > 1 OR ({nulls})\
              ) \
-             SELECT X.__EMBRASURE_SIDE, {}, X.__EMBRASURE_N::VARCHAR FROM ISSUES X \
+             SELECT X.__EMBRASURE_SIDE, {}, {} FROM ISSUES X \
              ORDER BY {ordering} LIMIT {}",
             candidate_keys.join(", "),
-            candidate.sql(),
+            candidate.sql(dialect),
             canonical.join(", "),
             production_keys.join(", "),
-            production.sql(),
+            production.sql(dialect),
             canonical.join(", "),
             values.join(", "),
+            dialect.cast_text("X.__EMBRASURE_N"),
             limits.rows
         ))
         .await?;
@@ -944,7 +936,7 @@ async fn key_integrity_examples<E: QueryExecutor>(
         .collect()
 }
 
-async fn compare_keyed<E: QueryExecutor>(
+async fn compare_keyed<E: QueryExecutor + ?Sized>(
     executor: &E,
     candidate: &Relation,
     production: &Relation,
@@ -953,13 +945,13 @@ async fn compare_keyed<E: QueryExecutor>(
     limits: ExampleLimits,
     examples_truncated: &mut bool,
 ) -> Result<QueryComparison> {
+    let dialect = executor.dialect();
     let join = keys
         .iter()
         .map(|pair| {
-            format!(
-                "EQUAL_NULL(C.{}, P.{})",
-                quote_identifier(&pair.0.name),
-                quote_identifier(&pair.1.name)
+            dialect.null_safe_equal(
+                &format!("C.{}", dialect.quote_identifier(&pair.0.name)),
+                &format!("P.{}", dialect.quote_identifier(&pair.1.name)),
             )
         })
         .collect::<Vec<_>>()
@@ -980,35 +972,61 @@ async fn compare_keyed<E: QueryExecutor>(
             .iter()
             .map(|pair| {
                 format!(
-                    "NOT EQUAL_NULL(C.{}, P.{})",
-                    quote_identifier(&pair.0.name),
-                    quote_identifier(&pair.1.name)
+                    "NOT {}",
+                    dialect.null_safe_equal(
+                        &format!("C.{}", dialect.quote_identifier(&pair.0.name)),
+                        &format!("P.{}", dialect.quote_identifier(&pair.1.name)),
+                    )
                 )
             })
             .collect::<Vec<_>>()
             .join(" OR ")
     };
-    let candidate_present = format!("C.{} IS NOT NULL", quote_identifier(&keys[0].0.name));
-    let production_present = format!("P.{} IS NOT NULL", quote_identifier(&keys[0].1.name));
+    let candidate_present = format!(
+        "C.{} IS NOT NULL",
+        dialect.quote_identifier(&keys[0].0.name)
+    );
+    let production_present = format!(
+        "P.{} IS NOT NULL",
+        dialect.quote_identifier(&keys[0].1.name)
+    );
     let mut metrics = vec![
-        format!("COALESCE(COUNT_IF(NOT ({production_present})), 0)"),
-        format!("COALESCE(COUNT_IF(NOT ({candidate_present})), 0)"),
         format!(
-            "COALESCE(COUNT_IF(({candidate_present}) AND ({production_present}) AND ({changed})), 0)"
+            "COALESCE({}, 0)",
+            dialect.count_if(&format!("NOT ({production_present})"))
+        ),
+        format!(
+            "COALESCE({}, 0)",
+            dialect.count_if(&format!("NOT ({candidate_present})"))
+        ),
+        format!(
+            "COALESCE({}, 0)",
+            dialect.count_if(&format!(
+                "({candidate_present}) AND ({production_present}) AND ({changed})"
+            ))
         ),
     ];
     metrics.extend(value_pairs.iter().map(|pair| {
+        let different = format!(
+            "NOT {}",
+            dialect.null_safe_equal(
+                &format!("C.{}", dialect.quote_identifier(&pair.0.name)),
+                &format!("P.{}", dialect.quote_identifier(&pair.1.name)),
+            )
+        );
         format!(
-            "COALESCE(COUNT_IF(({candidate_present}) AND ({production_present}) AND NOT EQUAL_NULL(C.{}, P.{})), 0)",
-            quote_identifier(&pair.0.name), quote_identifier(&pair.1.name)
+            "COALESCE({}, 0)",
+            dialect.count_if(&format!(
+                "({candidate_present}) AND ({production_present}) AND {different}"
+            ))
         )
     }));
     let counts = executor
         .execute(&format!(
             "SELECT {} FROM {} C FULL OUTER JOIN {} P ON {join}",
             metrics.join(", "),
-            candidate.sql(),
-            production.sql()
+            candidate.sql(dialect),
+            production.sql(dialect)
         ))
         .await?;
     let row = counts
@@ -1063,7 +1081,7 @@ async fn compare_keyed<E: QueryExecutor>(
 }
 
 #[allow(clippy::too_many_arguments)]
-async fn keyed_examples<E: QueryExecutor>(
+async fn keyed_examples<E: QueryExecutor + ?Sized>(
     executor: &E,
     candidate: &Relation,
     production: &Relation,
@@ -1077,17 +1095,18 @@ async fn keyed_examples<E: QueryExecutor>(
     value_limit: usize,
     examples_truncated: &mut bool,
 ) -> Result<Vec<QueryDiffExample>> {
+    let dialect = executor.dialect();
     let key_values = keys
         .iter()
-        .map(|pair| bounded_coalesce("C", &pair.0.name, "P", &pair.1.name, value_limit))
+        .map(|pair| bounded_coalesce(dialect, "C", &pair.0.name, "P", &pair.1.name, value_limit))
         .collect::<Vec<_>>();
     let candidate_values = pairs
         .iter()
-        .map(|pair| bounded_value("C", &pair.0.name, value_limit))
+        .map(|pair| bounded_value(dialect, "C", &pair.0.name, value_limit))
         .collect::<Vec<_>>();
     let production_values = pairs
         .iter()
-        .map(|pair| bounded_value("P", &pair.1.name, value_limit))
+        .map(|pair| bounded_value(dialect, "P", &pair.1.name, value_limit))
         .collect::<Vec<_>>();
     let selected = key_values
         .iter()
@@ -1100,14 +1119,14 @@ async fn keyed_examples<E: QueryExecutor>(
         .map(|pair| {
             format!(
                 "COALESCE(C.{}, P.{}) NULLS FIRST",
-                quote_identifier(&pair.0.name),
-                quote_identifier(&pair.1.name)
+                dialect.quote_identifier(&pair.0.name),
+                dialect.quote_identifier(&pair.1.name)
             )
         })
         .chain(pairs.iter().flat_map(|pair| {
             [
-                format!("C.{} NULLS FIRST", quote_identifier(&pair.0.name)),
-                format!("P.{} NULLS FIRST", quote_identifier(&pair.1.name)),
+                format!("C.{} NULLS FIRST", dialect.quote_identifier(&pair.0.name)),
+                format!("P.{} NULLS FIRST", dialect.quote_identifier(&pair.1.name)),
             ]
         }))
         .collect::<Vec<_>>()
@@ -1118,8 +1137,8 @@ async fn keyed_examples<E: QueryExecutor>(
              WHERE NOT ({candidate_present}) OR NOT ({production_present}) OR ({changed}) \
              ORDER BY {ordering} LIMIT {sample_limit}",
             selected.join(", "),
-            candidate.sql(),
-            production.sql()
+            candidate.sql(dialect),
+            production.sql(dialect)
         ))
         .await?;
     Ok(result
@@ -1142,7 +1161,7 @@ async fn keyed_examples<E: QueryExecutor>(
         .collect())
 }
 
-async fn compare_unkeyed<E: QueryExecutor>(
+async fn compare_unkeyed<E: QueryExecutor + ?Sized>(
     executor: &E,
     candidate: &Relation,
     production: &Relation,
@@ -1150,13 +1169,14 @@ async fn compare_unkeyed<E: QueryExecutor>(
     limits: ExampleLimits,
     examples_truncated: &mut bool,
 ) -> Result<QueryComparison> {
+    let dialect = executor.dialect();
     let candidate_columns = pairs
         .iter()
         .map(|pair| {
             format!(
                 "{} AS {}",
-                quote_identifier(&pair.0.name),
-                quote_identifier(&pair.0.name)
+                dialect.quote_identifier(&pair.0.name),
+                dialect.quote_identifier(&pair.0.name)
             )
         })
         .collect::<Vec<_>>();
@@ -1165,28 +1185,28 @@ async fn compare_unkeyed<E: QueryExecutor>(
         .map(|pair| {
             format!(
                 "{} AS {}",
-                quote_identifier(&pair.1.name),
-                quote_identifier(&pair.0.name)
+                dialect.quote_identifier(&pair.1.name),
+                dialect.quote_identifier(&pair.0.name)
             )
         })
         .collect::<Vec<_>>();
     let canonical = pairs
         .iter()
-        .map(|pair| quote_identifier(&pair.0.name))
+        .map(|pair| dialect.quote_identifier(&pair.0.name))
         .collect::<Vec<_>>();
     let join = canonical
         .iter()
-        .map(|name| format!("EQUAL_NULL(C.{name}, P.{name})"))
+        .map(|name| dialect.null_safe_equal(&format!("C.{name}"), &format!("P.{name}")))
         .collect::<Vec<_>>()
         .join(" AND ");
     let cte = format!(
         "C AS (SELECT {}, COUNT(*) AS __EMBRASURE_N FROM {} GROUP BY {}), \
          P AS (SELECT {}, COUNT(*) AS __EMBRASURE_N FROM {} GROUP BY {})",
         candidate_columns.join(", "),
-        candidate.sql(),
+        candidate.sql(dialect),
         canonical.join(", "),
         production_columns.join(", "),
-        production.sql(),
+        production.sql(dialect),
         canonical.join(", ")
     );
     let counts = executor
@@ -1208,17 +1228,22 @@ async fn compare_unkeyed<E: QueryExecutor>(
     } else {
         let candidate_values = pairs
             .iter()
-            .map(|pair| bounded_value("C", &pair.0.name, limits.value_chars))
+            .map(|pair| bounded_value(dialect, "C", &pair.0.name, limits.value_chars))
             .collect::<Vec<_>>();
         let production_values = pairs
             .iter()
-            .map(|pair| bounded_value("P", &pair.0.name, limits.value_chars))
+            .map(|pair| bounded_value(dialect, "P", &pair.0.name, limits.value_chars))
             .collect::<Vec<_>>();
         let row_values = pairs
             .iter()
-            .map(|pair| format!("COALESCE(C.{0}, P.{0})", quote_identifier(&pair.0.name)))
+            .map(|pair| {
+                format!(
+                    "COALESCE(C.{0}, P.{0})",
+                    dialect.quote_identifier(&pair.0.name)
+                )
+            })
             .collect::<Vec<_>>();
-        let ordering = std::iter::once(format!("HASH({})", row_values.join(", ")))
+        let ordering = std::iter::once(dialect.stable_hash(&row_values))
             .chain(
                 row_values
                     .iter()
@@ -1235,8 +1260,8 @@ async fn compare_unkeyed<E: QueryExecutor>(
             .chain(&production_values)
             .cloned()
             .chain([
-                "COALESCE(C.__EMBRASURE_N, 0)::VARCHAR".into(),
-                "COALESCE(P.__EMBRASURE_N, 0)::VARCHAR".into(),
+                dialect.cast_text("COALESCE(C.__EMBRASURE_N, 0)"),
+                dialect.cast_text("COALESCE(P.__EMBRASURE_N, 0)"),
             ])
             .collect::<Vec<_>>();
         let result = executor
@@ -1286,15 +1311,19 @@ async fn compare_unkeyed<E: QueryExecutor>(
     })
 }
 
-fn bounded_value(alias: &str, column: &str, limit: usize) -> String {
-    let value = format!("TO_VARCHAR({alias}.{})", quote_identifier(column));
-    format!(
-        "IFF({alias}.{column} IS NULL, NULL, IFF(LENGTH({value}) > {limit}, CONCAT(LEFT({value}, {limit}), '<truncated>'), {value}))",
-        column = quote_identifier(column)
-    )
+fn bounded_value(dialect: SqlDialect, alias: &str, column: &str, limit: usize) -> String {
+    let qualified = format!("{alias}.{}", dialect.quote_identifier(column));
+    let value = dialect.to_text(&qualified);
+    let bounded = dialect.conditional(
+        &format!("LENGTH({value}) > {limit}"),
+        &format!("CONCAT(LEFT({value}, {limit}), '<truncated>')"),
+        &value,
+    );
+    dialect.conditional(&format!("{qualified} IS NULL"), "NULL", &bounded)
 }
 
 fn bounded_coalesce(
+    dialect: SqlDialect,
     candidate_alias: &str,
     candidate_column: &str,
     production_alias: &str,
@@ -1304,14 +1333,17 @@ fn bounded_coalesce(
     let value = format!(
         "COALESCE({}.{}, {}.{})",
         candidate_alias,
-        quote_identifier(candidate_column),
+        dialect.quote_identifier(candidate_column),
         production_alias,
-        quote_identifier(production_column)
+        dialect.quote_identifier(production_column)
     );
-    let text = format!("TO_VARCHAR({value})");
-    format!(
-        "IFF({value} IS NULL, NULL, IFF(LENGTH({text}) > {limit}, CONCAT(LEFT({text}, {limit}), '<truncated>'), {text}))"
-    )
+    let text = dialect.to_text(&value);
+    let bounded = dialect.conditional(
+        &format!("LENGTH({text}) > {limit}"),
+        &format!("CONCAT(LEFT({text}, {limit}), '<truncated>')"),
+        &text,
+    );
+    dialect.conditional(&format!("{value} IS NULL"), "NULL", &bounded)
 }
 
 fn truncate_row(row: &mut [Option<String>], limit: usize, truncated: &mut bool) {
@@ -1333,9 +1365,9 @@ fn truncate_row(row: &mut [Option<String>], limit: usize, truncated: &mut bool) 
 fn parse_u64(value: Option<&Option<String>>) -> Result<u64> {
     value
         .and_then(Option::as_deref)
-        .context("Snowflake metric was null")?
+        .context("warehouse metric was null")?
         .parse()
-        .context("Snowflake metric was not an unsigned integer")
+        .context("warehouse metric was not an unsigned integer")
 }
 
 #[cfg(test)]
@@ -1358,10 +1390,11 @@ mod tests {
     }
 
     impl QueryExecutor for FakeExecutor {
-        fn execute<'a>(
-            &'a self,
-            statement: &'a str,
-        ) -> Pin<Box<dyn Future<Output = Result<QueryResult>> + Send + 'a>> {
+        fn dialect(&self) -> SqlDialect {
+            SqlDialect::Snowflake
+        }
+
+        fn execute<'a>(&'a self, statement: &'a str) -> ProviderFuture<'a, QueryResult> {
             Box::pin(async move {
                 self.statements.lock().unwrap().push(statement.into());
                 self.responses
@@ -1450,12 +1483,12 @@ mod tests {
             },
         ];
         assert!(
-            validate_preflight(&duplicate, &[], 10)
+            validate_preflight(SqlDialect::Snowflake, &duplicate, &[], 10)
                 .unwrap()
                 .contains("duplicate")
         );
         assert!(
-            validate_preflight(&duplicate[..1], &[], 0)
+            validate_preflight(SqlDialect::Snowflake, &duplicate[..1], &[], 0)
                 .unwrap()
                 .contains("above")
         );
@@ -1471,8 +1504,13 @@ mod tests {
             },
         ];
         assert_eq!(
-            primary_key_metadata_error(&["order;id".into()], &punctuation, &punctuation[..1])
-                .as_deref(),
+            primary_key_metadata_error(
+                SqlDialect::Snowflake,
+                &["order;id".into()],
+                &punctuation,
+                &punctuation[..1],
+            )
+            .as_deref(),
             Some("primary-key column order;id is ambiguous")
         );
 
@@ -1495,12 +1533,13 @@ mod tests {
             },
         ];
         assert!(
-            validate_preflight(&unrelated_then_key, &[], 10)
+            validate_preflight(SqlDialect::Snowflake, &unrelated_then_key, &[], 10)
                 .unwrap()
                 .contains("AMOUNT")
         );
         assert_eq!(
             primary_key_metadata_error(
+                SqlDialect::Snowflake,
                 &["order;id".into()],
                 &unrelated_then_key,
                 &punctuation[..1]
@@ -1516,17 +1555,23 @@ mod tests {
             }]
         };
         assert!(
-            primary_key_metadata_error(&["id".into()], &typed_key("NUMBER"), &typed_key("VARCHAR"))
-                .unwrap()
-                .contains("incompatible types")
+            primary_key_metadata_error(
+                SqlDialect::Snowflake,
+                &["id".into()],
+                &typed_key("NUMBER"),
+                &typed_key("VARCHAR"),
+            )
+            .unwrap()
+            .contains("incompatible types")
         );
     }
 
     #[test]
     fn unsupported_values_require_explicit_casts() {
-        assert!(unsupported_type("VARIANT"));
-        assert!(unsupported_type("GEOGRAPHY"));
-        assert!(!unsupported_type("VARCHAR(100)"));
+        let dialect = SqlDialect::Snowflake;
+        assert!(dialect.is_unsupported_value("VARIANT"));
+        assert!(dialect.is_unsupported_value("GEOGRAPHY"));
+        assert!(!dialect.is_unsupported_value("VARCHAR(100)"));
     }
 
     #[test]

--- a/src/report.rs
+++ b/src/report.rs
@@ -576,13 +576,13 @@ impl Report {
                     if cleaned == self.ci_schemas.len() {
                         let _ = writeln!(
                             output,
-                            "  Temporary Snowflake schema{} removed",
+                            "  Temporary warehouse schema{} removed",
                             plural(self.ci_schemas.len())
                         );
                     } else {
                         let _ = writeln!(
                             output,
-                            "  {cleaned} / {} temporary Snowflake schemas removed",
+                            "  {cleaned} / {} temporary warehouse schemas removed",
                             self.ci_schemas.len()
                         );
                     }

--- a/src/run.rs
+++ b/src/run.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     path::Path,
+    sync::Arc,
     time::Duration,
 };
 
@@ -18,12 +19,12 @@ use crate::{
     dbt::{self, DbtContext, Manifest, ManifestNode},
     git, lineage, metabase,
     progress::{Phase, Reporter as ProgressReporter},
+    provider::{self, Relation, SqlDialect, WarehouseProvider, is_managed_schema},
     query::{QueryDiffInput, QueryTemplate, RefTarget, run_query_diff},
     report::{
         CiSchema, ColumnLineageGap, CoverageGap, Finding, ModelReport, Notice, QueryCheckReport,
         QueryCheckStatus, Report, SkippedModel,
     },
-    snowflake::{Relation, SnowflakeClient, is_managed_schema},
 };
 
 #[cfg(test)]
@@ -113,19 +114,12 @@ async fn execute(
         config
             .accounts
             .iter()
-            .map(|account| {
-                (
-                    account.name.clone(),
-                    auth::ResolvedAuth::ProgrammaticAccessToken {
-                        token: "dry-run-not-used".into(),
-                    },
-                )
-            })
+            .map(|account| (account.name.clone(), auth::placeholder(account)))
             .collect()
     } else {
         auth::resolve_all(config)
             .await
-            .context("could not resolve Snowflake credentials")?
+            .context("could not resolve warehouse credentials")?
     };
     let schema = dbt::ci_schema_name(&config.safety.schema_prefix, &config.dbt.project_dir)?;
     let query_tag = format!("embrasure:{}:{}", env!("CARGO_PKG_VERSION"), Uuid::new_v4());
@@ -138,28 +132,28 @@ async fn execute(
                     progress.phase(Phase::Schema);
                 }
                 for account in &config.accounts {
-                    let client = SnowflakeClient::new(
+                    let client = provider::connect(
                         account,
                         resolved_auth
                             .get(&account.name)
-                            .context("resolved Snowflake credential was not retained")?,
+                            .context("resolved warehouse credential was not retained")?,
                         query_tag.clone(),
                         config.safety.statement_timeout_seconds,
                     )
                     .with_context(|| {
-                        format!("could not initialize Snowflake account {}", account.name)
+                        format!("could not initialize warehouse account {}", account.name)
                     })?;
                     report.ci_schemas.push(CiSchema {
                         account: account.name.clone(),
-                        database: account.database.clone(),
+                        database: account.database().to_owned(),
                         schema: schema.clone(),
                         cleaned_up: false,
                     });
                     clients.push(client);
                     clients
                         .last()
-                        .context("Snowflake client disappeared before schema creation")?
-                        .create_schema(&account.database, &schema)
+                        .context("warehouse connection disappeared before schema creation")?
+                        .create_schema(account.database(), &schema)
                         .await
                         .with_context(|| {
                             format!("could not create CI schema for account {}", account.name)
@@ -660,13 +654,14 @@ fn plan_model_reports(
 ) -> Result<Vec<(String, Relation)>> {
     let mut production_relations = Vec::new();
     for (account, selection) in config.accounts.iter().zip(selections) {
+        let dialect = provider::dialect(account);
         let manifest = context.manifest(&account.name)?;
         let production = context.production_manifest(&account.name)?;
         for id in &selection.removed {
             let node = &production.nodes[id];
             production_relations.push((
                 id.clone(),
-                relation_for(node, &account.database, &node.schema),
+                relation_for(dialect, node, account.database(), &node.schema),
             ));
             if !model_config(config, id, &node.name).allow_removal {
                 report.findings.push(Finding {
@@ -680,15 +675,19 @@ fn plan_model_reports(
             let node = manifest.nodes.get(id).with_context(|| {
                 format!("selected dbt model {id} is absent from current manifest")
             })?;
-            let ci_relation = relation_for(node, &account.database, &node.schema);
-            let production_relation = production
-                .nodes
-                .get(id)
-                .map(|production| relation_for(production, &account.database, &production.schema));
+            let ci_relation = relation_for(dialect, node, account.database(), &node.schema);
+            let production_relation = production.nodes.get(id).map(|production| {
+                relation_for(dialect, production, account.database(), &production.schema)
+            });
             production_relations.push((
                 id.clone(),
                 production_relation.clone().unwrap_or_else(|| {
-                    relation_for(node, &account.database, &account.production_schema)
+                    relation_for(
+                        dialect,
+                        node,
+                        account.database(),
+                        account.production_schema(),
+                    )
                 }),
             ));
             let build_strategy = if manifest.is_incremental(id) {
@@ -707,8 +706,10 @@ fn plan_model_reports(
                 unique_id: id.clone(),
                 name: node.name.clone(),
                 account: account.name.clone(),
-                ci_relation: ci_relation.sql(),
-                production_relation: production_relation.as_ref().map(Relation::sql),
+                ci_relation: ci_relation.sql(dialect),
+                production_relation: production_relation
+                    .as_ref()
+                    .map(|relation| relation.sql(dialect)),
                 dbt_build: dbt_build.into(),
                 build_strategy: build_strategy.into(),
                 comparison: None,
@@ -783,7 +784,7 @@ fn plan_query_reports(
 async fn execute_with_dbt(
     config: &Config,
     context: &mut DbtContext,
-    clients: &[SnowflakeClient],
+    clients: &[Arc<dyn WarehouseProvider>],
     ci_schema: &str,
     selections: &[AccountSelection],
     report: &mut Report,
@@ -805,22 +806,23 @@ async fn execute_with_dbt(
     for (index, selection) in selections.iter().enumerate() {
         let selected = &selection.selected;
         let account = &config.accounts[index];
+        let dialect = clients[index].dialect();
         let manifest = context.manifest(&account.name)?;
         let derived_schemas = selected
             .iter()
             .filter_map(|id| manifest.nodes.get(id))
             .map(|node| {
                 (
-                    snowflake_identifier(
-                        node.database.as_deref().unwrap_or(&account.database),
+                    dialect.normalize_identifier(
+                        node.database.as_deref().unwrap_or(account.database()),
                         node.config.quoting.database,
                     ),
-                    snowflake_identifier(&node.schema, node.config.quoting.schema),
+                    dialect.normalize_identifier(&node.schema, node.config.quoting.schema),
                 )
             })
             .collect::<BTreeSet<_>>();
         for (derived_database, derived_schema) in derived_schemas {
-            if !is_managed_schema(&derived_schema, ci_schema) {
+            if !is_managed_schema(dialect, &derived_schema, ci_schema) {
                 bail!(
                     "dbt generated schema {derived_schema} outside this run's namespace {ci_schema}; update generate_schema_name so derived schemas retain the complete target schema"
                 );
@@ -850,18 +852,19 @@ async fn execute_with_dbt(
         }
     }
 
+    let namespace_dialect = clients[0].dialect();
     let occupied_schemas = report
         .ci_schemas
         .iter()
-        .map(|item| item.schema.to_ascii_uppercase())
+        .map(|item| namespace_dialect.normalize_identifier(&item.schema, None))
         .collect::<BTreeSet<_>>();
-    let query_schema = unique_query_schema(ci_schema, &occupied_schemas);
+    let query_schema = unique_query_schema(namespace_dialect, ci_schema, &occupied_schemas);
     for (index, (account, selection)) in config.accounts.iter().zip(selections).enumerate() {
         if selection.query_checks.is_empty() {
             continue;
         }
         clients[index]
-            .create_schema(&account.database, &query_schema)
+            .create_schema(account.database(), &query_schema)
             .await
             .with_context(|| {
                 format!(
@@ -871,7 +874,7 @@ async fn execute_with_dbt(
             })?;
         report.ci_schemas.push(CiSchema {
             account: account.name.clone(),
-            database: account.database.clone(),
+            database: account.database().to_owned(),
             schema: query_schema.clone(),
             cleaned_up: false,
         });
@@ -879,6 +882,7 @@ async fn execute_with_dbt(
 
     let mut baseline_relations = BTreeMap::<(String, String), Relation>::new();
     for (index, (account, selection)) in config.accounts.iter().zip(selections).enumerate() {
+        let dialect = clients[index].dialect();
         let manifest = context.manifest(&account.name)?;
         let production = context.production_manifest(&account.name)?;
         let incrementals = selection
@@ -895,8 +899,8 @@ async fn execute_with_dbt(
             .iter()
             .map(|id| {
                 let node = &production.nodes[id];
-                snowflake_identifier(
-                    node.database.as_deref().unwrap_or(&account.database),
+                dialect.normalize_identifier(
+                    node.database.as_deref().unwrap_or(account.database()),
                     node.config.quoting.database,
                 )
             })
@@ -921,28 +925,38 @@ async fn execute_with_dbt(
         for (position, id) in incrementals.into_iter().enumerate() {
             let current_node = &manifest.nodes[&id];
             let production_node = &production.nodes[&id];
-            let source = relation_for(production_node, &account.database, &production_node.schema);
+            let source = relation_for(
+                dialect,
+                production_node,
+                account.database(),
+                &production_node.schema,
+            );
             let baseline = Relation {
                 database: source.database.clone(),
                 schema: baseline_schema.clone(),
                 identifier: format!("EMBRASURE_BASELINE_{position}"),
             };
             clients[index]
-                .clone_table(&source, &baseline)
+                .copy_table(&source, &baseline)
                 .await
                 .with_context(|| {
                     format!(
-                        "could not create a stable baseline clone for incremental model {id}; confirm the production relation is a Snowflake table and grant SELECT on it"
+                        "could not create a stable baseline copy for incremental model {id}; confirm the provider supports copying the production relation and grant read access to it"
                     )
                 })?;
             if config.validation.incremental_mode == IncrementalMode::Clone {
-                let candidate = relation_for(current_node, &account.database, &current_node.schema);
+                let candidate = relation_for(
+                    dialect,
+                    current_node,
+                    account.database(),
+                    &current_node.schema,
+                );
                 clients[index]
-                    .clone_table(&baseline, &candidate)
+                    .seed_table(&baseline, &candidate)
                     .await
                     .with_context(|| {
                         format!(
-                            "could not seed incremental model {id} from its baseline clone; rerun with --incremental-mode full-refresh"
+                            "could not seed incremental model {id} from its baseline copy; rerun with --incremental-mode full-refresh"
                         )
                     })?;
                 report.notices.push(Notice {
@@ -979,6 +993,7 @@ async fn execute_with_dbt(
     let production_relations = removed_production_relations;
     let mut comparison_jobs = Vec::new();
     for (index, (account, selection)) in config.accounts.iter().zip(selections).enumerate() {
+        let dialect = clients[index].dialect();
         let selected = &selection.selected;
         let manifest = context.manifest(&account.name)?;
         let production_manifest = context.production_manifest(&account.name)?;
@@ -1020,6 +1035,7 @@ async fn execute_with_dbt(
         match context.build_manifest(&account.name).and_then(|compiled| {
             lineage::extract(
                 &account.name,
+                dialect,
                 manifest,
                 production_manifest,
                 &compiled,
@@ -1054,12 +1070,17 @@ async fn execute_with_dbt(
                 });
                 continue;
             };
-            let ci_relation = relation_for(node, &account.database, &node.schema);
+            let ci_relation = relation_for(dialect, node, account.database(), &node.schema);
             let production_relation = baseline_relations
                 .get(&(account.name.clone(), id.clone()))
                 .cloned()
                 .unwrap_or_else(|| {
-                    relation_for(production_node, &account.database, &production_node.schema)
+                    relation_for(
+                        dialect,
+                        production_node,
+                        account.database(),
+                        &production_node.schema,
+                    )
                 });
             let model_config = model_config(config, id, &node.name);
             let primary_key = if model_config.primary_key.is_empty() {
@@ -1133,7 +1154,7 @@ async fn execute_with_dbt(
     .await
     .with_context(|| {
         format!(
-            "Snowflake comparisons exceeded comparison.timeout_seconds ({})",
+            "warehouse comparisons exceeded comparison.timeout_seconds ({})",
             config.comparison.timeout_seconds
         )
     })??;
@@ -1167,8 +1188,8 @@ async fn execute_with_dbt(
                     current_refs: item.current_refs,
                     production_refs: item.production_refs,
                     primary_key: item.primary_key,
-                    candidate_relation: Some(item.candidate.sql()),
-                    production_relation: Some(item.production.sql()),
+                    candidate_relation: Some(item.candidate.sql(item.dialect)),
+                    production_relation: Some(item.production.sql(item.dialect)),
                     candidate_row_count: None,
                     production_row_count: None,
                     columns: vec![],
@@ -1203,7 +1224,7 @@ async fn execute_with_dbt(
 }
 
 struct ComparisonJob {
-    client: SnowflakeClient,
+    client: Arc<dyn WarehouseProvider>,
     model_id: String,
     account: String,
     ci: Relation,
@@ -1221,7 +1242,7 @@ struct CompletedComparison {
 }
 
 struct QueryComparisonJob {
-    client: SnowflakeClient,
+    client: Arc<dyn WarehouseProvider>,
     name: String,
     account: String,
     current_refs: Vec<String>,
@@ -1242,13 +1263,14 @@ struct CompletedQueryComparison {
     primary_key: Vec<String>,
     candidate: Relation,
     production: Relation,
+    dialect: SqlDialect,
     result: Result<QueryCheckReport>,
 }
 
 fn prepare_query_jobs(
     config: &Config,
     context: &DbtContext,
-    clients: &[SnowflakeClient],
+    clients: &[Arc<dyn WarehouseProvider>],
     ci_schema: &str,
     selections: &[AccountSelection],
     baseline_relations: &BTreeMap<(String, String), Relation>,
@@ -1257,6 +1279,7 @@ fn prepare_query_jobs(
     let mut jobs = Vec::new();
     for (account_index, (account, selection)) in config.accounts.iter().zip(selections).enumerate()
     {
+        let dialect = clients[account_index].dialect();
         let Ok(current_manifest) = context.manifest(&account.name) else {
             continue;
         };
@@ -1320,7 +1343,7 @@ fn prepare_query_jobs(
                         .nodes
                         .get(id)
                         .context("resolved current ref disappeared from manifest")?;
-                    Ok(relation_for(node, &account.database, &node.schema).sql())
+                    Ok(relation_for(dialect, node, account.database(), &node.schema).sql(dialect))
                 } else {
                     let node = production_manifest.nodes.get(id).with_context(|| {
                         format!(
@@ -1331,8 +1354,10 @@ fn prepare_query_jobs(
                     Ok(baseline_relations
                         .get(&(account.name.clone(), id.to_owned()))
                         .cloned()
-                        .unwrap_or_else(|| relation_for(node, &account.database, &node.schema))
-                        .sql())
+                        .unwrap_or_else(|| {
+                            relation_for(dialect, node, account.database(), &node.schema)
+                        })
+                        .sql(dialect))
                 }
             });
             let production_sql = check.production.render(|target| {
@@ -1344,8 +1369,10 @@ fn prepare_query_jobs(
                 Ok(baseline_relations
                     .get(&(account.name.clone(), id.to_owned()))
                     .cloned()
-                    .unwrap_or_else(|| relation_for(node, &account.database, &node.schema))
-                    .sql())
+                    .unwrap_or_else(|| {
+                        relation_for(dialect, node, account.database(), &node.schema)
+                    })
+                    .sql(dialect))
             });
             let (candidate_sql, production_sql) = match (candidate_sql, production_sql) {
                 (Ok(candidate_sql), Ok(production_sql)) => (candidate_sql, production_sql),
@@ -1370,12 +1397,12 @@ fn prepare_query_jobs(
                 candidate_sql,
                 production_sql,
                 candidate: Relation {
-                    database: account.database.clone(),
+                    database: account.database().to_owned(),
                     schema: ci_schema.into(),
                     identifier: format!("EMBRASURE_QUERY_{check_index}_CANDIDATE"),
                 },
                 production: Relation {
-                    database: account.database.clone(),
+                    database: account.database().to_owned(),
                     schema: ci_schema.into(),
                     identifier: format!("EMBRASURE_QUERY_{check_index}_PRODUCTION"),
                 },
@@ -1550,8 +1577,9 @@ fn spawn_query_comparison(
     job: QueryComparisonJob,
 ) {
     running.spawn(async move {
+        let dialect = job.client.dialect();
         let result = run_query_diff(
-            &job.client,
+            job.client.as_ref(),
             QueryDiffInput {
                 name: &job.name,
                 account: &job.account,
@@ -1574,6 +1602,7 @@ fn spawn_query_comparison(
             primary_key: job.primary_key,
             candidate: job.candidate,
             production: job.production,
+            dialect,
             result,
         }
     });
@@ -1615,7 +1644,7 @@ fn spawn_comparison(
 ) {
     running.spawn(async move {
         let result = compare_model(
-            &job.client,
+            job.client.as_ref(),
             &job.model_id,
             &job.ci,
             &job.production,
@@ -1645,7 +1674,7 @@ fn spawn_comparison(
 
 async fn cleanup_schemas(
     config: &Config,
-    clients: &[SnowflakeClient],
+    clients: &[Arc<dyn WarehouseProvider>],
     run_schema: &str,
     report: &mut Report,
     progress: Option<&ProgressReporter>,
@@ -1682,7 +1711,7 @@ async fn cleanup_schemas(
         };
         let Some(client) = clients.get(account_index) else {
             report.execution_errors.push(format!(
-                "could not recover the Snowflake connection needed to clean up {database}.{target_schema}; run `embrasure clean` or remove it manually"
+                "could not recover the warehouse connection needed to clean up {database}.{target_schema}; run `embrasure clean` or remove it manually"
             ));
             completed += 1;
             if let Some(progress) = progress {
@@ -1711,30 +1740,31 @@ async fn cleanup_schemas(
     }
 }
 
-fn relation_for(node: &ManifestNode, default_database: &str, schema: &str) -> Relation {
+fn relation_for(
+    dialect: SqlDialect,
+    node: &ManifestNode,
+    default_database: &str,
+    schema: &str,
+) -> Relation {
     Relation {
-        database: snowflake_identifier(
+        database: dialect.normalize_identifier(
             node.database.as_deref().unwrap_or(default_database),
             node.config.quoting.database,
         ),
-        schema: snowflake_identifier(schema, node.config.quoting.schema),
-        identifier: snowflake_identifier(&node.alias, node.config.quoting.identifier),
+        schema: dialect.normalize_identifier(schema, node.config.quoting.schema),
+        identifier: dialect.normalize_identifier(&node.alias, node.config.quoting.identifier),
     }
 }
 
-fn snowflake_identifier(value: &str, quoted: Option<bool>) -> String {
-    if quoted.unwrap_or(false) {
-        value.to_owned()
-    } else {
-        value.to_ascii_uppercase()
-    }
-}
-
-fn unique_query_schema(ci_schema: &str, occupied: &BTreeSet<String>) -> String {
+fn unique_query_schema(
+    dialect: SqlDialect,
+    ci_schema: &str,
+    occupied: &BTreeSet<String>,
+) -> String {
     loop {
-        let random = Uuid::new_v4().simple().to_string()[..8].to_ascii_uppercase();
+        let random = dialect.normalize_identifier(&Uuid::new_v4().simple().to_string()[..8], None);
         let candidate = format!("{ci_schema}_Q_{random}");
-        if !occupied.contains(&candidate.to_ascii_uppercase()) {
+        if !occupied.contains(&dialect.normalize_identifier(&candidate, None)) {
             return candidate;
         }
     }
@@ -1976,10 +2006,9 @@ mod tests {
     use crate::auth::ResolvedAuth;
     use crate::{
         dbt::{DependsOn, ManifestNode, NodeConfig, QuotePolicy},
-        query::QueryExecutor,
-        snowflake::{QueryResult, ResultColumn},
+        provider::{ProviderFuture, QueryExecutor, QueryResult, ResultColumn},
     };
-    use std::{collections::VecDeque, future::Future, path::PathBuf, pin::Pin, sync::Mutex};
+    use std::{collections::VecDeque, path::PathBuf, sync::Mutex};
 
     struct FakeExecutor(Mutex<VecDeque<QueryResult>>);
 
@@ -1997,10 +2026,11 @@ mod tests {
     }
 
     impl QueryExecutor for FakeExecutor {
-        fn execute<'a>(
-            &'a self,
-            _statement: &'a str,
-        ) -> Pin<Box<dyn Future<Output = Result<QueryResult>> + Send + 'a>> {
+        fn dialect(&self) -> SqlDialect {
+            SqlDialect::Snowflake
+        }
+
+        fn execute<'a>(&'a self, _statement: &'a str) -> ProviderFuture<'a, QueryResult> {
             Box::pin(async move {
                 self.0
                     .lock()
@@ -2095,20 +2125,25 @@ checks:
             config: NodeConfig::default(),
             compiled_code: None,
         };
-        assert_eq!(relation_for(&node, "OTHER", "CHECK").schema, "CHECK");
+        assert_eq!(
+            relation_for(SqlDialect::Snowflake, &node, "OTHER", "CHECK").schema,
+            "CHECK"
+        );
     }
 
     #[test]
     fn query_schema_cannot_reuse_a_dbt_custom_schema() {
         let occupied = BTreeSet::from(["RUN_QUERY".into()]);
-        let schema = unique_query_schema("RUN", &occupied);
+        let schema = unique_query_schema(SqlDialect::Snowflake, "RUN", &occupied);
         assert_ne!(schema, "RUN_QUERY");
         assert!(schema.starts_with("RUN_Q_"));
-        assert!(is_managed_schema(&schema, "RUN"));
+        assert!(is_managed_schema(SqlDialect::Snowflake, &schema, "RUN"));
         let longest_run_schema = "R".repeat(241);
-        let longest_query_schema = unique_query_schema(&longest_run_schema, &BTreeSet::new());
+        let longest_query_schema =
+            unique_query_schema(SqlDialect::Snowflake, &longest_run_schema, &BTreeSet::new());
         assert!(longest_query_schema.len() <= 255);
         assert!(is_managed_schema(
+            SqlDialect::Snowflake,
             &longest_query_schema,
             &longest_run_schema
         ));
@@ -2138,7 +2173,8 @@ checks:
         };
 
         assert_eq!(
-            relation_for(&node, "other", "ci_schema").sql(),
+            relation_for(SqlDialect::Snowflake, &node, "other", "ci_schema")
+                .sql(SqlDialect::Snowflake),
             "\"ANALYTICS\".\"CI_SCHEMA\".\"ORDERS\""
         );
     }
@@ -2168,7 +2204,8 @@ checks:
         };
 
         assert_eq!(
-            relation_for(&node, "other", "CiSchema").sql(),
+            relation_for(SqlDialect::Snowflake, &node, "other", "CiSchema")
+                .sql(SqlDialect::Snowflake),
             "\"Analytics\".\"CiSchema\".\"OrderLines\""
         );
     }
@@ -2291,7 +2328,10 @@ checks:
             .production
             .render(|target| {
                 let id = resolved_id(&planned[0].production_refs, target)?;
-                Ok(relation_for(&production.nodes[id], "DB", "PROD").sql())
+                Ok(
+                    relation_for(SqlDialect::Snowflake, &production.nodes[id], "DB", "PROD")
+                        .sql(SqlDialect::Snowflake),
+                )
             })
             .unwrap();
         assert_eq!(rendered, r#"select id from "DB"."PROD"."REMOVED""#);
@@ -2636,11 +2676,13 @@ checks:
             identifier: "TARGET".into(),
         };
         let baselines = BTreeMap::from([(("primary".into(), target_id.into()), baseline.clone())]);
-        let client = SnowflakeClient::new(
+        let client = provider::connect(
             &config.accounts[0],
-            &ResolvedAuth::ProgrammaticAccessToken {
-                token: "unused".into(),
-            },
+            &ResolvedAuth::Snowflake(
+                crate::auth::SnowflakeResolvedAuth::ProgrammaticAccessToken {
+                    token: "unused".into(),
+                },
+            ),
             "test".into(),
             30,
         )
@@ -2660,7 +2702,11 @@ checks:
         }));
         let target_job = jobs.iter().find(|job| job.name == "target check").unwrap();
         assert!(target_job.candidate_sql.contains(r#""DB"."RUN"."TARGET""#));
-        assert!(target_job.production_sql.contains(&baseline.sql()));
+        assert!(
+            target_job
+                .production_sql
+                .contains(&baseline.sql(SqlDialect::Snowflake))
+        );
         assert!(jobs.iter().any(|job| {
             job.name == "always check"
                 && job.current_refs.is_empty()
@@ -2734,11 +2780,13 @@ checks:
         let failed_jobs = prepare_query_jobs(
             &config,
             &context,
-            &[SnowflakeClient::new(
+            &[provider::connect(
                 &config.accounts[0],
-                &ResolvedAuth::ProgrammaticAccessToken {
-                    token: "unused".into(),
-                },
+                &ResolvedAuth::Snowflake(
+                    crate::auth::SnowflakeResolvedAuth::ProgrammaticAccessToken {
+                        token: "unused".into(),
+                    },
+                ),
                 "test".into(),
                 30,
             )

--- a/src/snowflake.rs
+++ b/src/snowflake.rs
@@ -22,8 +22,12 @@ use tokio::time::{sleep, timeout};
 use uuid::Uuid;
 
 use crate::{
-    auth::{ResolvedAuth, account_host},
-    config::AccountConfig,
+    auth::{ResolvedAuth, SnowflakeResolvedAuth, account_host},
+    config::{AccountConfig, SnowflakeConfig},
+    provider::{
+        ProviderFuture, QueryExecutor, QueryResult, Relation, ResultColumn, SqlDialect,
+        WarehouseProvider, is_managed_schema,
+    },
 };
 
 #[derive(Clone)]
@@ -32,28 +36,9 @@ pub struct SnowflakeClient {
     endpoint: String,
     token: String,
     token_type: &'static str,
-    account: AccountConfig,
+    account: SnowflakeConfig,
     query_tag: String,
     timeout_seconds: u64,
-}
-
-#[derive(Debug, Clone, Default)]
-pub struct QueryResult {
-    pub columns: Vec<ResultColumn>,
-    pub rows: Vec<Vec<Option<String>>>,
-}
-
-#[derive(Debug, Clone)]
-pub struct ResultColumn {
-    pub name: String,
-    pub data_type: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Relation {
-    pub database: String,
-    pub schema: String,
-    pub identifier: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -64,17 +49,6 @@ struct Claims {
     exp: u64,
 }
 
-impl Relation {
-    pub fn sql(&self) -> String {
-        format!(
-            "{}.{}.{}",
-            quote_identifier(&self.database),
-            quote_identifier(&self.schema),
-            quote_identifier(&self.identifier)
-        )
-    }
-}
-
 impl SnowflakeClient {
     pub fn new(
         account: &AccountConfig,
@@ -82,16 +56,22 @@ impl SnowflakeClient {
         query_tag: String,
         timeout_seconds: u64,
     ) -> Result<Self> {
+        let account = account
+            .snowflake()
+            .context("Snowflake client requires Snowflake account configuration")?;
+        let ResolvedAuth::Snowflake(auth) = auth else {
+            bail!("Snowflake client received credentials for another provider");
+        };
         let (token, token_type) = match auth {
-            ResolvedAuth::OAuth { token } => (token.clone(), "OAUTH"),
-            ResolvedAuth::KeyPair {
+            SnowflakeResolvedAuth::OAuth { token } => (token.clone(), "OAUTH"),
+            SnowflakeResolvedAuth::KeyPair {
                 private_key_path,
                 passphrase,
             } => (
                 key_pair_jwt(account, private_key_path, passphrase.as_deref())?,
                 "KEYPAIR_JWT",
             ),
-            ResolvedAuth::ProgrammaticAccessToken { token } => {
+            SnowflakeResolvedAuth::ProgrammaticAccessToken { token } => {
                 (token.clone(), "PROGRAMMATIC_ACCESS_TOKEN")
             }
         };
@@ -241,13 +221,17 @@ impl SnowflakeClient {
         Ok(())
     }
 
-    pub async fn clone_table(&self, source: &Relation, target: &Relation) -> Result<()> {
+    pub async fn copy_table(&self, source: &Relation, target: &Relation) -> Result<()> {
         self.execute(&clone_table_statement(source, target)).await?;
         Ok(())
     }
 
+    pub async fn seed_table(&self, source: &Relation, target: &Relation) -> Result<()> {
+        self.copy_table(source, target).await
+    }
+
     pub async fn drop_schema(&self, database: &str, schema: &str, run_schema: &str) -> Result<()> {
-        if !is_managed_schema(schema, run_schema) {
+        if !is_managed_schema(SqlDialect::Snowflake, schema, run_schema) {
             bail!("refusing to drop schema {schema}: it is not owned by this run ({run_schema})");
         }
         let Some(comment) = self.schema_comment(database, schema).await? else {
@@ -342,8 +326,56 @@ impl SnowflakeClient {
     }
 }
 
+impl QueryExecutor for SnowflakeClient {
+    fn dialect(&self) -> SqlDialect {
+        SqlDialect::Snowflake
+    }
+
+    fn execute<'a>(&'a self, statement: &'a str) -> ProviderFuture<'a, QueryResult> {
+        Box::pin(SnowflakeClient::execute(self, statement))
+    }
+}
+
+impl WarehouseProvider for SnowflakeClient {
+    fn create_schema<'a>(&'a self, database: &'a str, schema: &'a str) -> ProviderFuture<'a, ()> {
+        Box::pin(SnowflakeClient::create_schema(self, database, schema))
+    }
+
+    fn copy_table<'a>(
+        &'a self,
+        source: &'a Relation,
+        target: &'a Relation,
+    ) -> ProviderFuture<'a, ()> {
+        Box::pin(SnowflakeClient::copy_table(self, source, target))
+    }
+
+    fn seed_table<'a>(
+        &'a self,
+        source: &'a Relation,
+        target: &'a Relation,
+    ) -> ProviderFuture<'a, ()> {
+        Box::pin(SnowflakeClient::seed_table(self, source, target))
+    }
+
+    fn drop_schema<'a>(
+        &'a self,
+        database: &'a str,
+        schema: &'a str,
+        run_schema: &'a str,
+    ) -> ProviderFuture<'a, ()> {
+        Box::pin(SnowflakeClient::drop_schema(
+            self, database, schema, run_schema,
+        ))
+    }
+}
+
 fn clone_table_statement(source: &Relation, target: &Relation) -> String {
-    format!("CREATE TABLE {} CLONE {}", target.sql(), source.sql())
+    let dialect = SqlDialect::Snowflake;
+    format!(
+        "CREATE TABLE {} CLONE {}",
+        target.sql(dialect),
+        source.sql(dialect)
+    )
 }
 
 fn drop_schema_statement(database: &str, schema: &str) -> String {
@@ -356,7 +388,7 @@ fn drop_schema_statement(database: &str, schema: &str) -> String {
 
 fn statement_body(
     statement: &str,
-    account: &AccountConfig,
+    account: &SnowflakeConfig,
     query_tag: &str,
     timeout_seconds: u64,
 ) -> Value {
@@ -371,7 +403,7 @@ fn statement_body(
 }
 
 fn key_pair_jwt(
-    account: &AccountConfig,
+    account: &SnowflakeConfig,
     path: &std::path::Path,
     passphrase: Option<&str>,
 ) -> Result<String> {
@@ -484,24 +516,18 @@ fn parse_rows(rows: Vec<Vec<Value>>) -> Vec<Vec<Option<String>>> {
 }
 
 pub fn quote_identifier(value: &str) -> String {
-    format!("\"{}\"", value.replace('"', "\"\""))
+    SqlDialect::Snowflake.quote_identifier(value)
 }
 
 fn quote_string(value: &str) -> String {
     format!("'{}'", value.replace('\'', "''"))
 }
 
-pub fn is_managed_schema(schema: &str, run_schema: &str) -> bool {
-    let schema = schema.to_ascii_uppercase();
-    let run_schema = run_schema.to_ascii_uppercase();
-    schema == run_schema || schema.starts_with(&format!("{run_schema}_"))
-}
-
 fn privilege_hint(
     code: &str,
     message: &str,
     statement: &str,
-    account: &AccountConfig,
+    account: &SnowflakeConfig,
 ) -> Option<String> {
     let upper = statement.trim_start().to_ascii_uppercase();
     let insufficient = code == "003001"
@@ -554,7 +580,7 @@ mod tests {
                 schema: "S".into(),
                 identifier: "T".into()
             }
-            .sql(),
+            .sql(SqlDialect::Snowflake),
             "\"D\".\"S\".\"T\""
         );
     }
@@ -570,26 +596,37 @@ mod tests {
     #[test]
     fn cleanup_is_limited_to_the_exact_run_namespace() {
         let run = "EMBRASURE_CHECK_SHA_TIME_RANDOM";
-        assert!(is_managed_schema(run, run));
-        assert!(is_managed_schema(
+        assert!(crate::provider::is_managed_schema(
+            SqlDialect::Snowflake,
+            run,
+            run
+        ));
+        assert!(crate::provider::is_managed_schema(
+            SqlDialect::Snowflake,
             "EMBRASURE_CHECK_SHA_TIME_RANDOM_MARKETING",
             run
         ));
-        assert!(!is_managed_schema("EMBRASURE_CHECK_PROD", run));
-        assert!(!is_managed_schema("EMBRASURE_CHECK_SHA_TIME_RANDOMLY", run));
+        assert!(!crate::provider::is_managed_schema(
+            SqlDialect::Snowflake,
+            "EMBRASURE_CHECK_PROD",
+            run
+        ));
+        assert!(!crate::provider::is_managed_schema(
+            SqlDialect::Snowflake,
+            "EMBRASURE_CHECK_SHA_TIME_RANDOMLY",
+            run
+        ));
     }
 
     #[test]
     fn privilege_errors_include_actionable_hints() {
-        let account = AccountConfig {
-            name: "primary".into(),
+        let account = SnowflakeConfig {
             account: "org-account".into(),
             user: "DBT_CI".into(),
             role: "DBT_CI_ROLE".into(),
             database: "ANALYTICS".into(),
             warehouse: "DBT_CI_WH".into(),
             production_schema: "PROD".into(),
-            selector: None,
             auth: AuthConfig::OauthLocal,
         };
         assert!(
@@ -689,15 +726,13 @@ mod tests {
 
     #[test]
     fn sql_api_body_uses_supported_request_fields() {
-        let account = AccountConfig {
-            name: "one".into(),
+        let account = SnowflakeConfig {
             account: "org-account".into(),
             user: "CI".into(),
             role: "ROLE".into(),
             database: "DB".into(),
             warehouse: "WH".into(),
             production_schema: "PROD".into(),
-            selector: None,
             auth: AuthConfig::Oauth {
                 token_env: "TOKEN".into(),
             },
@@ -722,20 +757,23 @@ mod tests {
         };
         let account = AccountConfig {
             name: "integration".into(),
-            account: required("EMBRASURE_TEST_SNOWFLAKE_ACCOUNT"),
-            user: required("EMBRASURE_TEST_SNOWFLAKE_USER"),
-            role: required("EMBRASURE_TEST_SNOWFLAKE_ROLE"),
-            database: required("EMBRASURE_TEST_SNOWFLAKE_DATABASE"),
-            warehouse: required("EMBRASURE_TEST_SNOWFLAKE_WAREHOUSE"),
-            production_schema: "unused".into(),
             selector: None,
-            auth: AuthConfig::ProgrammaticAccessToken {
-                token_env: "EMBRASURE_TEST_SNOWFLAKE_TOKEN".into(),
-            },
+            provider: crate::config::ProviderConfig::Snowflake(SnowflakeConfig {
+                account: required("EMBRASURE_TEST_SNOWFLAKE_ACCOUNT"),
+                user: required("EMBRASURE_TEST_SNOWFLAKE_USER"),
+                role: required("EMBRASURE_TEST_SNOWFLAKE_ROLE"),
+                database: required("EMBRASURE_TEST_SNOWFLAKE_DATABASE"),
+                warehouse: required("EMBRASURE_TEST_SNOWFLAKE_WAREHOUSE"),
+                production_schema: "unused".into(),
+                auth: AuthConfig::ProgrammaticAccessToken {
+                    token_env: "EMBRASURE_TEST_SNOWFLAKE_TOKEN".into(),
+                },
+            }),
+            legacy: false,
         };
-        let auth = ResolvedAuth::ProgrammaticAccessToken {
+        let auth = ResolvedAuth::Snowflake(SnowflakeResolvedAuth::ProgrammaticAccessToken {
             token: required("EMBRASURE_TEST_SNOWFLAKE_TOKEN"),
-        };
+        });
         let run_schema = format!("EMBRASURE_IT_{}", Uuid::new_v4().simple()).to_ascii_uppercase();
         let second_schema = format!("{run_schema}_SECOND");
         let client = SnowflakeClient::new(
@@ -746,26 +784,26 @@ mod tests {
         )
         .unwrap();
         client
-            .create_schema(&account.database, &run_schema)
+            .create_schema(account.database(), &run_schema)
             .await
             .unwrap();
         client
-            .create_schema(&account.database, &second_schema)
+            .create_schema(account.database(), &second_schema)
             .await
             .unwrap();
 
         let source = Relation {
-            database: account.database.clone(),
+            database: account.database().to_owned(),
             schema: run_schema.clone(),
             identifier: "SOURCE".into(),
         };
         let baseline = Relation {
-            database: account.database.clone(),
+            database: account.database().to_owned(),
             schema: second_schema.clone(),
             identifier: "BASELINE".into(),
         };
         let candidate = Relation {
-            database: account.database.clone(),
+            database: account.database().to_owned(),
             schema: second_schema.clone(),
             identifier: "CANDIDATE".into(),
         };
@@ -773,32 +811,36 @@ mod tests {
             client
                 .execute(&format!(
                     "CREATE TABLE {} AS SELECT ID, MOD(ID, 100) AS SEGMENT FROM (SELECT ROW_NUMBER() OVER (ORDER BY SEQ4()) - 1 AS ID FROM TABLE(GENERATOR(ROWCOUNT => 100000)))",
-                    source.sql()
+                    source.sql(SqlDialect::Snowflake)
                 ))
                 .await?;
-            client.clone_table(&source, &baseline).await?;
-            client.clone_table(&baseline, &candidate).await?;
+            client.copy_table(&source, &baseline).await?;
+            client.seed_table(&baseline, &candidate).await?;
             client
                 .execute(&format!(
                     "MERGE INTO {} C USING (SELECT 100000 AS ID, 0 AS SEGMENT) N ON C.ID = N.ID WHEN NOT MATCHED THEN INSERT (ID, SEGMENT) VALUES (N.ID, N.SEGMENT)",
-                    candidate.sql()
+                    candidate.sql(SqlDialect::Snowflake)
                 ))
                 .await?;
             let incremental = client
-                .execute(&format!("SELECT COUNT(*) FROM {}", candidate.sql()))
+                .execute(&format!(
+                    "SELECT COUNT(*) FROM {}",
+                    candidate.sql(SqlDialect::Snowflake)
+                ))
                 .await?;
             assert_eq!(incremental.rows[0][0].as_deref(), Some("100001"));
 
             client
                 .execute(&format!(
                     "CREATE OR REPLACE TABLE {} AS SELECT * FROM {} WHERE ID < 50000 UNION ALL SELECT 1, 1",
-                    candidate.sql(), baseline.sql()
+                    candidate.sql(SqlDialect::Snowflake),
+                    baseline.sql(SqlDialect::Snowflake)
                 ))
                 .await?;
             let integrity = client
                 .execute(&format!(
                     "SELECT COUNT(*) AS ROWS, COUNT_IF(ID IS NULL) AS NULL_KEYS, COUNT(*) - COUNT(DISTINCT ID) AS DUPLICATE_ROWS FROM {}",
-                    candidate.sql()
+                    candidate.sql(SqlDialect::Snowflake)
                 ))
                 .await?;
             assert_eq!(integrity.rows[0][0].as_deref(), Some("50001"));
@@ -806,19 +848,22 @@ mod tests {
             assert_eq!(integrity.rows[0][2].as_deref(), Some("1"));
 
             let query_candidate = Relation {
-                database: account.database.clone(),
+                database: account.database().to_owned(),
                 schema: second_schema.clone(),
                 identifier: "QUERY_CANDIDATE".into(),
             };
             let query_production = Relation {
-                database: account.database.clone(),
+                database: account.database().to_owned(),
                 schema: second_schema.clone(),
                 identifier: "QUERY_PRODUCTION".into(),
             };
-            let candidate_sql = format!("SELECT ID, SEGMENT FROM {}", candidate.sql());
+            let candidate_sql = format!(
+                "SELECT ID, SEGMENT FROM {}",
+                candidate.sql(SqlDialect::Snowflake)
+            );
             let production_sql = format!(
                 "SELECT ID, SEGMENT FROM {} WHERE ID < 50000",
-                baseline.sql()
+                baseline.sql(SqlDialect::Snowflake)
             );
             let query_report = run_query_diff(
                 &client,
@@ -844,16 +889,19 @@ mod tests {
             assert_eq!(comparison.examples[0].production_multiplicity, Some(1));
 
             let pass_candidate = Relation {
-                database: account.database.clone(),
+                database: account.database().to_owned(),
                 schema: second_schema.clone(),
                 identifier: "QUERY_PASS_CANDIDATE".into(),
             };
             let pass_production = Relation {
-                database: account.database.clone(),
+                database: account.database().to_owned(),
                 schema: second_schema.clone(),
                 identifier: "QUERY_PASS_PRODUCTION".into(),
             };
-            let pass_sql = format!("SELECT ID, SEGMENT FROM {}", baseline.sql());
+            let pass_sql = format!(
+                "SELECT ID, SEGMENT FROM {}",
+                baseline.sql(SqlDialect::Snowflake)
+            );
             let pass = run_query_diff(
                 &client,
                 QueryDiffInput {
@@ -873,12 +921,12 @@ mod tests {
             assert_eq!(pass.status, QueryCheckStatus::Pass);
 
             let keyed_candidate = Relation {
-                database: account.database.clone(),
+                database: account.database().to_owned(),
                 schema: second_schema.clone(),
                 identifier: "QUERY_KEYED_CANDIDATE".into(),
             };
             let keyed_production = Relation {
-                database: account.database.clone(),
+                database: account.database().to_owned(),
                 schema: second_schema.clone(),
                 identifier: "QUERY_KEYED_PRODUCTION".into(),
             };
@@ -912,10 +960,10 @@ mod tests {
         .await;
 
         let second_cleanup = client
-            .drop_schema(&account.database, &second_schema, &run_schema)
+            .drop_schema(account.database(), &second_schema, &run_schema)
             .await;
         let first_cleanup = client
-            .drop_schema(&account.database, &run_schema, &run_schema)
+            .drop_schema(account.database(), &run_schema, &run_schema)
             .await;
         result.unwrap();
         second_cleanup.unwrap();

--- a/src/sqlglot_lineage.py
+++ b/src/sqlglot_lineage.py
@@ -42,17 +42,25 @@ def terminal_nodes(node):
         yield from terminal_nodes(child)
 
 
-def relation_sql(table):
+def normalize_unquoted(value, quoted, unquoted_case):
+    if quoted or unquoted_case == "preserve":
+        return value
+    if unquoted_case == "lower":
+        return value.lower()
+    return value.upper()
+
+
+def relation_sql(table, dialect):
     relation = table.copy()
     relation.set("alias", None)
-    return relation.sql(dialect="snowflake")
+    return relation.sql(dialect=dialect)
 
 
-def trace_model(model):
+def trace_model(model, dialect, unquoted_case):
     edges = []
     gaps = []
     try:
-        expression = sqlglot.parse_one(model["sql"], dialect="snowflake")
+        expression = sqlglot.parse_one(model["sql"], dialect=dialect)
     except Exception as error:
         return {
             "unique_id": model["unique_id"],
@@ -76,15 +84,16 @@ def trace_model(model):
             output_node = lineage(
                 exp.column(output_column, quoted=output_is_quoted),
                 expression,
-                dialect="snowflake",
+                dialect=dialect,
             )
         except Exception as error:
             gaps.append(
                 f"{output_column} could not be resolved by SQLGlot: {error_text(error)}"
             )
             continue
-        if not output_is_quoted:
-            output_column = output_column.upper()
+        output_column = normalize_unquoted(
+            output_column, output_is_quoted, unquoted_case
+        )
 
         for leaf in terminal_nodes(output_node):
             table = leaf.expression
@@ -93,11 +102,16 @@ def trace_model(model):
             if not isinstance(table, exp.Table):
                 gaps.append(
                     f"{output_column} ends at an unsupported SQL source: "
-                    f"{table.sql(dialect='snowflake')}"
+                    f"{table.sql(dialect=dialect)}"
                 )
                 continue
 
-            source_column = exp.to_column(leaf.name).name
+            source = exp.to_column(leaf.name)
+            source_column = normalize_unquoted(
+                source.name,
+                bool(source.this.args.get("quoted")),
+                unquoted_case,
+            )
             if source_column == "*":
                 gaps.append(
                     f"{output_column} depends on a wildcard that cannot be expanded "
@@ -115,7 +129,7 @@ def trace_model(model):
                     "source_database": identifier(table.args.get("catalog")),
                     "source_schema": identifier(table.args.get("db")),
                     "source_table": identifier(table.this),
-                    "source_relation": relation_sql(table),
+                    "source_relation": relation_sql(table, dialect),
                 }
             )
 
@@ -140,9 +154,14 @@ def main():
             f"SQLGlot 30.x is required; found {sqlglot.__version__}"
         )
     request = json.load(sys.stdin)
+    dialect = request.get("dialect", "snowflake")
+    unquoted_case = request.get("unquoted_case", "upper")
     response = {
         "sqlglot_version": sqlglot.__version__,
-        "models": [trace_model(model) for model in request["models"]],
+        "models": [
+            trace_model(model, dialect, unquoted_case)
+            for model in request["models"]
+        ],
     }
     json.dump(response, sys.stdout, separators=(",", ":"))
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -179,7 +179,7 @@ accounts:
     assert_eq!(report["exit_code"], 3);
     assert!(report["ci_schemas"].as_array().unwrap().is_empty());
     let error = report["execution_errors"][0].as_str().unwrap();
-    assert!(error.contains("Install dbt Core and dbt-snowflake"));
+    assert!(error.contains("Install dbt Core and the adapter"));
     assert!(error.contains("missing-dbt-for-embrasure-test --version"));
     assert!(!error.contains("No such file or directory"));
     #[cfg(windows)]


### PR DESCRIPTION
## Summary

- introduce a small typed warehouse provider API while keeping validation, comparison, query diffing, and reporting provider-neutral
- preserve existing Snowflake behavior and legacy configuration while adding Databricks authentication, SQL execution, dbt profiles, doctor checks, cleanup, lineage, and incremental shallow-clone support
- document the provider boundary, Databricks setup, security behavior, and unsupported complex/geospatial comparison handling

## Validation

- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-features with SQLGlot environment: 119 unit tests and 17 CLI tests passed
- live Databricks readiness checks passed for session access, production reads, managed Delta cloning, and temporary schema lifecycle
- live no-op control: 2 models selected, built, and compared; query diff passed; 0 findings; exit code 0
- live intentional regression: changed an existing amount and added a row; both the changed model and downstream incremental model were flagged; keyed query diff identified the exact changed and added rows; 29 findings; exit code 1
- all disposable Databricks schemas were removed and verified absent after testing

## Design review

A focused reviewer checked the provider boundary for simplicity and extensibility. The final pass found no redundant abstractions or duplicative tests; complex and geospatial values now skip unsafe metrics and are rejected as direct comparison keys.