### PR TITLE
Add end-to-end BigQuery support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,8 +463,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link",
 ]
 
@@ -841,6 +843,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "directories",
+ "gcp_auth",
  "globset",
  "jsonschema",
  "keyring",
@@ -1060,6 +1063,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-sink"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
+
+[[package]]
 name = "futures-task"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1076,6 +1085,33 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "gcp_auth"
+version = "0.12.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d27dbcc645b60b8e7f6e2868a9d7102ece97d1bb49c1288b5321fcc67f7260"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "ring",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+ "url",
 ]
 
 [[package]]
@@ -1140,6 +1176,25 @@ dependencies = [
  "log",
  "regex-automata",
  "regex-syntax",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -1258,6 +1313,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1278,6 +1334,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1960,6 +2017,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "openssl-src"
 version = "300.6.1+3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2070,6 +2133,26 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -2566,6 +2649,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2605,6 +2700,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3056,6 +3160,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "libc",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml"
 version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3180,6 +3298,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 repository = "https://github.com/EmbrasureAI/embrasure-cli"
 homepage = "https://embrasure.ai"
 readme = "README.md"
-keywords = ["dbt", "snowflake", "databricks", "data-quality", "cli"]
+keywords = ["dbt", "data-warehouse", "data-quality", "testing", "cli"]
 categories = ["command-line-utilities", "development-tools::testing"]
 
 [[bin]]
@@ -27,6 +27,7 @@ chrono = { version = "0.4", default-features = false, features = ["clock", "serd
 clap = { version = "4.5", features = ["derive"] }
 clap_complete = "4.5"
 globset = "0.4"
+gcp_auth = "0.12.7"
 directories = "6.0"
 keyring = { version = "4.1", optional = true }
 openssl = { version = "0.10", features = ["vendored"] }

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 <p align="center"><strong>Catch unexpected data changes before a dbt PR is reviewed.</strong></p>
 
-Embrasure is open-source, local dbt PR validation for Snowflake and Databricks:
+Embrasure is open-source, local dbt PR validation for Snowflake, Databricks, and BigQuery:
 
 - Builds changed models and critical downstream paths in temporary schemas, then cleans them up.
 - Runs dbt tests and compares schema, row counts, null rates, cardinality, ranges, and primary keys with production.
@@ -21,7 +21,7 @@ Embrasure is open-source, local dbt PR validation for Snowflake and Databricks:
 - Connects directly to your warehouse, with no Embrasure account or data sent to Embrasure.
 - Includes a [`verify`](.agents/skills/verify/SKILL.md) skill that runs the agent check-and-fix loop.
 
-`embrasure auth login` uses Snowflake OAuth. Databricks uses a token supplied through the configured environment variable. The warehouse identity needs production read access and permission to create and remove temporary schemas.
+`embrasure auth login` uses Snowflake OAuth. Databricks uses a token supplied through the configured environment variable. BigQuery uses Google Application Default Credentials. The warehouse identity needs production read access and permission to create and remove temporary schemas or datasets.
 
 ## Snowflake quickstart
 
@@ -83,6 +83,44 @@ accounts:
 
 The integration uses a Databricks SQL warehouse and Unity Catalog. Set `DATABRICKS_TOKEN`, then run `embrasure doctor` and `embrasure check`. Incremental baselines currently require managed Delta tables and use Unity Catalog shallow clones; `doctor` verifies that a suitable table and grants are available.
 
+## BigQuery
+
+Install the BigQuery dbt adapter:
+
+```sh
+python -m pip install "dbt-core>=1.5,<2" "dbt-bigquery>=1.5,<2" "sqlglot>=30,<31"
+```
+
+For local development, create Google Application Default Credentials, then initialize Embrasure from the dbt project root:
+
+```sh
+gcloud auth application-default login
+embrasure init
+embrasure doctor
+embrasure check --dry-run
+embrasure check
+```
+
+`init` detects an active BigQuery dbt profile and writes the version 2 provider configuration. The equivalent manual configuration is:
+
+```yaml
+version: 2
+dbt:
+  project_dir: .
+  profile: analytics
+accounts:
+  - name: primary
+    provider:
+      type: bigquery
+      project: analytics-prod
+      location: US
+      production_schema: prod
+      auth:
+        type: application_default
+```
+
+Application Default Credentials also support `GOOGLE_APPLICATION_CREDENTIALS` and an attached Google Cloud service account. Incremental baselines use BigQuery table clones; clone mode seeds candidates with table copies. The source and temporary datasets must be in the same location, and table-clone restrictions still apply.
+
 If you do not use Homebrew, use the installer:
 
 ```sh
@@ -131,9 +169,9 @@ winget install --id EmbrasureAI.Embrasure --exact
 
 </details>
 
-Use Embrasure from an existing Snowflake or Databricks dbt project whose unchanged production models are already materialized. Embrasure uses those existing relations as the comparison baseline.
+Use Embrasure from an existing Snowflake, Databricks, or BigQuery dbt project whose unchanged production models are already materialized. Embrasure uses those existing relations as the comparison baseline.
 
-For Snowflake, `init` reads the active dbt profile and asks only for missing values. Databricks uses the version 2 configuration shown above. Use `--config <path>` before or after any subcommand to choose another config file.
+For Snowflake and BigQuery, `init` reads the active dbt profile and asks only for missing values. Databricks uses the version 2 configuration shown above. Use `--config <path>` before or after any subcommand to choose another config file.
 
 Continue only when `embrasure doctor` reports `READY`. Embrasure generates a temporary dbt profile for its own runs; it does not modify your existing profile or production models.
 
@@ -312,7 +350,7 @@ Your `generate_schema_name` macro must preserve the complete target schema. Make
 
 ### Incremental relation cannot be cloned
 
-Every existing incremental model needs a stable baseline copy, including in `full-refresh` mode. Snowflake supports tables that can be zero-copy cloned; Databricks currently supports managed Delta tables that can be shallow cloned. Use another materialization or exclude an unsupported relation from this validation path.
+Every existing incremental model needs a stable baseline copy, including in `full-refresh` mode. Snowflake supports tables that can be zero-copy cloned; Databricks currently supports managed Delta tables that can be shallow cloned; BigQuery supports base tables, table clones, and table snapshots accepted by `CREATE TABLE CLONE`. Use another materialization or exclude an unsupported relation from this validation path.
 
 ### Incremental candidate seeding fails
 

--- a/docs/provider-api.md
+++ b/docs/provider-api.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-Keep Snowflake and Databricks behind a small internal warehouse API so another SQL warehouse can be added without branching the validation pipeline or copying comparison logic.
+Keep Snowflake, Databricks, and BigQuery behind a small internal warehouse API so another SQL warehouse can be added without branching the validation pipeline or copying comparison logic.
 
 This is an internal Rust API, not a dynamic plugin ABI. Providers are compiled into the CLI and selected from configuration.
 
@@ -81,7 +81,7 @@ pub trait WarehouseProvider: QueryExecutor {
 
 The runner stores `Arc<dyn WarehouseProvider>`, which keeps concurrent jobs cheap to clone without requiring a second abstraction or an async-trait dependency.
 
-`SqlDialect` is a small copyable enum. It renders the warehouse differences already present in the shared SQL: identifier quoting and normalization, create-table-as, text/numeric casts, null-safe equality, conditionals and conditional counts, approximate distinct counts and percentiles, stable row hashes, and type classification. It also supplies the SQLGlot dialect name. Prefer portable SQL expressions when supported providers agree. Common query construction stays in `compare.rs` and `query.rs`; the enum should grow only when a real provider proves another fragment is different. Databricks complex and geospatial values retain schema evidence but skip column metrics that the warehouse cannot compare reliably; query diffs require an explicit scalar cast.
+`SqlDialect` is a small copyable enum. It renders the warehouse differences already present in the shared SQL: identifier quoting and normalization, create-table-as, text/numeric casts, null-safe equality, conditionals and conditional counts, approximate distinct counts and percentiles, stable row hashes, and type classification. It also supplies the SQLGlot dialect name. Prefer portable SQL expressions when supported providers agree. Common query construction stays in `compare.rs` and `query.rs`; the enum should grow only when a real provider proves another fragment is different. Databricks and BigQuery complex or geospatial values retain schema evidence but skip column metrics that the warehouse cannot compare reliably; query diffs require an explicit scalar cast.
 
 `Relation::sql(dialect)` renders a fully qualified name. A relation does not remember a global or implicit dialect.
 
@@ -108,18 +108,20 @@ accounts:
 
 Each provider owns a typed configuration structure. There is no string-keyed property map and no common credential enum containing every provider's fields.
 
+BigQuery uses the same version 2 shape with `type: bigquery`, `project`, `location`, `production_schema`, and `auth: { type: application_default }`. The provider resolves ADC for REST requests and writes a dbt-bigquery `method: oauth` profile so dbt uses the same credential chain.
+
 Provider-specific entry points for auth, dbt profile generation, `doctor`, and `clean` are dispatched by the same tagged configuration. They do not belong on `WarehouseProvider` because the validation runner does not need them.
 
 ## Incremental models and capabilities
 
-The runner asks the provider to copy a production table into a stable baseline for every existing incremental model. Snowflake implements the semantic operation with a zero-copy clone and Databricks uses a Unity Catalog shallow clone of a managed Delta table. `incremental_mode: clone` additionally seeds the candidate from that baseline. Snowflake can clone again; Databricks uses CTAS because Unity Catalog does not permit a shallow clone of another shallow clone. `full_refresh` skips only candidate seeding, not the stable baseline. A provider may reject an unsupported relation with an actionable error. Provider-specific `doctor` checks are the authoritative preflight; there is no general capability registry.
+The runner asks the provider to copy a production table into a stable baseline for every existing incremental model. Snowflake implements the semantic operation with a zero-copy clone, Databricks uses a Unity Catalog shallow clone of a managed Delta table, and BigQuery uses a table clone. `incremental_mode: clone` additionally seeds the candidate from that baseline. Snowflake can clone again, Databricks uses CTAS because Unity Catalog does not permit a shallow clone of another shallow clone, and BigQuery uses a table copy to avoid extending a clone chain. `full_refresh` skips only candidate seeding, not the stable baseline. A provider may reject an unsupported relation with an actionable error. Provider-specific `doctor` checks are the authoritative preflight; there is no general capability registry.
 
 Another provider may implement the stable copy with an equivalent snapshot operation or reject incremental models until it can preserve a stable baseline.
 
 ## Implementation sequence
 
 1. Add the common provider types, dialect descriptor, executor trait, and lifecycle trait.
-2. Implement them for `SnowflakeClient` and `DatabricksClient`, selected by one factory.
+2. Implement them for `SnowflakeClient`, `DatabricksClient`, and `BigQueryClient`, selected by one factory.
 3. Change the runner and comparison/query code to depend on trait objects and explicit dialect rendering, including identifier normalization and type classification.
 4. Pass each account's provider dialect through SQLGlot parsing, lineage, rendering, and output-name normalization, and into provider-specific dbt profile generation.
 5. Keep version 1 behavior and configuration unchanged, add the tagged version 2 shape, and use only focused provider-contract tests.
@@ -131,5 +133,5 @@ Another provider may implement the stable copy with an equivalent snapshot opera
 - Common relation/result types live in the provider module.
 - SQLGlot receives the selected dialect per account instead of assuming Snowflake.
 - Snowflake output, cleanup safety, report contracts, and CLI behavior remain unchanged.
-- Snowflake and Databricks share the same validation runner.
+- Snowflake, Databricks, and BigQuery share the same validation runner.
 - No dynamic loading, generic property bags, speculative capability matrices, or duplicate Snowflake wrappers are introduced.

--- a/docs/security-and-data-flow.md
+++ b/docs/security-and-data-flow.md
@@ -18,7 +18,7 @@ Local terminal or report
 Optional: Embrasure reads metadata from your configured Metabase URL.
 ```
 
-Validation SQL runs in Snowflake or Databricks. Embrasure does not upload warehouse data, dbt artifacts, reports, credentials, or usage information to Embrasure.
+Validation SQL runs in Snowflake, Databricks, or BigQuery. Embrasure does not upload warehouse data, dbt artifacts, reports, credentials, or usage information to Embrasure.
 
 ## Outbound connections
 
@@ -26,6 +26,7 @@ The CLI itself makes only these connections:
 
 - `https://<account>.snowflakecomputing.com` for browser authentication and Snowflake SQL API requests.
 - The configured Databricks workspace host for Statement Execution API requests.
+- `https://bigquery.googleapis.com` for BigQuery jobs and temporary dataset lifecycle requests, plus the Google OAuth token or Google Cloud metadata endpoint selected by Application Default Credentials.
 - The configured Metabase URL when the optional Metabase integration is enabled.
 - `https://api.github.com/repos/EmbrasureAI/embrasure-cli/releases/latest` for `embrasure update --check`, `embrasure update`, and the gated doctor notice.
 - `https://github.com/EmbrasureAI/embrasure-cli/releases/download/...` when `embrasure update` downloads a release and its checksums.
@@ -52,6 +53,7 @@ Query checks accept a single read-only query expression, but syntax validation i
 - The configuration file contains warehouse identifiers and environment-variable names, not secret values.
 - Programmatic access tokens and external OAuth tokens are read from environment variables.
 - Databricks tokens are read from the configured environment variable and sent only to the configured workspace host and the temporary dbt profile.
+- BigQuery uses Google Application Default Credentials. Depending on the environment, those credentials come from a service-account JSON file named by `GOOGLE_APPLICATION_CREDENTIALS`, the local ADC file created by gcloud, or an attached Google Cloud service account. Access tokens are sent only to Google APIs and are not written to Embrasure configuration or reports.
 - RSA private keys are read from the configured local path.
 - Browser OAuth sessions are cached under `~/.config/embrasure-check/oauth/` by default on Unix, with owner-only file and directory permissions. Windows sessions are encrypted for the current user with DPAPI and stored under `%APPDATA%\embrasure-check\oauth\`. Run `embrasure auth logout` to remove a cached session.
 - Temporary dbt profiles, manifests, target directories, and the detached base worktree live under an operating-system temporary directory and are removed after the process exits normally.
@@ -73,13 +75,15 @@ Incremental baselines use Snowflake table-level zero-copy clones. Embrasure neve
 
 For Databricks, use a Unity Catalog SQL warehouse. The identity needs `USE CATALOG`, production schema/table read access, and permission to create schemas and tables in the configured catalog. Incremental baselines currently use managed Delta shallow clones; candidate seeding uses CTAS so it does not create an unsupported nested shallow clone.
 
+For BigQuery, the identity needs permission to create query jobs, read production table data and metadata, create and delete temporary datasets, and create, update, and delete tables inside those datasets. Typical predefined roles are BigQuery Job User on the project plus Data Viewer on production datasets and Data Editor or Data Owner on the temporary-dataset project. Embrasure creates each temporary dataset with an explicit empty legacy access list so BigQuery does not add its default project-wide dataset ACL entries; inherited IAM still applies. Incremental baselines use writable table clones; candidate seeding uses table copies. BigQuery requires clone sources and destinations to share a location and organization, and recently streamed rows in write-optimized storage are not included in a clone.
+
 ## Schema cleanup
 
 Each run uses unique candidate and baseline schema names and writes an ownership marker to every schema. Cleanup requires both the exact run namespace and matching marker. The CLI refuses to drop a schema that fails either check.
 
-Snowflake schemas are dropped with `RESTRICT` instead of the Snowflake `CASCADE` default, so cleanup never removes foreign keys held by objects outside the schema. Databricks schemas are dropped with `CASCADE` only after both the run namespace and ownership marker are verified; the cascade is limited to objects inside that temporary Unity Catalog schema.
+Snowflake schemas are dropped with `RESTRICT` instead of the Snowflake `CASCADE` default, so cleanup never removes foreign keys held by objects outside the schema. Databricks schemas are dropped with `CASCADE` only after both the run namespace and ownership marker are verified; the cascade is limited to objects inside that temporary Unity Catalog schema. BigQuery datasets are deleted with their contents only after the dataset name, managed label, and exact ownership description are verified.
 
-Cleanup is attempted after success, findings, execution failures, Ctrl-C, and normal termination signals. No process can clean up after `SIGKILL`, a machine crash, or power loss. `embrasure clean` lists old marked schemas by default and removes them only with `--yes`. It searches only each configured account database and verifies both the configured prefix and an Embrasure ownership marker before removal.
+Cleanup is attempted after success, findings, execution failures, Ctrl-C, and normal termination signals. No process can clean up after `SIGKILL`, a machine crash, or power loss. `embrasure clean` lists old marked schemas or datasets by default and removes them only with `--yes`. It searches only each configured account database or project and verifies both the configured prefix and an Embrasure ownership marker before removal.
 
 ## Release integrity
 

--- a/embrasure-check.example.yml
+++ b/embrasure-check.example.yml
@@ -29,7 +29,7 @@ validation:
   # for changed models only. Full downstream impact is always reported.
   downstream: critical
   critical_tags: [critical]
-  # Existing incremental models start from zero-copy production clones.
+  # Existing incremental models start from provider-specific production copies.
   incremental_mode: clone
 
 thresholds:
@@ -64,6 +64,17 @@ accounts:
   #   auth:
   #     type: programmatic_access_token
   #     token_env: SECONDARY_SNOWFLAKE_PAT
+
+  # For BigQuery, change the top-level version to 2 and replace the Snowflake
+  # account above with this typed provider block:
+  # - name: primary
+  #   provider:
+  #     type: bigquery
+  #     project: analytics-prod
+  #     location: US
+  #     production_schema: prod
+  #     auth:
+  #       type: application_default
 
 models:
   # Keys may be dbt unique IDs or model names.

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -3,6 +3,7 @@ use std::{
     env, fs,
     io::Write,
     path::{Path, PathBuf},
+    sync::Arc,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
@@ -15,17 +16,19 @@ use url::Url;
 
 use crate::{
     config::{
-        AccountConfig, AuthConfig, Config, DatabricksAuthConfig, ProviderConfig, SnowflakeConfig,
+        AccountConfig, AuthConfig, BigQueryAuthConfig, Config, DatabricksAuthConfig,
+        ProviderConfig, SnowflakeConfig,
     },
     loopback, update,
 };
 
 const LOCAL_CLIENT_ID: &str = "LOCAL_APPLICATION";
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub enum ResolvedAuth {
     Snowflake(SnowflakeResolvedAuth),
     Databricks(DatabricksResolvedAuth),
+    BigQuery(BigQueryResolvedAuth),
 }
 
 #[derive(Debug, Clone)]
@@ -45,6 +48,11 @@ pub enum SnowflakeResolvedAuth {
 #[derive(Debug, Clone)]
 pub enum DatabricksResolvedAuth {
     Token { token: String },
+}
+
+#[derive(Clone)]
+pub struct BigQueryResolvedAuth {
+    pub token_provider: Option<Arc<dyn gcp_auth::TokenProvider>>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -90,6 +98,9 @@ pub fn placeholder(account: &AccountConfig) -> ResolvedAuth {
         ProviderConfig::Databricks(_) => ResolvedAuth::Databricks(DatabricksResolvedAuth::Token {
             token: "dry-run-not-used".into(),
         }),
+        ProviderConfig::BigQuery(_) => ResolvedAuth::BigQuery(BigQueryResolvedAuth {
+            token_provider: None,
+        }),
     }
 }
 
@@ -102,6 +113,14 @@ pub async fn resolve(account: &AccountConfig) -> Result<ResolvedAuth> {
             DatabricksAuthConfig::Token { token_env } => {
                 Ok(ResolvedAuth::Databricks(DatabricksResolvedAuth::Token {
                     token: required_env(token_env, "Databricks token")?,
+                }))
+            }
+        },
+        ProviderConfig::BigQuery(config) => match &config.auth {
+            BigQueryAuthConfig::ApplicationDefault => {
+                let token_provider = bigquery_adc_provider().await?;
+                Ok(ResolvedAuth::BigQuery(BigQueryResolvedAuth {
+                    token_provider: Some(token_provider),
                 }))
             }
         },
@@ -179,17 +198,35 @@ pub fn logout_from_config(config_path: &Path, requested: Option<&str>) -> Result
     Ok(account.name.clone())
 }
 
-pub fn status_from_config(config_path: &Path) -> Result<Vec<AuthStatus>> {
+pub async fn status_from_config(config_path: &Path) -> Result<Vec<AuthStatus>> {
     let mut config = Config::load(config_path)?;
     config.resolve_from(config_path)?;
-    config.accounts.iter().map(status).collect()
+    let mut statuses = Vec::with_capacity(config.accounts.len());
+    for account in &config.accounts {
+        statuses.push(status(account).await?);
+    }
+    Ok(statuses)
 }
 
-pub fn status(account: &AccountConfig) -> Result<AuthStatus> {
+pub async fn status(account: &AccountConfig) -> Result<AuthStatus> {
     let (method, ready, message) = match &account.provider {
         ProviderConfig::Snowflake(config) => snowflake_status(account, config)?,
         ProviderConfig::Databricks(config) => match &config.auth {
             DatabricksAuthConfig::Token { token_env } => env_status("token", token_env),
+        },
+        ProviderConfig::BigQuery(config) => match &config.auth {
+            BigQueryAuthConfig::ApplicationDefault => match bigquery_adc_provider().await {
+                Ok(_) => (
+                    "application_default",
+                    true,
+                    "Google Application Default Credentials are available".into(),
+                ),
+                Err(error) => (
+                    "application_default",
+                    false,
+                    format!("Google Application Default Credentials are unavailable: {error}"),
+                ),
+            },
         },
     };
     Ok(AuthStatus {
@@ -198,6 +235,25 @@ pub fn status(account: &AccountConfig) -> Result<AuthStatus> {
         ready,
         status: message,
     })
+}
+
+async fn bigquery_adc_provider() -> Result<Arc<dyn gcp_auth::TokenProvider>> {
+    if let Some(provider) = gcp_auth::CustomServiceAccount::from_env()
+        .context("GOOGLE_APPLICATION_CREDENTIALS is not a valid service-account JSON file")?
+    {
+        return Ok(Arc::new(provider));
+    }
+    let user_error = match gcp_auth::ConfigDefaultCredentials::new().await {
+        Ok(provider) => return Ok(Arc::new(provider)),
+        Err(error) => error,
+    };
+    let metadata_error = match gcp_auth::MetadataServiceAccount::new().await {
+        Ok(provider) => return Ok(Arc::new(provider)),
+        Err(error) => error,
+    };
+    bail!(
+        "could not resolve Google Application Default Credentials from the local ADC file or metadata service (local: {user_error}; metadata: {metadata_error})"
+    )
 }
 
 fn snowflake_status(

--- a/src/bigquery.rs
+++ b/src/bigquery.rs
@@ -1,0 +1,698 @@
+use std::{
+    collections::BTreeMap,
+    sync::Arc,
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+};
+
+use anyhow::{Context, Result, bail};
+use chrono::{DateTime, Utc};
+use reqwest::{Client, RequestBuilder, Response, StatusCode, Url, header};
+use serde::Deserialize;
+use serde_json::{Value, json};
+use tokio::time::sleep;
+use uuid::Uuid;
+
+use crate::{
+    auth::{BigQueryResolvedAuth, ResolvedAuth},
+    clean,
+    config::{AccountConfig, BigQueryConfig},
+    provider::{
+        ProviderFuture, QueryExecutor, QueryResult, Relation, ResultColumn, SqlDialect,
+        WarehouseProvider, is_managed_schema,
+    },
+};
+
+const API_ROOT: &str = "https://bigquery.googleapis.com/bigquery/v2/";
+const BIGQUERY_SCOPE: &str = "https://www.googleapis.com/auth/bigquery";
+const MANAGED_LABEL: &str = "embrasure_managed";
+
+#[derive(Clone)]
+pub struct BigQueryClient {
+    http: Client,
+    auth: Arc<dyn gcp_auth::TokenProvider>,
+    account: BigQueryConfig,
+    query_tag: String,
+    timeout_seconds: u64,
+    api_root: Url,
+}
+
+impl BigQueryClient {
+    pub fn new(
+        account: &AccountConfig,
+        auth: &ResolvedAuth,
+        query_tag: String,
+        timeout_seconds: u64,
+    ) -> Result<Self> {
+        let account = account
+            .bigquery()
+            .context("BigQuery client requires BigQuery account configuration")?;
+        let ResolvedAuth::BigQuery(BigQueryResolvedAuth { token_provider }) = auth else {
+            bail!("BigQuery client received credentials for another provider");
+        };
+        let auth = token_provider
+            .clone()
+            .context("BigQuery Application Default Credentials were not resolved")?;
+        Ok(Self {
+            http: Client::builder()
+                .timeout(Duration::from_secs(timeout_seconds + 30))
+                .build()?,
+            auth,
+            account: account.clone(),
+            query_tag,
+            timeout_seconds,
+            api_root: Url::parse(API_ROOT)?,
+        })
+    }
+
+    pub async fn execute(&self, statement: &str) -> Result<QueryResult> {
+        let started = Instant::now();
+        let timeout_ms = self.timeout_seconds.saturating_mul(1_000);
+        let url = self.api_url(&["projects", &self.account.project, "queries"])?;
+        let response = self
+            .send(self.http.post(url).json(&json!({
+                "query": format!("/* {} */\n{statement}", self.query_tag),
+                "useLegacySql": false,
+                "location": self.account.location,
+                "defaultDataset": {
+                    "projectId": self.account.project,
+                    "datasetId": self.account.production_schema,
+                },
+                "timeoutMs": timeout_ms.min(200_000),
+                "jobTimeoutMs": timeout_ms.to_string(),
+                "maxResults": 10_000,
+                "requestId": Uuid::new_v4().to_string(),
+                "labels": { "embrasure_managed": "true" },
+            })))
+            .await?;
+        let mut page: QueryResponse = parse_response(response, "BigQuery query request").await?;
+        let job = page
+            .job_reference
+            .clone()
+            .context("BigQuery query response omitted its job reference")?;
+
+        while !page.job_complete {
+            if started.elapsed() >= Duration::from_secs(self.timeout_seconds) {
+                let _ = self.cancel_job(&job).await;
+                bail!(
+                    "BigQuery job exceeded {} seconds; cancellation was requested",
+                    self.timeout_seconds
+                );
+            }
+            sleep(Duration::from_millis(500)).await;
+            page = self.query_results(&job, None).await?;
+        }
+        fail_for_query_errors(&page.errors)?;
+
+        let mut columns = page.schema.take().map(table_columns).unwrap_or_default();
+        let mut rows = parse_rows(std::mem::take(&mut page.rows));
+        let mut page_token = page.page_token.take();
+        while let Some(token) = page_token {
+            let mut next = self.query_results(&job, Some(&token)).await?;
+            if !next.job_complete {
+                bail!("BigQuery returned an incomplete result page for a completed job");
+            }
+            fail_for_query_errors(&next.errors)?;
+            if columns.is_empty() {
+                columns = next.schema.take().map(table_columns).unwrap_or_default();
+            }
+            rows.extend(parse_rows(std::mem::take(&mut next.rows)));
+            page_token = next.page_token.take();
+        }
+        Ok(QueryResult { columns, rows })
+    }
+
+    pub async fn create_schema(&self, project: &str, schema: &str) -> Result<()> {
+        let url = self.api_url(&["projects", project, "datasets"])?;
+        let response = self
+            .send(self.http.post(url).json(&json!({
+                "datasetReference": {
+                    "projectId": project,
+                    "datasetId": schema,
+                },
+                "location": self.account.location,
+                "description": self.schema_ownership_marker(),
+                "labels": { (MANAGED_LABEL): "true" },
+                "access": [],
+            })))
+            .await?;
+        ensure_success(response, "BigQuery dataset creation").await
+    }
+
+    pub async fn copy_table(&self, source: &Relation, target: &Relation) -> Result<()> {
+        self.execute(&copy_table_statement(source, target)).await?;
+        Ok(())
+    }
+
+    pub async fn seed_table(&self, source: &Relation, target: &Relation) -> Result<()> {
+        self.execute(&seed_table_statement(source, target)).await?;
+        Ok(())
+    }
+
+    pub async fn drop_schema(&self, project: &str, schema: &str, run_schema: &str) -> Result<()> {
+        if !is_managed_schema(SqlDialect::BigQuery, schema, run_schema) {
+            bail!("refusing to drop dataset {schema}: it is not owned by this run ({run_schema})");
+        }
+        let Some(dataset) = self.dataset(project, schema).await? else {
+            return Ok(());
+        };
+        if dataset.description.as_deref() != Some(&self.schema_ownership_marker())
+            || dataset.labels.get(MANAGED_LABEL).map(String::as_str) != Some("true")
+        {
+            bail!(
+                "refusing to drop dataset {project}.{schema}: its ownership marker does not match this run"
+            );
+        }
+        self.drop_dataset(project, schema).await
+    }
+
+    pub async fn stale_managed_schemas(
+        &self,
+        project: &str,
+        prefix: &str,
+        older_than_hours: u64,
+    ) -> Result<QueryResult> {
+        let mut datasets = Vec::new();
+        let mut page_token = None;
+        loop {
+            let url = self.api_url(&["projects", project, "datasets"])?;
+            let mut request = self.http.get(url).query(&[
+                ("all", "true"),
+                ("filter", "labels.embrasure_managed:true"),
+                ("maxResults", "1000"),
+            ]);
+            if let Some(token) = page_token.as_deref() {
+                request = request.query(&[("pageToken", token)]);
+            }
+            let response = self.send(request).await?;
+            let page: DatasetList = parse_response(response, "BigQuery dataset listing").await?;
+            datasets.extend(page.datasets);
+            page_token = page.next_page_token;
+            if page_token.is_none() {
+                break;
+            }
+        }
+
+        let cutoff = SystemTime::now()
+            .checked_sub(Duration::from_secs(older_than_hours.saturating_mul(3_600)))
+            .unwrap_or(UNIX_EPOCH)
+            .duration_since(UNIX_EPOCH)?
+            .as_millis();
+        let mut rows = Vec::new();
+        for item in datasets {
+            let Some(reference) = item.dataset_reference else {
+                continue;
+            };
+            if !clean::is_managed_prefix(&reference.dataset_id, prefix)
+                || !item
+                    .location
+                    .as_deref()
+                    .is_some_and(|location| location.eq_ignore_ascii_case(&self.account.location))
+            {
+                continue;
+            }
+            let Some(dataset) = self.dataset(project, &reference.dataset_id).await? else {
+                continue;
+            };
+            let Some(marker) = dataset.description.as_deref() else {
+                continue;
+            };
+            if dataset.labels.get(MANAGED_LABEL).map(String::as_str) != Some("true")
+                || clean::parse_ownership_marker(marker).is_none()
+            {
+                continue;
+            }
+            let created_ms = dataset
+                .creation_time
+                .as_deref()
+                .and_then(|value| value.parse::<u128>().ok())
+                .unwrap_or(u128::MAX);
+            if created_ms >= cutoff {
+                continue;
+            }
+            let created = i64::try_from(created_ms)
+                .ok()
+                .and_then(DateTime::<Utc>::from_timestamp_millis)
+                .map(|value| value.to_rfc3339())
+                .unwrap_or_else(|| "unknown".into());
+            rows.push(vec![
+                Some(reference.dataset_id),
+                Some(marker.to_owned()),
+                Some(created),
+            ]);
+        }
+        rows.sort_by(|left, right| left[2].cmp(&right[2]).then(left[0].cmp(&right[0])));
+        Ok(QueryResult {
+            columns: vec![
+                ResultColumn {
+                    name: "schema_name".into(),
+                    data_type: "STRING".into(),
+                },
+                ResultColumn {
+                    name: "description".into(),
+                    data_type: "STRING".into(),
+                },
+                ResultColumn {
+                    name: "created".into(),
+                    data_type: "STRING".into(),
+                },
+            ],
+            rows,
+        })
+    }
+
+    pub async fn drop_marked_schema(
+        &self,
+        project: &str,
+        schema: &str,
+        prefix: &str,
+    ) -> Result<()> {
+        if !clean::is_managed_prefix(schema, prefix) {
+            bail!("refusing to drop dataset {schema}: it is outside the managed prefix {prefix}");
+        }
+        let Some(dataset) = self.dataset(project, schema).await? else {
+            return Ok(());
+        };
+        if dataset.labels.get(MANAGED_LABEL).map(String::as_str) != Some("true")
+            || dataset
+                .description
+                .as_deref()
+                .and_then(clean::parse_ownership_marker)
+                .is_none()
+        {
+            bail!(
+                "refusing to drop dataset {project}.{schema}: its Embrasure ownership marker is invalid"
+            );
+        }
+        self.drop_dataset(project, schema).await
+    }
+
+    async fn query_results(
+        &self,
+        job: &JobReference,
+        page_token: Option<&str>,
+    ) -> Result<QueryResponse> {
+        let url = self.api_url(&["projects", &job.project_id, "queries", &job.job_id])?;
+        let mut request = self.http.get(url).query(&[
+            ("location", job.location.as_str()),
+            ("timeoutMs", "10000"),
+            ("maxResults", "10000"),
+        ]);
+        if let Some(token) = page_token {
+            request = request.query(&[("pageToken", token)]);
+        }
+        let response = self.send(request).await?;
+        parse_response(response, "BigQuery result request").await
+    }
+
+    async fn cancel_job(&self, job: &JobReference) -> Result<()> {
+        let url = self.api_url(&["projects", &job.project_id, "jobs", &job.job_id, "cancel"])?;
+        let response = self
+            .send(self.http.post(url).query(&[("location", &job.location)]))
+            .await?;
+        ensure_success(response, "BigQuery job cancellation").await
+    }
+
+    async fn dataset(&self, project: &str, schema: &str) -> Result<Option<DatasetResource>> {
+        let url = self.api_url(&["projects", project, "datasets", schema])?;
+        let response = self.send(self.http.get(url)).await?;
+        if response.status() == StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        parse_response(response, "BigQuery dataset lookup")
+            .await
+            .map(Some)
+    }
+
+    async fn drop_dataset(&self, project: &str, schema: &str) -> Result<()> {
+        let url = self.api_url(&["projects", project, "datasets", schema])?;
+        let response = self
+            .send(self.http.delete(url).query(&[("deleteContents", "true")]))
+            .await?;
+        if response.status() == StatusCode::NOT_FOUND {
+            return Ok(());
+        }
+        ensure_success(response, "BigQuery dataset deletion").await
+    }
+
+    async fn send(&self, request: RequestBuilder) -> Result<Response> {
+        let token = self
+            .auth
+            .token(&[BIGQUERY_SCOPE])
+            .await
+            .context("could not obtain a BigQuery access token")?;
+        request
+            .bearer_auth(token.as_str())
+            .header(
+                header::USER_AGENT,
+                concat!("embrasure/", env!("CARGO_PKG_VERSION")),
+            )
+            .send()
+            .await
+            .context("BigQuery API request failed")
+    }
+
+    fn api_url(&self, segments: &[&str]) -> Result<Url> {
+        joined_api_url(&self.api_root, segments)
+    }
+
+    fn schema_ownership_marker(&self) -> String {
+        format!("Temporary schema managed by Embrasure; {}", self.query_tag)
+    }
+}
+
+fn joined_api_url(root: &Url, segments: &[&str]) -> Result<Url> {
+    let mut url = root.clone();
+    url.path_segments_mut()
+        .map_err(|_| anyhow::anyhow!("BigQuery API endpoint cannot contain path segments"))?
+        .pop_if_empty()
+        .extend(segments);
+    Ok(url)
+}
+
+impl QueryExecutor for BigQueryClient {
+    fn dialect(&self) -> SqlDialect {
+        SqlDialect::BigQuery
+    }
+
+    fn execute<'a>(&'a self, statement: &'a str) -> ProviderFuture<'a, QueryResult> {
+        Box::pin(BigQueryClient::execute(self, statement))
+    }
+}
+
+impl WarehouseProvider for BigQueryClient {
+    fn create_schema<'a>(&'a self, project: &'a str, schema: &'a str) -> ProviderFuture<'a, ()> {
+        Box::pin(BigQueryClient::create_schema(self, project, schema))
+    }
+
+    fn copy_table<'a>(
+        &'a self,
+        source: &'a Relation,
+        target: &'a Relation,
+    ) -> ProviderFuture<'a, ()> {
+        Box::pin(BigQueryClient::copy_table(self, source, target))
+    }
+
+    fn seed_table<'a>(
+        &'a self,
+        source: &'a Relation,
+        target: &'a Relation,
+    ) -> ProviderFuture<'a, ()> {
+        Box::pin(BigQueryClient::seed_table(self, source, target))
+    }
+
+    fn drop_schema<'a>(
+        &'a self,
+        project: &'a str,
+        schema: &'a str,
+        run_schema: &'a str,
+    ) -> ProviderFuture<'a, ()> {
+        Box::pin(BigQueryClient::drop_schema(
+            self, project, schema, run_schema,
+        ))
+    }
+}
+
+fn copy_table_statement(source: &Relation, target: &Relation) -> String {
+    let dialect = SqlDialect::BigQuery;
+    format!(
+        "CREATE TABLE {} CLONE {}",
+        target.sql(dialect),
+        source.sql(dialect)
+    )
+}
+
+fn seed_table_statement(source: &Relation, target: &Relation) -> String {
+    let dialect = SqlDialect::BigQuery;
+    format!(
+        "CREATE TABLE {} COPY {}",
+        target.sql(dialect),
+        source.sql(dialect)
+    )
+}
+
+async fn ensure_success(response: Response, label: &str) -> Result<()> {
+    let status = response.status();
+    let body = response.bytes().await?;
+    if status.is_success() {
+        return Ok(());
+    }
+    bail!("{label} failed (HTTP {status}): {}", api_error(&body));
+}
+
+async fn parse_response<T: for<'de> Deserialize<'de>>(
+    response: Response,
+    label: &str,
+) -> Result<T> {
+    let status = response.status();
+    let body = response.bytes().await?;
+    if !status.is_success() {
+        bail!("{label} failed (HTTP {status}): {}", api_error(&body));
+    }
+    serde_json::from_slice(&body).with_context(|| format!("{label} returned invalid JSON"))
+}
+
+fn api_error(body: &[u8]) -> String {
+    serde_json::from_slice::<Value>(body)
+        .ok()
+        .and_then(|value| {
+            value
+                .pointer("/error/message")
+                .and_then(Value::as_str)
+                .map(str::to_owned)
+        })
+        .unwrap_or_else(|| String::from_utf8_lossy(body).trim().to_owned())
+}
+
+fn fail_for_query_errors(errors: &[ApiError]) -> Result<()> {
+    if errors.is_empty() {
+        return Ok(());
+    }
+    let detail = errors
+        .iter()
+        .map(|error| match error.reason.as_deref() {
+            Some(reason) => format!("{reason}: {}", error.message),
+            None => error.message.clone(),
+        })
+        .collect::<Vec<_>>()
+        .join("; ");
+    bail!("BigQuery job failed: {detail}")
+}
+
+fn table_columns(schema: TableSchema) -> Vec<ResultColumn> {
+    schema
+        .fields
+        .into_iter()
+        .map(|field| {
+            let data_type = field.data_type();
+            ResultColumn {
+                name: field.name,
+                data_type,
+            }
+        })
+        .collect()
+}
+
+fn parse_rows(rows: Vec<TableRow>) -> Vec<Vec<Option<String>>> {
+    rows.into_iter()
+        .map(|row| {
+            row.fields
+                .into_iter()
+                .map(|cell| cell_text(cell.value))
+                .collect()
+        })
+        .collect()
+}
+
+fn cell_text(value: Value) -> Option<String> {
+    match value {
+        Value::Null => None,
+        Value::String(value) => Some(value),
+        Value::Bool(value) => Some(value.to_string()),
+        Value::Number(value) => Some(value.to_string()),
+        value => serde_json::to_string(&value).ok(),
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct QueryResponse {
+    #[serde(default)]
+    schema: Option<TableSchema>,
+    #[serde(default)]
+    job_reference: Option<JobReference>,
+    #[serde(default)]
+    page_token: Option<String>,
+    #[serde(default)]
+    job_complete: bool,
+    #[serde(default)]
+    rows: Vec<TableRow>,
+    #[serde(default)]
+    errors: Vec<ApiError>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct JobReference {
+    project_id: String,
+    job_id: String,
+    location: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct TableSchema {
+    #[serde(default)]
+    fields: Vec<TableField>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct TableField {
+    name: String,
+    #[serde(rename = "type")]
+    kind: String,
+    #[serde(default)]
+    mode: Option<String>,
+    #[serde(default)]
+    fields: Vec<TableField>,
+}
+
+impl TableField {
+    fn data_type(&self) -> String {
+        let kind = if self.kind.eq_ignore_ascii_case("RECORD") {
+            if self.fields.is_empty() {
+                "STRUCT".into()
+            } else {
+                format!(
+                    "STRUCT<{}>",
+                    self.fields
+                        .iter()
+                        .map(|field| format!("{} {}", field.name, field.data_type()))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )
+            }
+        } else {
+            self.kind.clone()
+        };
+        if self.mode.as_deref() == Some("REPEATED") {
+            format!("ARRAY<{kind}>")
+        } else {
+            kind
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct TableRow {
+    #[serde(rename = "f", default)]
+    fields: Vec<TableCell>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct TableCell {
+    #[serde(rename = "v")]
+    value: Value,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct ApiError {
+    #[serde(default)]
+    reason: Option<String>,
+    message: String,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DatasetResource {
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    labels: BTreeMap<String, String>,
+    #[serde(default)]
+    creation_time: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DatasetList {
+    #[serde(default)]
+    datasets: Vec<DatasetListItem>,
+    #[serde(default)]
+    next_page_token: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DatasetListItem {
+    #[serde(default)]
+    dataset_reference: Option<DatasetReference>,
+    #[serde(default)]
+    location: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DatasetReference {
+    dataset_id: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn renders_clone_and_copy_operations() {
+        let source = Relation {
+            database: "analytics-prod".into(),
+            schema: "prod".into(),
+            identifier: "orders".into(),
+        };
+        let target = Relation {
+            database: "analytics-dev".into(),
+            schema: "check".into(),
+            identifier: "orders".into(),
+        };
+        assert_eq!(
+            copy_table_statement(&source, &target),
+            "CREATE TABLE `analytics-dev`.`check`.`orders` CLONE `analytics-prod`.`prod`.`orders`"
+        );
+        assert_eq!(
+            seed_table_statement(&source, &target),
+            "CREATE TABLE `analytics-dev`.`check`.`orders` COPY `analytics-prod`.`prod`.`orders`"
+        );
+    }
+
+    #[test]
+    fn api_urls_do_not_keep_the_root_trailing_slash_as_an_empty_segment() {
+        let root = Url::parse(API_ROOT).unwrap();
+        let url = joined_api_url(&root, &["projects", "analytics-prod", "queries"]).unwrap();
+        assert_eq!(
+            url.as_str(),
+            "https://bigquery.googleapis.com/bigquery/v2/projects/analytics-prod/queries"
+        );
+    }
+
+    #[test]
+    fn decodes_scalar_rows_and_marks_complex_columns() {
+        let response: QueryResponse = serde_json::from_str(
+            r#"{
+              "jobReference":{"projectId":"p","jobId":"j","location":"US"},
+              "jobComplete":true,
+              "schema":{"fields":[
+                {"name":"count","type":"INT64","mode":"NULLABLE"},
+                {"name":"tags","type":"STRING","mode":"REPEATED"},
+                {"name":"metadata","type":"RECORD","mode":"NULLABLE"}
+              ]},
+              "rows":[{"f":[{"v":"42"},{"v":[{"v":"a"}]},{"v":null}]}]
+            }"#,
+        )
+        .unwrap();
+        let columns = table_columns(response.schema.unwrap());
+        assert_eq!(columns[0].data_type, "INT64");
+        assert_eq!(columns[1].data_type, "ARRAY<STRING>");
+        assert_eq!(columns[2].data_type, "STRUCT");
+        assert_eq!(
+            parse_rows(response.rows),
+            vec![vec![Some("42".into()), Some(r#"[{"v":"a"}]"#.into()), None]]
+        );
+    }
+}

--- a/src/clean.rs
+++ b/src/clean.rs
@@ -6,6 +6,7 @@ use uuid::Uuid;
 
 use crate::{
     auth,
+    bigquery::BigQueryClient,
     config::{Config, ProviderConfig},
     databricks::DatabricksClient,
     provider::{QueryResult, dialect},
@@ -111,6 +112,29 @@ async fn run_inner(
                         report.candidates.push(candidate.finish(
                             &account.name,
                             &provider.catalog,
+                            remove,
+                        ));
+                    }
+                }
+                ProviderConfig::BigQuery(provider) => {
+                    let client = BigQueryClient::new(
+                        account,
+                        credential,
+                        query_tag,
+                        config.safety.statement_timeout_seconds,
+                    )?;
+                    let rows = client
+                        .stale_managed_schemas(&provider.project, &prefix, older_than_hours)
+                        .await?;
+                    for candidate in managed_candidates(rows, &prefix) {
+                        if remove {
+                            client
+                                .drop_marked_schema(&provider.project, &candidate.schema, &prefix)
+                                .await?;
+                        }
+                        report.candidates.push(candidate.finish(
+                            &account.name,
+                            &provider.project,
                             remove,
                         ));
                     }

--- a/src/compare.rs
+++ b/src/compare.rs
@@ -445,7 +445,7 @@ async fn compare_primary_key<E: QueryExecutor + ?Sized>(
         .iter()
         .map(|key| {
             let key = dialect.quote_identifier(key);
-            dialect.null_safe_equal(&format!("C.{key}"), &format!("P.{key}"))
+            dialect.full_join_equal(&format!("C.{key}"), &format!("P.{key}"))
         })
         .collect::<Vec<_>>()
         .join(" AND ");

--- a/src/config.rs
+++ b/src/config.rs
@@ -281,6 +281,8 @@ impl From<AccountConfigWire> for AccountConfig {
 pub enum ProviderConfig {
     Snowflake(SnowflakeConfig),
     Databricks(DatabricksConfig),
+    #[serde(rename = "bigquery")]
+    BigQuery(BigQueryConfig),
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -306,12 +308,27 @@ pub struct DatabricksConfig {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BigQueryConfig {
+    pub project: String,
+    pub location: String,
+    pub production_schema: String,
+    pub auth: BigQueryAuthConfig,
+}
+
+#[derive(Debug, Clone, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
 pub enum DatabricksAuthConfig {
     Token {
         #[serde(default = "default_databricks_token_env")]
         token_env: String,
     },
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+pub enum BigQueryAuthConfig {
+    ApplicationDefault,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -338,6 +355,7 @@ impl AccountConfig {
         match &self.provider {
             ProviderConfig::Snowflake(config) => &config.database,
             ProviderConfig::Databricks(config) => &config.catalog,
+            ProviderConfig::BigQuery(config) => &config.project,
         }
     }
 
@@ -345,20 +363,28 @@ impl AccountConfig {
         match &self.provider {
             ProviderConfig::Snowflake(config) => &config.production_schema,
             ProviderConfig::Databricks(config) => &config.production_schema,
+            ProviderConfig::BigQuery(config) => &config.production_schema,
         }
     }
 
     pub fn snowflake(&self) -> Option<&SnowflakeConfig> {
         match &self.provider {
             ProviderConfig::Snowflake(config) => Some(config),
-            ProviderConfig::Databricks(_) => None,
+            ProviderConfig::Databricks(_) | ProviderConfig::BigQuery(_) => None,
         }
     }
 
     pub fn databricks(&self) -> Option<&DatabricksConfig> {
         match &self.provider {
-            ProviderConfig::Snowflake(_) => None,
+            ProviderConfig::Snowflake(_) | ProviderConfig::BigQuery(_) => None,
             ProviderConfig::Databricks(config) => Some(config),
+        }
+    }
+
+    pub fn bigquery(&self) -> Option<&BigQueryConfig> {
+        match &self.provider {
+            ProviderConfig::Snowflake(_) | ProviderConfig::Databricks(_) => None,
+            ProviderConfig::BigQuery(config) => Some(config),
         }
     }
 }
@@ -586,6 +612,7 @@ impl Config {
             match &account.provider {
                 ProviderConfig::Snowflake(config) => validate_snowflake(account, config)?,
                 ProviderConfig::Databricks(config) => validate_databricks(account, config)?,
+                ProviderConfig::BigQuery(config) => validate_bigquery(account, config)?,
             }
         }
         let mut check_names = BTreeSet::new();
@@ -794,6 +821,53 @@ fn validate_databricks(account: &AccountConfig, config: &DatabricksConfig) -> Re
             bail!("account {} has an empty token_env", account.name)
         }
         DatabricksAuthConfig::Token { .. } => {}
+    }
+    Ok(())
+}
+
+fn validate_bigquery(account: &AccountConfig, config: &BigQueryConfig) -> Result<()> {
+    for (field, value) in [
+        ("project", &config.project),
+        ("location", &config.location),
+        ("production_schema", &config.production_schema),
+    ] {
+        if value.trim().is_empty() {
+            bail!("account {} has an empty {field}", account.name);
+        }
+    }
+    if config.project.len() > 255
+        || config.project.contains(['/', '\\'])
+        || config.project.chars().any(char::is_whitespace)
+    {
+        bail!(
+            "account {} BigQuery project must be a project ID without whitespace or path separators",
+            account.name
+        );
+    }
+    if config.production_schema.len() > 1024
+        || !config
+            .production_schema
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || character == '_')
+    {
+        bail!(
+            "account {} BigQuery production_schema must contain only letters, numbers, or underscores",
+            account.name
+        );
+    }
+    if config.location.len() > 255
+        || !config
+            .location
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || character == '-')
+    {
+        bail!(
+            "account {} BigQuery location must contain only letters, numbers, or hyphens",
+            account.name
+        );
+    }
+    match &config.auth {
+        BigQueryAuthConfig::ApplicationDefault => {}
     }
     Ok(())
 }
@@ -1041,6 +1115,38 @@ accounts:
                 .unwrap_err()
                 .to_string()
                 .contains("http_path")
+        );
+    }
+
+    #[test]
+    fn version_two_accepts_a_typed_bigquery_provider() {
+        let yaml = r#"
+version: 2
+accounts:
+  - name: warehouse
+    provider:
+      type: bigquery
+      project: analytics-prod
+      location: US
+      production_schema: prod
+      auth: { type: application_default }
+"#;
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        config.validate().unwrap();
+        assert_eq!(config.accounts[0].database(), "analytics-prod");
+        assert!(matches!(
+            config.accounts[0].provider,
+            ProviderConfig::BigQuery(_)
+        ));
+
+        let invalid = yaml.replace("production_schema: prod", "production_schema: prod-data");
+        let config: Config = serde_yaml::from_str(&invalid).unwrap();
+        assert!(
+            config
+                .validate()
+                .unwrap_err()
+                .to_string()
+                .contains("production_schema")
         );
     }
 

--- a/src/dbt.rs
+++ b/src/dbt.rs
@@ -205,6 +205,7 @@ struct Profile {
 enum ProfileOutput {
     Snowflake(SnowflakeProfileOutput),
     Databricks(DatabricksProfileOutput),
+    BigQuery(BigQueryProfileOutput),
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -242,6 +243,18 @@ struct DatabricksProfileOutput {
     schema: String,
     token: String,
     threads: u16,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct BigQueryProfileOutput {
+    #[serde(rename = "type")]
+    kind: &'static str,
+    method: &'static str,
+    project: String,
+    dataset: String,
+    location: String,
+    threads: u16,
+    job_execution_timeout_seconds: u64,
 }
 
 impl Manifest {
@@ -1138,6 +1151,17 @@ fn write_profiles(
                     threads: config.dbt.threads,
                 })
             }
+            (ProviderConfig::BigQuery(bigquery), ResolvedAuth::BigQuery(_)) => {
+                ProfileOutput::BigQuery(BigQueryProfileOutput {
+                    kind: provider::dialect(account).dbt_adapter_name(),
+                    method: "oauth",
+                    project: bigquery.project.clone(),
+                    dataset: schema(account),
+                    location: bigquery.location.clone(),
+                    threads: config.dbt.threads,
+                    job_execution_timeout_seconds: config.safety.statement_timeout_seconds,
+                })
+            }
             _ => bail!(
                 "resolved auth provider does not match account {}",
                 account.name
@@ -1627,5 +1651,39 @@ accounts:
         assert!(profile.contains("catalog: analytics"));
         assert!(profile.contains("token: secret-token"));
         assert!(!profile.contains("warehouse:"));
+    }
+
+    #[test]
+    fn bigquery_profile_uses_adc_and_the_run_dataset() {
+        let yaml = r#"
+version: 2
+safety: { statement_timeout_seconds: 420 }
+accounts:
+  - name: warehouse
+    provider:
+      type: bigquery
+      project: analytics-prod
+      location: US
+      production_schema: prod
+      auth: { type: application_default }
+"#;
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        config.validate().unwrap();
+        let auth = BTreeMap::from([(
+            "warehouse".into(),
+            ResolvedAuth::BigQuery(crate::auth::BigQueryResolvedAuth {
+                token_provider: None,
+            }),
+        )]);
+        let dir = tempfile::tempdir().unwrap();
+        write_profiles(&config, &auth, dir.path(), |_| "check_run".into(), "tag").unwrap();
+        let profile = fs::read_to_string(dir.path().join("profiles.yml")).unwrap();
+        assert!(profile.contains("type: bigquery"));
+        assert!(profile.contains("method: oauth"));
+        assert!(profile.contains("project: analytics-prod"));
+        assert!(profile.contains("dataset: check_run"));
+        assert!(profile.contains("location: US"));
+        assert!(profile.contains("job_execution_timeout_seconds: 420"));
+        assert!(!profile.contains("dataset: prod"));
     }
 }

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -6,7 +6,8 @@ use uuid::Uuid;
 
 use crate::{
     auth,
-    config::{Config, DatabricksConfig, ProviderConfig, SnowflakeConfig},
+    bigquery::BigQueryClient,
+    config::{BigQueryConfig, Config, DatabricksConfig, ProviderConfig, SnowflakeConfig},
     databricks::DatabricksClient,
     dbt, lineage, metabase,
     provider::{QueryResult, Relation, SqlDialect, WarehouseProvider, dialect},
@@ -62,7 +63,7 @@ pub async fn run(config_path: &Path, write_test: bool) -> DoctorReport {
 
     for account in &config.accounts {
         let scope = format!("{}:{}", dialect(account).dbt_adapter_name(), account.name);
-        let auth_status = match auth::status(account) {
+        let auth_status = match auth::status(account).await {
             Ok(status) => status,
             Err(error) => {
                 report.fail(&scope, "credential", format!("{error:#}"));
@@ -118,6 +119,27 @@ pub async fn run(config_path: &Path, write_test: bool) -> DoctorReport {
                 ) {
                     Ok(client) => {
                         check_databricks(
+                            &client,
+                            provider,
+                            &scope,
+                            &config.safety.schema_prefix,
+                            write_test,
+                            &mut report,
+                        )
+                        .await
+                    }
+                    Err(error) => report.fail(&scope, "authentication", format!("{error:#}")),
+                }
+            }
+            ProviderConfig::BigQuery(provider) => {
+                match BigQueryClient::new(
+                    account,
+                    &resolved,
+                    query_tag,
+                    config.safety.statement_timeout_seconds,
+                ) {
+                    Ok(client) => {
+                        check_bigquery(
                             &client,
                             provider,
                             &scope,
@@ -289,6 +311,76 @@ async fn check_databricks(
         client,
         dialect,
         &account.catalog,
+        &account.production_schema,
+        schema_prefix,
+        clone_source,
+        scope,
+        write_test,
+        report,
+    )
+    .await;
+}
+
+async fn check_bigquery(
+    client: &BigQueryClient,
+    account: &BigQueryConfig,
+    scope: &str,
+    schema_prefix: &str,
+    write_test: bool,
+    report: &mut DoctorReport,
+) {
+    match client.execute("SELECT SESSION_USER()").await {
+        Ok(result) => match verify_bigquery_session(account, &result) {
+            Ok(identity) => report.pass(scope, "session", identity),
+            Err(error) => {
+                report.fail(scope, "session", format!("{error:#}"));
+                return;
+            }
+        },
+        Err(error) => {
+            report.fail(scope, "session", format!("{error:#}"));
+            return;
+        }
+    }
+    let dialect = SqlDialect::BigQuery;
+    let tables = client
+        .execute(&format!(
+            "SELECT table_name, table_type FROM {}.{}.INFORMATION_SCHEMA.TABLES ORDER BY table_name",
+            dialect.quote_identifier(&account.project),
+            dialect.quote_identifier(&account.production_schema),
+        ))
+        .await;
+    let mut clone_source = None;
+    match tables {
+        Ok(tables) => {
+            let relations = tables
+                .rows
+                .iter()
+                .filter_map(|row| row.first().and_then(|value| value.clone()))
+                .collect::<Vec<_>>();
+            clone_source = tables.rows.iter().find_map(|row| {
+                let kind = row.get(1)?.as_deref()?;
+                matches!(kind, "BASE TABLE" | "CLONE" | "SNAPSHOT")
+                    .then(|| row.first().and_then(|value| value.clone()))
+                    .flatten()
+            });
+            check_readable_relation(
+                client,
+                dialect,
+                &account.project,
+                &account.production_schema,
+                &relations,
+                scope,
+                report,
+            )
+            .await;
+        }
+        Err(error) => report.fail(scope, "production_read", format!("{error:#}")),
+    }
+    check_schema_lifecycle(
+        client,
+        dialect,
+        &account.project,
         &account.production_schema,
         schema_prefix,
         clone_source,
@@ -473,6 +565,19 @@ fn verify_databricks_session(account: &DatabricksConfig, result: &QueryResult) -
         }
     }
     Ok(values.join(" / "))
+}
+
+fn verify_bigquery_session(account: &BigQueryConfig, result: &QueryResult) -> Result<String> {
+    let identity = result
+        .rows
+        .first()
+        .and_then(|row| row.first())
+        .and_then(Option::as_deref)
+        .context("BigQuery session query returned no user")?;
+    Ok(format!(
+        "{identity} / {} / {}",
+        account.project, account.location
+    ))
 }
 
 fn relation_names(result: &QueryResult) -> Vec<String> {

--- a/src/init.rs
+++ b/src/init.rs
@@ -9,14 +9,16 @@ use directories::BaseDirs;
 use serde::Serialize;
 use serde_yaml::Value;
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct Options {
     pub profile: Option<String>,
+    pub provider: Option<String>,
     pub account: Option<String>,
     pub user: Option<String>,
     pub role: Option<String>,
     pub database: Option<String>,
     pub warehouse: Option<String>,
+    pub location: Option<String>,
     pub production_schema: Option<String>,
 }
 
@@ -34,13 +36,35 @@ struct GeneratedDbt<'a> {
 }
 
 #[derive(Serialize)]
-struct GeneratedAccount<'a> {
+#[serde(untagged)]
+enum GeneratedAccount<'a> {
+    Snowflake(GeneratedSnowflakeAccount<'a>),
+    Tagged(GeneratedTaggedAccount<'a>),
+}
+
+#[derive(Serialize)]
+struct GeneratedSnowflakeAccount<'a> {
     name: &'static str,
     account: &'a str,
     user: &'a str,
     role: &'a str,
     database: &'a str,
     warehouse: &'a str,
+    production_schema: &'a str,
+    auth: GeneratedAuth,
+}
+
+#[derive(Serialize)]
+struct GeneratedTaggedAccount<'a> {
+    name: &'static str,
+    provider: GeneratedBigQueryProvider<'a>,
+}
+
+#[derive(Serialize)]
+struct GeneratedBigQueryProvider<'a> {
+    r#type: &'static str,
+    project: &'a str,
+    location: &'a str,
     production_schema: &'a str,
     auth: GeneratedAuth,
 }
@@ -65,6 +89,20 @@ pub fn run(config_path: &Path, force: bool, options: Options) -> Result<()> {
 
     let defaults = discover_defaults(project_file);
     println!("Set up Embrasure for this dbt project.\n");
+
+    let provider = options
+        .provider
+        .clone()
+        .or_else(|| defaults.provider.clone())
+        .unwrap_or_else(|| "snowflake".into());
+    if provider.eq_ignore_ascii_case("bigquery") {
+        return run_bigquery(config_path, options, defaults);
+    }
+    if !provider.eq_ignore_ascii_case("snowflake") {
+        bail!(
+            "detected dbt adapter {provider}; init currently supports Snowflake and BigQuery projects"
+        );
+    }
 
     let profile = detected_or_required("dbt profile", options.profile.or(defaults.profile))?;
     let account = detected_or_required(
@@ -92,7 +130,7 @@ pub fn run(config_path: &Path, force: bool, options: Options) -> Result<()> {
             project_dir: ".",
             profile: &profile,
         },
-        accounts: vec![GeneratedAccount {
+        accounts: vec![GeneratedAccount::Snowflake(GeneratedSnowflakeAccount {
             name: "primary",
             account: &account,
             user: &user,
@@ -103,7 +141,7 @@ pub fn run(config_path: &Path, force: bool, options: Options) -> Result<()> {
             auth: GeneratedAuth {
                 r#type: "oauth_local",
             },
-        }],
+        })],
     };
 
     let yaml = serde_yaml::to_string(&generated).context("could not generate configuration")?;
@@ -112,6 +150,46 @@ pub fn run(config_path: &Path, force: bool, options: Options) -> Result<()> {
 
     println!(
         "\nCreated {}.\n\nNext:\n  embrasure auth login\n  embrasure doctor\n  embrasure check",
+        config_path.display()
+    );
+    Ok(())
+}
+
+fn run_bigquery(config_path: &Path, options: Options, defaults: Options) -> Result<()> {
+    let profile = detected_or_required("dbt profile", options.profile.or(defaults.profile))?;
+    let project = detected_or_required("BigQuery project", options.database.or(defaults.database))?;
+    let location = detected_or_required(
+        "BigQuery location",
+        options.location.or(defaults.location).or(Some("US".into())),
+    )?;
+    let production_schema = match options.production_schema {
+        Some(value) if !value.trim().is_empty() => value,
+        _ => required("Production dataset", Some("prod".to_owned()))?,
+    };
+    let generated = GeneratedConfig {
+        version: 2,
+        dbt: GeneratedDbt {
+            project_dir: ".",
+            profile: &profile,
+        },
+        accounts: vec![GeneratedAccount::Tagged(GeneratedTaggedAccount {
+            name: "primary",
+            provider: GeneratedBigQueryProvider {
+                r#type: "bigquery",
+                project: &project,
+                location: &location,
+                production_schema: &production_schema,
+                auth: GeneratedAuth {
+                    r#type: "application_default",
+                },
+            },
+        })],
+    };
+    let yaml = serde_yaml::to_string(&generated).context("could not generate configuration")?;
+    fs::write(config_path, yaml)
+        .with_context(|| format!("could not write {}", config_path.display()))?;
+    println!(
+        "\nCreated {}.\n\nEnsure Google Application Default Credentials are available, then run:\n  embrasure doctor\n  embrasure check",
         config_path.display()
     );
     Ok(())
@@ -185,11 +263,14 @@ fn discover_defaults(project_file: &Path) -> Options {
         return defaults;
     };
 
+    defaults.provider = mapping_string(output, "type");
     defaults.account = mapping_string(output, "account");
     defaults.user = mapping_string(output, "user");
     defaults.role = mapping_string(output, "role");
-    defaults.database = mapping_string(output, "database");
+    defaults.database =
+        mapping_string(output, "project").or_else(|| mapping_string(output, "database"));
     defaults.warehouse = mapping_string(output, "warehouse");
+    defaults.location = mapping_string(output, "location");
     defaults
 }
 

--- a/src/lineage.rs
+++ b/src/lineage.rs
@@ -51,7 +51,7 @@ struct ModelResponse {
     gaps: Vec<String>,
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 struct ParsedEdge {
     output_column: String,
     source_column: String,
@@ -61,7 +61,7 @@ struct ParsedEdge {
     source_relation: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 struct SqlIdentifier {
     name: String,
     quoted: bool,
@@ -582,6 +582,40 @@ mod tests {
                 && edge.source_relation == "analytics.raw.orders"
                 && edge.source_column == "customer_id"
         }));
+    }
+
+    #[test]
+    fn sqlglot_uses_bigquery_identifier_rules() {
+        let request = Request {
+            models: vec![ModelRequest {
+                unique_id: "model.project.summary",
+                sql: "select Customer_ID, safe_cast(Amount as float64) as Total from `Analytics.Raw.Orders`",
+            }],
+        };
+        let response = invoke(&request, Some(SqlDialect::BigQuery)).unwrap();
+        let edges = &response.models[0].edges;
+        assert!(response.models[0].gaps.is_empty());
+        assert!(
+            edges.iter().any(|edge| {
+                edge.output_column == "Customer_ID"
+                    && edge.source_relation == "`Analytics.Raw.Orders`"
+                    && edge.source_column == "customer_id"
+            }),
+            "{edges:#?}"
+        );
+    }
+
+    #[test]
+    fn sqlglot_bigquery_unnest_sources_do_not_crash_lineage_extraction() {
+        let request = Request {
+            models: vec![ModelRequest {
+                unique_id: "model.project.generated",
+                sql: "select order_id, concat('category_', cast(mod(order_id, 7) as string)) as category from unnest(generate_array(1, 10)) as order_id",
+            }],
+        };
+        let response = invoke(&request, Some(SqlDialect::BigQuery)).unwrap();
+        assert_eq!(response.models.len(), 1);
+        assert_eq!(response.models[0].unique_id, "model.project.generated");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod auth;
+mod bigquery;
 mod clean;
 #[cfg(feature = "cloud-demo")]
 mod cloud;
@@ -117,6 +118,8 @@ enum Command {
         #[arg(long, hide = true)]
         warehouse: Option<String>,
         #[arg(long, hide = true)]
+        location: Option<String>,
+        #[arg(long, hide = true)]
         production_schema: Option<String>,
     },
     /// Build and compare changed dbt models, then run configured query checks.
@@ -171,14 +174,14 @@ enum Command {
     },
     /// Check local tools, credentials, warehouse permissions, optional Metabase access, and available updates.
     Doctor {
-        /// Skip the temporary schema create/drop permission test.
+        /// Skip the temporary schema or dataset create/drop permission test.
         #[arg(long)]
         read_only: bool,
         /// Emit exactly one JSON document on stdout.
         #[arg(long)]
         json: bool,
     },
-    /// Manage interactive Snowflake browser sessions.
+    /// Inspect warehouse credentials or manage Snowflake browser sessions.
     Auth {
         #[command(subcommand)]
         command: AuthCommand,
@@ -194,9 +197,9 @@ enum Command {
         #[arg(value_enum)]
         shell: CompletionShell,
     },
-    /// List or remove old Embrasure-managed temporary schemas.
+    /// List or remove old Embrasure-managed temporary schemas or datasets.
     Clean {
-        /// Minimum schema age in hours.
+        /// Minimum schema or dataset age in hours.
         #[arg(long, default_value_t = 6)]
         older_than: u64,
         /// Remove matched schemas. Without this flag, only list them.
@@ -268,17 +271,20 @@ async fn main() -> ExitCode {
             role,
             database,
             warehouse,
+            location,
             production_schema,
         } => match init::run(
             &config,
             force,
             init::Options {
                 profile,
+                provider: None,
                 account,
                 user,
                 role,
                 database,
                 warehouse,
+                location,
                 production_schema,
             },
         ) {
@@ -508,7 +514,7 @@ async fn main() -> ExitCode {
                     Err(error) => fail(error),
                 }
             }
-            AuthCommand::Status { json } => match auth::status_from_config(&config) {
+            AuthCommand::Status { json } => match auth::status_from_config(&config).await {
                 Ok(statuses) => {
                     if json {
                         println!(

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 
 use crate::{
     auth::ResolvedAuth,
+    bigquery::BigQueryClient,
     config::{AccountConfig, ProviderConfig},
     databricks::DatabricksClient,
     snowflake::SnowflakeClient,
@@ -45,6 +46,7 @@ impl Relation {
 pub enum SqlDialect {
     Snowflake,
     Databricks,
+    BigQuery,
 }
 
 impl SqlDialect {
@@ -52,6 +54,7 @@ impl SqlDialect {
         match self {
             Self::Snowflake => "snowflake",
             Self::Databricks => "databricks",
+            Self::BigQuery => "bigquery",
         }
     }
 
@@ -59,6 +62,7 @@ impl SqlDialect {
         match self {
             Self::Snowflake => "upper",
             Self::Databricks => "lower",
+            Self::BigQuery => "preserve",
         }
     }
 
@@ -66,6 +70,7 @@ impl SqlDialect {
         match self {
             Self::Snowflake => "snowflake",
             Self::Databricks => "databricks",
+            Self::BigQuery => "bigquery",
         }
     }
 
@@ -73,6 +78,7 @@ impl SqlDialect {
         match self {
             Self::Snowflake => format!("\"{}\"", value.replace('"', "\"\"")),
             Self::Databricks => format!("`{}`", value.replace('`', "``")),
+            Self::BigQuery => format!("`{}`", value.replace('`', "\\`")),
         }
     }
 
@@ -82,6 +88,7 @@ impl SqlDialect {
             Self::Snowflake => value.to_owned(),
             Self::Databricks if !quoted.unwrap_or(false) => value.to_ascii_lowercase(),
             Self::Databricks => value.to_owned(),
+            Self::BigQuery => value.to_owned(),
         }
     }
 
@@ -91,20 +98,21 @@ impl SqlDialect {
                 format!("CREATE TRANSIENT TABLE {} AS {query}", target.sql(self))
             }
             Self::Databricks => format!("CREATE TABLE {} AS {query}", target.sql(self)),
+            Self::BigQuery => format!("CREATE TABLE {} AS {query}", target.sql(self)),
         }
     }
 
     pub fn cast_text(self, expression: &str) -> String {
         match self {
             Self::Snowflake => format!("{expression}::VARCHAR"),
-            Self::Databricks => format!("CAST({expression} AS STRING)"),
+            Self::Databricks | Self::BigQuery => format!("CAST({expression} AS STRING)"),
         }
     }
 
     pub fn to_text(self, expression: &str) -> String {
         match self {
             Self::Snowflake => format!("TO_VARCHAR({expression})"),
-            Self::Databricks => format!("CAST({expression} AS STRING)"),
+            Self::Databricks | Self::BigQuery => format!("CAST({expression} AS STRING)"),
         }
     }
 
@@ -112,6 +120,7 @@ impl SqlDialect {
         match self {
             Self::Snowflake => format!("{expression}::DOUBLE"),
             Self::Databricks => format!("CAST({expression} AS DOUBLE)"),
+            Self::BigQuery => format!("CAST({expression} AS FLOAT64)"),
         }
     }
 
@@ -119,20 +128,31 @@ impl SqlDialect {
         match self {
             Self::Snowflake => format!("EQUAL_NULL({left}, {right})"),
             Self::Databricks => format!("{left} <=> {right}"),
+            Self::BigQuery => format!("{left} IS NOT DISTINCT FROM {right}"),
+        }
+    }
+
+    pub fn full_join_equal(self, left: &str, right: &str) -> String {
+        match self {
+            Self::BigQuery => format!("({left} = {right} OR ({left} IS NULL AND {right} IS NULL))"),
+            Self::Snowflake | Self::Databricks => self.null_safe_equal(left, right),
         }
     }
 
     pub fn conditional(self, condition: &str, when_true: &str, when_false: &str) -> String {
         match self {
             Self::Snowflake => format!("IFF({condition}, {when_true}, {when_false})"),
-            Self::Databricks => {
+            Self::Databricks | Self::BigQuery => {
                 format!("CASE WHEN {condition} THEN {when_true} ELSE {when_false} END")
             }
         }
     }
 
     pub fn count_if(self, condition: &str) -> String {
-        format!("COUNT_IF({condition})")
+        match self {
+            Self::BigQuery => format!("COUNTIF({condition})"),
+            Self::Snowflake | Self::Databricks => format!("COUNT_IF({condition})"),
+        }
     }
 
     pub fn approximate_distinct(self, expression: &str) -> String {
@@ -140,18 +160,33 @@ impl SqlDialect {
     }
 
     pub fn supports_column_metrics(self, data_type: &str) -> bool {
-        self != Self::Databricks || !self.is_unsupported_value(data_type)
+        !matches!(self, Self::Databricks | Self::BigQuery) || !self.is_unsupported_value(data_type)
     }
 
     pub fn approximate_percentile(self, expression: &str, percentile: &str) -> String {
         match self {
             Self::Snowflake => format!("APPROX_PERCENTILE({expression}, {percentile})"),
             Self::Databricks => format!("PERCENTILE_APPROX({expression}, {percentile})"),
+            Self::BigQuery => {
+                let offset = percentile
+                    .parse::<f64>()
+                    .map(|value| (value * 100.0).round() as u32)
+                    .unwrap_or(50);
+                format!("APPROX_QUANTILES({expression}, 100)[OFFSET({offset})]")
+            }
         }
     }
 
     pub fn stable_hash(self, expressions: &[String]) -> String {
-        format!("HASH({})", expressions.join(", "))
+        match self {
+            Self::BigQuery => format!(
+                "FARM_FINGERPRINT(TO_JSON_STRING(STRUCT({})))",
+                expressions.join(", ")
+            ),
+            Self::Snowflake | Self::Databricks => {
+                format!("HASH({})", expressions.join(", "))
+            }
+        }
     }
 
     pub fn is_numeric(self, data_type: &str) -> bool {
@@ -194,6 +229,17 @@ impl SqlDialect {
                             | "decimal"
                     )
             }
+            Self::BigQuery => matches!(
+                data_type.to_ascii_uppercase().as_str(),
+                "INT64"
+                    | "INTEGER"
+                    | "FLOAT64"
+                    | "FLOAT"
+                    | "NUMERIC"
+                    | "DECIMAL"
+                    | "BIGNUMERIC"
+                    | "BIGDECIMAL"
+            ),
         }
     }
 
@@ -214,6 +260,14 @@ impl SqlDialect {
                     .next()
                     .unwrap_or_default(),
                 "ARRAY" | "MAP" | "STRUCT" | "VARIANT" | "BINARY" | "GEOGRAPHY" | "GEOMETRY"
+            ),
+            Self::BigQuery => !matches!(
+                data_type
+                    .to_ascii_uppercase()
+                    .split(['<', '('])
+                    .next()
+                    .unwrap_or_default(),
+                "ARRAY" | "STRUCT" | "GEOGRAPHY" | "JSON" | "INTERVAL"
             ),
         }
     }
@@ -237,6 +291,15 @@ impl SqlDialect {
                     .to_ascii_uppercase()
                     .as_str(),
                 "ARRAY" | "MAP" | "STRUCT" | "VARIANT" | "GEOGRAPHY" | "GEOMETRY"
+            ),
+            Self::BigQuery => matches!(
+                data_type
+                    .split(['<', '(', ' '])
+                    .next()
+                    .unwrap_or(data_type)
+                    .to_ascii_uppercase()
+                    .as_str(),
+                "ARRAY" | "STRUCT" | "RECORD" | "GEOGRAPHY" | "JSON" | "INTERVAL"
             ),
         }
     }
@@ -290,6 +353,12 @@ pub fn connect(
             query_tag,
             timeout_seconds,
         )?)),
+        ProviderConfig::BigQuery(_) => Ok(Arc::new(BigQueryClient::new(
+            account,
+            auth,
+            query_tag,
+            timeout_seconds,
+        )?)),
     }
 }
 
@@ -297,6 +366,7 @@ pub fn dialect(account: &AccountConfig) -> SqlDialect {
     match &account.provider {
         ProviderConfig::Snowflake(_) => SqlDialect::Snowflake,
         ProviderConfig::Databricks(_) => SqlDialect::Databricks,
+        ProviderConfig::BigQuery(_) => SqlDialect::BigQuery,
     }
 }
 
@@ -334,5 +404,19 @@ mod tests {
             databricks.null_safe_equal("left", "right"),
             "left <=> right"
         );
+        let bigquery = SqlDialect::BigQuery;
+        assert_eq!(bigquery.quote_identifier("odd`name"), "`odd\\`name`");
+        assert_eq!(bigquery.normalize_identifier("Mixed", None), "Mixed");
+        assert_eq!(bigquery.count_if("value IS NULL"), "COUNTIF(value IS NULL)");
+        assert_eq!(
+            bigquery.approximate_percentile("value", "0.95"),
+            "APPROX_QUANTILES(value, 100)[OFFSET(95)]"
+        );
+        assert_eq!(
+            bigquery.full_join_equal("C.key", "P.key"),
+            "(C.key = P.key OR (C.key IS NULL AND P.key IS NULL))"
+        );
+        assert!(bigquery.is_numeric("BIGNUMERIC"));
+        assert!(!bigquery.supports_column_metrics("ARRAY<STRING>"));
     }
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -949,7 +949,7 @@ async fn compare_keyed<E: QueryExecutor + ?Sized>(
     let join = keys
         .iter()
         .map(|pair| {
-            dialect.null_safe_equal(
+            dialect.full_join_equal(
                 &format!("C.{}", dialect.quote_identifier(&pair.0.name)),
                 &format!("P.{}", dialect.quote_identifier(&pair.1.name)),
             )
@@ -1196,7 +1196,7 @@ async fn compare_unkeyed<E: QueryExecutor + ?Sized>(
         .collect::<Vec<_>>();
     let join = canonical
         .iter()
-        .map(|name| dialect.null_safe_equal(&format!("C.{name}"), &format!("P.{name}")))
+        .map(|name| dialect.full_join_equal(&format!("C.{name}"), &format!("P.{name}")))
         .collect::<Vec<_>>()
         .join(" AND ");
     let cte = format!(

--- a/src/sqlglot_lineage.py
+++ b/src/sqlglot_lineage.py
@@ -107,9 +107,13 @@ def trace_model(model, dialect, unquoted_case):
                 continue
 
             source = exp.to_column(leaf.name)
+            source_name = source.name
+            if not source_name:
+                gaps.append(f"{output_column} has an unresolved source column")
+                continue
             source_column = normalize_unquoted(
-                source.name,
-                bool(source.this.args.get("quoted")),
+                source_name,
+                bool(source.this and source.this.args.get("quoted")),
                 unquoted_case,
             )
             if source_column == "*":
@@ -118,10 +122,6 @@ def trace_model(model, dialect, unquoted_case):
                     "without an authoritative input schema"
                 )
                 continue
-            if not source_column:
-                gaps.append(f"{output_column} has an unresolved source column")
-                continue
-
             edges.append(
                 {
                     "output_column": output_column,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -134,6 +134,52 @@ fn init_reuses_values_from_the_active_dbt_profile() {
 }
 
 #[test]
+fn init_generates_a_typed_bigquery_config() {
+    let directory = tempfile::tempdir().unwrap();
+    let profiles_directory = directory.path().join("profiles");
+    fs::create_dir(&profiles_directory).unwrap();
+    fs::write(
+        directory.path().join("dbt_project.yml"),
+        "name: analytics\nprofile: analytics\n",
+    )
+    .unwrap();
+    fs::write(
+        profiles_directory.join("profiles.yml"),
+        r#"analytics:
+  target: dev
+  outputs:
+    dev:
+      type: bigquery
+      method: oauth
+      project: analytics-prod
+      dataset: developer
+      location: europe-west1
+"#,
+    )
+    .unwrap();
+
+    Command::cargo_bin("embrasure")
+        .unwrap()
+        .current_dir(directory.path())
+        .env("DBT_PROFILES_DIR", &profiles_directory)
+        .arg("init")
+        .write_stdin("production\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Production dataset [prod]"))
+        .stdout(predicate::str::contains("BigQuery project").not());
+
+    let config = fs::read_to_string(directory.path().join("embrasure-check.yml")).unwrap();
+    assert!(config.contains("version: 2"));
+    assert!(config.contains("type: bigquery"));
+    assert!(config.contains("project: analytics-prod"));
+    assert!(config.contains("location: europe-west1"));
+    assert!(config.contains("production_schema: production"));
+    assert!(config.contains("type: application_default"));
+    assert!(!config.contains("dataset: developer"));
+}
+
+#[test]
 fn doctor_returns_execution_failure_for_a_missing_config() {
     Command::cargo_bin("embrasure")
         .unwrap()


### PR DESCRIPTION
## Summary

- add a typed BigQuery provider using Application Default Credentials and the BigQuery REST API
- support query execution, dbt profiles, SQL dialect differences, incremental table clones and copies, temporary dataset lifecycle, doctor, clean, and init
- document configuration, permissions, security behavior, and provider limitations
- add regression coverage for API URL construction, BigQuery full-join semantics, nested result types, profile generation, init, and SQLGlot lineage

## Validation

- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-targets --all-features --locked: 126 unit tests and 18 CLI tests passed
- live BigQuery doctor: ADC, session, production read, clone, create, and guarded delete passed
- live dbt end-to-end check against origin/main: 3 models built and compared, 12,345-row incremental clone path passed, downstream view and keyed query diff passed, zero findings and zero coverage gaps
- deliberate aggregate regression returned exit 1 and detected all 7 changed keyed rows
- clean dry-run and guarded deletion passed on a non-empty managed dataset
- all disposable BigQuery datasets were removed after testing