### PR TITLE
Make CLI validation canonical in Cloud

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "embrasure"
 path = "src/main.rs"
 
 [features]
-default = []
+default = ["cloud-demo"]
 cloud-demo = ["dep:keyring"]
 
 [dependencies]

--- a/src/cloud.rs
+++ b/src/cloud.rs
@@ -13,6 +13,7 @@ use std::{
 use anyhow::{Context, Result, bail};
 use chrono::{DateTime, Utc};
 use directories::ProjectDirs;
+use globset::Glob;
 use keyring::Entry;
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
@@ -221,20 +222,34 @@ pub fn prepare_snapshot(
     let mut candidates = changed_paths(&repository_root, base_ref)?;
     candidates.sort_by(|a, b| a.0.cmp(&b.0));
     candidates.dedup_by(|a, b| a.0 == b.0);
+    let external_matchers = config
+        .external_changes
+        .iter()
+        .map(|mapping| {
+            Glob::new(&mapping.path)
+                .with_context(|| format!("invalid external change glob {}", mapping.path))
+                .map(|glob| glob.compile_matcher())
+        })
+        .collect::<Result<Vec<_>>>()?;
 
     let mut files = Vec::new();
     let mut total_bytes = 0;
     for (repo_path, status) in candidates {
         let relative = Path::new(&repo_path);
+        let normalized = normalize_snapshot_path(relative)?;
         let project_path = if dbt_root.is_empty() {
-            relative
-        } else if let Ok(path) = relative.strip_prefix(&dbt_root) {
-            path
+            Some(relative)
         } else {
-            continue;
+            relative.strip_prefix(&dbt_root).ok()
         };
-        let normalized = normalize_snapshot_path(project_path)?;
-        if !eligible(&normalized) {
+        let eligible_project_file = project_path
+            .map(normalize_snapshot_path)
+            .transpose()?
+            .is_some_and(|path| eligible(&path));
+        let configured_external_file = external_matchers
+            .iter()
+            .any(|matcher| matcher.is_match(&normalized));
+        if excluded(&normalized) || (!eligible_project_file && !configured_external_file) {
             continue;
         }
         let absolute = repository_root.join(relative);
@@ -322,19 +337,14 @@ pub fn prepare_snapshot(
         incremental_mode: options.incremental_mode,
         select: options.select.clone(),
     };
-    let fingerprint = hex_digest(
-        format!(
-            "{}\0{}\0{}\0{}\0{}\0{}\0{:?}",
-            repository_root.display(),
-            dbt_root,
-            base_sha,
-            snapshot_hash,
-            env!("CARGO_PKG_VERSION"),
-            hex_digest(&config_bytes),
-            options,
-        )
-        .as_bytes(),
-    );
+    let fingerprint = snapshot_fingerprint(
+        &repository_root,
+        &dbt_root,
+        &base_sha,
+        &snapshot_hash,
+        &validation_config,
+        &validation_options,
+    )?;
     Ok(PreparedSnapshot {
         dbt_root,
         owner,
@@ -898,6 +908,16 @@ fn normalize_snapshot_path(path: &Path) -> Result<String> {
 }
 
 fn eligible(path: &str) -> bool {
+    if excluded(path) {
+        return false;
+    }
+    let lower = path.to_ascii_lowercase();
+    [".sql", ".yml", ".yaml", ".py", ".json", ".md", ".csv"]
+        .iter()
+        .any(|suffix| lower.ends_with(suffix))
+}
+
+fn excluded(path: &str) -> bool {
     let lower = path.to_ascii_lowercase();
     let parts = lower.split('/').collect::<Vec<_>>();
     if parts.iter().any(|part| {
@@ -918,11 +938,9 @@ fn eligible(path: &str) -> bool {
             )
         })
     {
-        return false;
+        return true;
     }
-    [".sql", ".yml", ".yaml", ".py", ".json", ".md", ".csv"]
-        .iter()
-        .any(|suffix| lower.ends_with(suffix))
+    false
 }
 
 fn contains_secret(value: &str) -> bool {
@@ -945,6 +963,33 @@ fn contains_secret(value: &str) -> bool {
 
 fn hex_digest(bytes: &[u8]) -> String {
     encode_hex(&Sha256::digest(bytes))
+}
+
+fn snapshot_fingerprint(
+    repository_root: &Path,
+    dbt_root: &str,
+    base_sha: &str,
+    snapshot_hash: &str,
+    validation_config: &ValidationConfigSnapshot,
+    validation_options: &ValidationOptionsSnapshot,
+) -> Result<String> {
+    let config = serde_json::to_vec(validation_config)?;
+    let options = serde_json::to_vec(validation_options)?;
+    let parts = [
+        repository_root.to_string_lossy().as_bytes().to_vec(),
+        dbt_root.as_bytes().to_vec(),
+        base_sha.as_bytes().to_vec(),
+        snapshot_hash.as_bytes().to_vec(),
+        env!("CARGO_PKG_VERSION").as_bytes().to_vec(),
+        config,
+        options,
+    ];
+    let mut fingerprint = Sha256::new();
+    for part in parts {
+        fingerprint.update((part.len() as u64).to_be_bytes());
+        fingerprint.update(part);
+    }
+    Ok(encode_hex(&fingerprint.finalize()))
 }
 
 fn encode_hex(bytes: &[u8]) -> String {
@@ -1089,6 +1134,139 @@ mod tests {
     #[test]
     fn seed_files_are_eligible_for_the_exact_cloud_snapshot() {
         assert!(eligible("seeds/orders.csv"));
+    }
+
+    #[test]
+    fn snapshot_fingerprint_uses_only_the_serialized_cloud_contract() {
+        let repository = Path::new("/tmp/example-repository");
+        let options = ValidationOptionsSnapshot {
+            mode: Some(ComparisonMode::Quick),
+            downstream: Some(DownstreamPolicy::All),
+            critical_tags: Some(vec!["finance".into()]),
+            incremental_mode: Some(IncrementalMode::FullRefresh),
+            select: vec!["orders".into()],
+        };
+        let first_config = ValidationConfigSnapshot {
+            sha256: "a".repeat(64),
+            content_utf8: "version: 2\n".into(),
+            repository_path: Some("embrasure-check.yml".into()),
+        };
+        let moved_config = ValidationConfigSnapshot {
+            repository_path: Some("config/embrasure-check.yml".into()),
+            ..first_config.clone()
+        };
+        let first = snapshot_fingerprint(
+            repository,
+            "analytics",
+            &"b".repeat(40),
+            &"c".repeat(64),
+            &first_config,
+            &options,
+        )
+        .unwrap();
+        let repeated = snapshot_fingerprint(
+            repository,
+            "analytics",
+            &"b".repeat(40),
+            &"c".repeat(64),
+            &first_config,
+            &options,
+        )
+        .unwrap();
+        let moved = snapshot_fingerprint(
+            repository,
+            "analytics",
+            &"b".repeat(40),
+            &"c".repeat(64),
+            &moved_config,
+            &options,
+        )
+        .unwrap();
+
+        assert_eq!(first, repeated);
+        assert_ne!(first, moved);
+    }
+
+    #[test]
+    fn snapshot_includes_configured_external_changes_with_repository_paths() {
+        fn run_git(root: &Path, args: &[&str]) {
+            let output = std::process::Command::new("git")
+                .args(args)
+                .current_dir(root)
+                .output()
+                .unwrap();
+            assert!(
+                output.status.success(),
+                "{}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+
+        let repo = tempfile::tempdir().unwrap();
+        run_git(repo.path(), &["init", "--quiet"]);
+        run_git(repo.path(), &["config", "user.name", "Embrasure Test"]);
+        run_git(repo.path(), &["config", "user.email", "test@embrasure.ai"]);
+        run_git(
+            repo.path(),
+            &[
+                "remote",
+                "add",
+                "origin",
+                "https://github.com/EmbrasureAI/demo.git",
+            ],
+        );
+        fs::create_dir_all(repo.path().join("analytics/models")).unwrap();
+        fs::create_dir_all(repo.path().join("shared")).unwrap();
+        fs::write(
+            repo.path().join("analytics/models/orders.sql"),
+            "select 1\n",
+        )
+        .unwrap();
+        fs::write(repo.path().join("shared/metrics.lock"), "one\n").unwrap();
+        let config_path = repo.path().join("embrasure-check.yml");
+        fs::write(
+            &config_path,
+            r#"
+version: 1
+dbt: { project_dir: analytics }
+accounts:
+  - name: primary
+    account: org-account
+    user: ci
+    role: ci
+    database: analytics
+    warehouse: ci
+    production_schema: prod
+    auth: { type: oauth, token_env: TOKEN }
+external_changes:
+  - path: shared/*.lock
+    models: [orders]
+"#,
+        )
+        .unwrap();
+        run_git(repo.path(), &["add", "."]);
+        run_git(repo.path(), &["commit", "--quiet", "-m", "base"]);
+        fs::write(
+            repo.path().join("analytics/models/orders.sql"),
+            "select 2\n",
+        )
+        .unwrap();
+        fs::write(repo.path().join("shared/metrics.lock"), "two\n").unwrap();
+
+        let mut config = Config::load(&config_path).unwrap();
+        config.resolve_from(&config_path).unwrap();
+        let snapshot =
+            prepare_snapshot(&config_path, &config, "HEAD", &CheckOptions::default()).unwrap();
+        let paths = snapshot
+            .files
+            .iter()
+            .map(|file| file.path.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            paths,
+            vec!["analytics/models/orders.sql", "shared/metrics.lock"]
+        );
     }
 
     #[test]

--- a/src/cloud.rs
+++ b/src/cloud.rs
@@ -21,6 +21,7 @@ use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 use tokio::net::TcpListener;
 use url::Url;
+use uuid::Uuid;
 
 use crate::{
     config::{ComparisonMode, Config, DownstreamPolicy, IncrementalMode},
@@ -418,7 +419,8 @@ pub async fn handoff(
     intent: &str,
 ) -> Result<HandoffReceipt> {
     let mut session = valid_session().await?;
-    let payload = handoff_payload(snapshot, report, base_ref, intent);
+    let idempotency_key = format!("cli:{}", Uuid::new_v4());
+    let payload = handoff_payload(snapshot, report, base_ref, intent, &idempotency_key);
     let mut response = send_handoff(&session, &payload).await?;
     if response.status() == StatusCode::UNAUTHORIZED {
         session = refresh_session(&session).await?;
@@ -433,9 +435,10 @@ fn handoff_payload(
     report: &Report,
     base_ref: &str,
     intent: &str,
+    idempotency_key: &str,
 ) -> Value {
     json!({
-        "idempotency_key": format!("cli:{}", snapshot.fingerprint),
+        "idempotency_key": idempotency_key,
         "repository": {
             "provider": "github",
             "owner": snapshot.owner,
@@ -1111,7 +1114,13 @@ mod tests {
             total_bytes: 0,
         };
         let report = Report::empty("origin/main".into(), crate::config::Thresholds::default());
-        let payload = handoff_payload(&snapshot, &report, "origin/main", "Preserve totals");
+        let payload = handoff_payload(
+            &snapshot,
+            &report,
+            "origin/main",
+            "Preserve totals",
+            "cli:request-1",
+        );
 
         assert_eq!(payload["validation_config"]["content_utf8"], config);
         assert_eq!(
@@ -1129,6 +1138,7 @@ mod tests {
             "full_refresh"
         );
         assert_eq!(payload["validation_options"]["select"][0], "orders");
+        assert_eq!(payload["idempotency_key"], "cli:request-1");
     }
 
     #[test]

--- a/src/cloud.rs
+++ b/src/cloud.rs
@@ -21,7 +21,13 @@ use sha2::{Digest, Sha256};
 use tokio::net::TcpListener;
 use url::Url;
 
-use crate::{config::Config, git, loopback, report::Report, run::CheckOptions, style, update};
+use crate::{
+    config::{ComparisonMode, Config, DownstreamPolicy, IncrementalMode},
+    git, loopback,
+    report::Report,
+    run::CheckOptions,
+    style, update,
+};
 
 const KEYCHAIN_SERVICE: &str = "ai.embrasure.cli.cloud";
 const KEYCHAIN_ACCOUNT: &str = "session";
@@ -65,6 +71,23 @@ struct ChangedFile {
     content_utf8: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize)]
+struct ValidationConfigSnapshot {
+    sha256: String,
+    content_utf8: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    repository_path: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct ValidationOptionsSnapshot {
+    mode: Option<ComparisonMode>,
+    downstream: Option<DownstreamPolicy>,
+    critical_tags: Option<Vec<String>>,
+    incremental_mode: Option<IncrementalMode>,
+    select: Vec<String>,
+}
+
 #[derive(Debug, Clone)]
 pub struct PreparedSnapshot {
     dbt_root: String,
@@ -75,6 +98,8 @@ pub struct PreparedSnapshot {
     snapshot_hash: String,
     fingerprint: String,
     files: Vec<ChangedFile>,
+    validation_config: ValidationConfigSnapshot,
+    validation_options: ValidationOptionsSnapshot,
     total_bytes: usize,
 }
 
@@ -263,7 +288,40 @@ pub fn prepare_snapshot(
         manifest.update(b"\n");
     }
     let snapshot_hash = encode_hex(&manifest.finalize());
-    let config_bytes = fs::read(config_path).unwrap_or_default();
+    let canonical_config_path = config_path.canonicalize().with_context(|| {
+        format!(
+            "could not resolve validation config {}",
+            config_path.display()
+        )
+    })?;
+    let config_bytes = fs::read(&canonical_config_path)
+        .with_context(|| format!("could not read validation config {}", config_path.display()))?;
+    if config_bytes.len() > MAX_FILE_BYTES {
+        bail!("validation config exceeds the 256 KB upload limit");
+    }
+    let config_content =
+        String::from_utf8(config_bytes.clone()).context("validation config is not UTF-8 text")?;
+    if contains_secret(&config_content) {
+        bail!(
+            "validation config appears to contain a secret; use environment-variable references instead"
+        );
+    }
+    let validation_config = ValidationConfigSnapshot {
+        sha256: hex_digest(&config_bytes),
+        content_utf8: config_content,
+        repository_path: canonical_config_path
+            .strip_prefix(&repository_root)
+            .ok()
+            .map(normalize_snapshot_path)
+            .transpose()?,
+    };
+    let validation_options = ValidationOptionsSnapshot {
+        mode: options.mode,
+        downstream: options.downstream,
+        critical_tags: options.critical_tags.clone(),
+        incremental_mode: options.incremental_mode,
+        select: options.select.clone(),
+    };
     let fingerprint = hex_digest(
         format!(
             "{}\0{}\0{}\0{}\0{}\0{}\0{:?}",
@@ -286,6 +344,8 @@ pub fn prepare_snapshot(
         snapshot_hash,
         fingerprint,
         files,
+        validation_config,
+        validation_options,
         total_bytes,
     })
 }
@@ -327,7 +387,7 @@ fn cache_is_reusable(
 ) -> bool {
     cached_fingerprint == snapshot_fingerprint
         && cache_is_fresh(saved_at)
-        && report_schema_version == 3
+        && report_schema_version == 4
 }
 
 pub fn save_review(snapshot: &PreparedSnapshot, report: &Report) -> Result<()> {
@@ -379,6 +439,8 @@ fn handoff_payload(
         "intent_context": intent,
         "changed_files": snapshot.files,
         "local_review": report,
+        "validation_config": snapshot.validation_config,
+        "validation_options": snapshot.validation_options,
         "cli": {"version": env!("CARGO_PKG_VERSION"), "platform": env::consts::OS},
         "notify_slack": true,
     })
@@ -731,8 +793,6 @@ fn git_path(cwd: &Path, args: &[&str]) -> Result<PathBuf> {
 }
 
 fn changed_paths(root: &Path, base: &str) -> Result<Vec<(String, String)>> {
-    // Cloud snapshots intentionally follow tracked Git diff output only.
-    // Follow-up: decide whether cloud handoffs should include untracked files.
     let output = git::output(root, &["diff", "--name-status", "-z", base, "--"])?;
     if !output.status.success() {
         bail!(
@@ -749,15 +809,33 @@ fn changed_paths(root: &Path, base: &str) -> Result<Vec<(String, String)>> {
     let mut index = 0;
     while index + 1 < parts.len() {
         let code = String::from_utf8_lossy(parts[index]);
-        let status = match code.chars().next().unwrap_or('M') {
-            'A' => "added",
-            'D' => "deleted",
-            _ => "modified",
-        };
-        let path_index = if code.starts_with('R') || code.starts_with('C') {
-            index + 2
+        if code.starts_with('R') {
+            if index + 2 >= parts.len() {
+                break;
+            }
+            rows.push((
+                String::from_utf8(parts[index + 1].to_vec())?,
+                "deleted".into(),
+            ));
+            rows.push((
+                String::from_utf8(parts[index + 2].to_vec())?,
+                "added".into(),
+            ));
+            index += 3;
+            continue;
+        }
+        let (path_index, status, width) = if code.starts_with('C') {
+            (index + 2, "added", 3)
         } else {
-            index + 1
+            (
+                index + 1,
+                match code.chars().next().unwrap_or('M') {
+                    'A' => "added",
+                    'D' => "deleted",
+                    _ => "modified",
+                },
+                2,
+            )
         };
         if path_index >= parts.len() {
             break;
@@ -766,11 +844,21 @@ fn changed_paths(root: &Path, base: &str) -> Result<Vec<(String, String)>> {
             String::from_utf8(parts[path_index].to_vec())?,
             status.into(),
         ));
-        index += if code.starts_with('R') || code.starts_with('C') {
-            3
-        } else {
-            2
-        };
+        index += width;
+    }
+    let untracked = git::output(root, &["ls-files", "--others", "--exclude-standard", "-z"])?;
+    if !untracked.status.success() {
+        bail!(
+            "could not inspect untracked working-tree files: {}",
+            String::from_utf8_lossy(&untracked.stderr).trim()
+        );
+    }
+    for path in untracked
+        .stdout
+        .split(|byte| *byte == 0)
+        .filter(|part| !part.is_empty())
+    {
+        rows.push((String::from_utf8(path.to_vec())?, "added".into()));
     }
     Ok(rows)
 }
@@ -832,7 +920,7 @@ fn eligible(path: &str) -> bool {
     {
         return false;
     }
-    [".sql", ".yml", ".yaml", ".py", ".json", ".md"]
+    [".sql", ".yml", ".yaml", ".py", ".json", ".md", ".csv"]
         .iter()
         .any(|suffix| lower.ends_with(suffix))
 }
@@ -952,6 +1040,96 @@ mod tests {
     }
 
     #[test]
+    fn handoff_includes_the_exact_hashed_validation_config() {
+        let config = "version: 2\naccounts: []\n";
+        let snapshot = PreparedSnapshot {
+            dbt_root: "analytics".into(),
+            owner: "EmbrasureAI".into(),
+            name: "demo".into(),
+            base_sha: "a".repeat(40),
+            head_sha: Some("b".repeat(40)),
+            snapshot_hash: "c".repeat(64),
+            fingerprint: "d".repeat(64),
+            files: vec![],
+            validation_config: ValidationConfigSnapshot {
+                sha256: hex_digest(config.as_bytes()),
+                content_utf8: config.into(),
+                repository_path: Some("embrasure-check.yml".into()),
+            },
+            validation_options: ValidationOptionsSnapshot {
+                mode: Some(ComparisonMode::Quick),
+                downstream: Some(DownstreamPolicy::All),
+                critical_tags: Some(vec!["critical".into()]),
+                incremental_mode: Some(IncrementalMode::FullRefresh),
+                select: vec!["orders".into()],
+            },
+            total_bytes: 0,
+        };
+        let report = Report::empty("origin/main".into(), crate::config::Thresholds::default());
+        let payload = handoff_payload(&snapshot, &report, "origin/main", "Preserve totals");
+
+        assert_eq!(payload["validation_config"]["content_utf8"], config);
+        assert_eq!(
+            payload["validation_config"]["repository_path"],
+            "embrasure-check.yml"
+        );
+        assert_eq!(
+            payload["validation_config"]["sha256"],
+            hex_digest(config.as_bytes())
+        );
+        assert_eq!(payload["validation_options"]["mode"], "quick");
+        assert_eq!(payload["validation_options"]["downstream"], "all");
+        assert_eq!(
+            payload["validation_options"]["incremental_mode"],
+            "full_refresh"
+        );
+        assert_eq!(payload["validation_options"]["select"][0], "orders");
+    }
+
+    #[test]
+    fn seed_files_are_eligible_for_the_exact_cloud_snapshot() {
+        assert!(eligible("seeds/orders.csv"));
+    }
+
+    #[test]
+    fn snapshot_changes_preserve_renames_and_untracked_files() {
+        fn run_git(root: &Path, args: &[&str]) {
+            let output = std::process::Command::new("git")
+                .args(args)
+                .current_dir(root)
+                .output()
+                .unwrap();
+            assert!(
+                output.status.success(),
+                "{}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+
+        let repo = tempfile::tempdir().unwrap();
+        run_git(repo.path(), &["init", "--quiet"]);
+        run_git(repo.path(), &["config", "user.name", "Embrasure Test"]);
+        run_git(repo.path(), &["config", "user.email", "test@embrasure.ai"]);
+        fs::create_dir(repo.path().join("models")).unwrap();
+        fs::write(repo.path().join("models/old.sql"), "select 1\n").unwrap();
+        run_git(repo.path(), &["add", "."]);
+        run_git(repo.path(), &["commit", "--quiet", "-m", "base"]);
+        run_git(repo.path(), &["mv", "models/old.sql", "models/new.sql"]);
+        fs::write(repo.path().join("models/untracked.sql"), "select 2\n").unwrap();
+
+        let mut changes = changed_paths(repo.path(), "HEAD").unwrap();
+        changes.sort();
+        assert_eq!(
+            changes,
+            vec![
+                ("models/new.sql".into(), "added".into()),
+                ("models/old.sql".into(), "deleted".into()),
+                ("models/untracked.sql".into(), "added".into()),
+            ]
+        );
+    }
+
+    #[test]
     fn api_errors_use_actionable_server_messages() {
         assert_eq!(
             api_error(r#"{"detail":{"message":"Connect this GitHub dbt project."}}"#),
@@ -968,7 +1146,7 @@ mod tests {
         ));
         assert!(!cache_is_fresh("not-a-timestamp"));
         let now = Utc::now().to_rfc3339();
-        assert!(cache_is_reusable("same", "same", &now, 3));
-        assert!(!cache_is_reusable("same", "same", &now, 2));
+        assert!(cache_is_reusable("same", "same", &now, 4));
+        assert!(!cache_is_reusable("same", "same", &now, 3));
     }
 }

--- a/src/dbt.rs
+++ b/src/dbt.rs
@@ -15,7 +15,7 @@ use uuid::Uuid;
 
 use crate::{
     auth::{DatabricksResolvedAuth, ResolvedAuth, SnowflakeResolvedAuth},
-    config::{AccountConfig, Config, ProviderConfig},
+    config::{AccountConfig, AuthConfig, Config, DatabricksAuthConfig, ProviderConfig},
     git, provider,
     report::{ImpactReport, ImpactedAsset, LineageChange, LineageChangeKind, LineageEdge},
 };
@@ -1195,9 +1195,37 @@ fn dbt_process(config: &Config, project: &Path, profiles: &Path, args: &[&str]) 
         .arg("--profile")
         .arg(&config.dbt.profile)
         .current_dir(project);
+    for variable in warehouse_auth_env_vars(config) {
+        command.env_remove(variable);
+    }
     command
         .output()
         .with_context(|| format!("could not run {}", config.dbt.command))
+}
+
+fn warehouse_auth_env_vars(config: &Config) -> BTreeSet<&str> {
+    let mut variables = BTreeSet::new();
+    for account in &config.accounts {
+        match &account.provider {
+            ProviderConfig::Snowflake(snowflake) => match &snowflake.auth {
+                AuthConfig::OauthLocal => {}
+                AuthConfig::Oauth { token_env }
+                | AuthConfig::ProgrammaticAccessToken { token_env } => {
+                    variables.insert(token_env.as_str());
+                }
+                AuthConfig::KeyPair { passphrase_env, .. } => {
+                    if let Some(variable) = passphrase_env {
+                        variables.insert(variable.as_str());
+                    }
+                }
+            },
+            ProviderConfig::Databricks(databricks) => {
+                let DatabricksAuthConfig::Token { token_env } = &databricks.auth;
+                variables.insert(token_env.as_str());
+            }
+        }
+    }
+    variables
 }
 
 fn git_output(repo: &Path, args: &[&str]) -> Result<String> {
@@ -1594,6 +1622,49 @@ accounts:
         let profile = fs::read_to_string(dir.path().join("profiles.yml")).unwrap();
         assert!(profile.contains("password: secret-pat"));
         assert!(!profile.contains("authenticator:"));
+    }
+
+    #[test]
+    fn dbt_children_do_not_inherit_warehouse_secret_environment_names() {
+        let snowflake: Config = serde_yaml::from_str(
+            r#"
+version: 1
+accounts:
+  - name: primary
+    account: org-account
+    user: DBT_CI
+    role: TRANSFORMER
+    database: ANALYTICS
+    warehouse: COMPUTE_WH
+    production_schema: PROD
+    auth: { type: programmatic_access_token, token_env: CLOUD_PAT }
+"#,
+        )
+        .unwrap();
+        assert_eq!(
+            warehouse_auth_env_vars(&snowflake),
+            BTreeSet::from(["CLOUD_PAT"])
+        );
+
+        let databricks: Config = serde_yaml::from_str(
+            r#"
+version: 2
+accounts:
+  - name: primary
+    provider:
+      type: databricks
+      host: https://example.cloud.databricks.com
+      http_path: /sql/1.0/warehouses/abc
+      catalog: analytics
+      production_schema: prod
+      auth: { type: token, token_env: CLOUD_DATABRICKS_TOKEN }
+"#,
+        )
+        .unwrap();
+        assert_eq!(
+            warehouse_auth_env_vars(&databricks),
+            BTreeSet::from(["CLOUD_DATABRICKS_TOKEN"])
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- enable Cloud handoff in the standard Rust CLI build
- upload the exact validation config, CLI options, and bounded repository snapshot
- include renames, untracked files, and configured external changes
- keep local review caching deterministic while making every Cloud handoff independently rerunnable
- prevent warehouse credentials from leaking into dbt child processes

## Verification

- cargo test --all-features: 125 unit and 17 integration tests passed
- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt --check