### PR TITLE
Enforce BigQuery query byte limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,11 +115,12 @@ accounts:
       project: analytics-prod
       location: US
       production_schema: prod
+      maximum_bytes_billed: 10737418240
       auth:
         type: application_default
 ```
 
-Application Default Credentials also support `GOOGLE_APPLICATION_CREDENTIALS` and an attached Google Cloud service account. Incremental baselines use BigQuery table clones; clone mode seeds candidates with table copies. The source and temporary datasets must be in the same location, and table-clone restrictions still apply.
+Application Default Credentials also support `GOOGLE_APPLICATION_CREDENTIALS` and an attached Google Cloud service account. `maximum_bytes_billed` applies the same per-query cap to dbt builds and Embrasure comparison queries. Incremental baselines use BigQuery table clones; clone mode seeds candidates with table copies. The source and temporary datasets must be in the same location, and table-clone restrictions still apply.
 
 If you do not use Homebrew, use the installer:
 

--- a/docs/provider-api.md
+++ b/docs/provider-api.md
@@ -108,7 +108,7 @@ accounts:
 
 Each provider owns a typed configuration structure. There is no string-keyed property map and no common credential enum containing every provider's fields.
 
-BigQuery uses the same version 2 shape with `type: bigquery`, `project`, `location`, `production_schema`, and `auth: { type: application_default }`. The provider resolves ADC for REST requests and writes a dbt-bigquery `method: oauth` profile so dbt uses the same credential chain.
+BigQuery uses the same version 2 shape with `type: bigquery`, `project`, `location`, `production_schema`, optional `maximum_bytes_billed`, and `auth: { type: application_default }`. The provider resolves ADC for REST requests and writes a dbt-bigquery `method: oauth` profile so dbt uses the same credential chain and per-query byte cap.
 
 Provider-specific entry points for auth, dbt profile generation, `doctor`, and `clean` are dispatched by the same tagged configuration. They do not belong on `WarehouseProvider` because the validation runner does not need them.
 

--- a/src/bigquery.rs
+++ b/src/bigquery.rs
@@ -69,20 +69,12 @@ impl BigQueryClient {
         let timeout_ms = self.timeout_seconds.saturating_mul(1_000);
         let url = self.api_url(&["projects", &self.account.project, "queries"])?;
         let response = self
-            .send(self.http.post(url).json(&json!({
-                "query": format!("/* {} */\n{statement}", self.query_tag),
-                "useLegacySql": false,
-                "location": self.account.location,
-                "defaultDataset": {
-                    "projectId": self.account.project,
-                    "datasetId": self.account.production_schema,
-                },
-                "timeoutMs": timeout_ms.min(200_000),
-                "jobTimeoutMs": timeout_ms.to_string(),
-                "maxResults": 10_000,
-                "requestId": Uuid::new_v4().to_string(),
-                "labels": { "embrasure_managed": "true" },
-            })))
+            .send(self.http.post(url).json(&query_request(
+                &self.account,
+                &self.query_tag,
+                statement,
+                timeout_ms,
+            )))
             .await?;
         let mut page: QueryResponse = parse_response(response, "BigQuery query request").await?;
         let job = page
@@ -358,6 +350,32 @@ impl BigQueryClient {
     fn schema_ownership_marker(&self) -> String {
         format!("Temporary schema managed by Embrasure; {}", self.query_tag)
     }
+}
+
+fn query_request(
+    account: &BigQueryConfig,
+    query_tag: &str,
+    statement: &str,
+    timeout_ms: u64,
+) -> Value {
+    let mut request = json!({
+        "query": format!("/* {query_tag} */\n{statement}"),
+        "useLegacySql": false,
+        "location": account.location,
+        "defaultDataset": {
+            "projectId": account.project,
+            "datasetId": account.production_schema,
+        },
+        "timeoutMs": timeout_ms.min(200_000),
+        "jobTimeoutMs": timeout_ms.to_string(),
+        "maxResults": 10_000,
+        "requestId": Uuid::new_v4().to_string(),
+        "labels": { "embrasure_managed": "true" },
+    });
+    if let Some(limit) = account.maximum_bytes_billed {
+        request["maximumBytesBilled"] = json!(limit.to_string());
+    }
+    request
 }
 
 fn joined_api_url(root: &Url, segments: &[&str]) -> Result<Url> {
@@ -639,6 +657,18 @@ struct DatasetReference {
 mod tests {
     use super::*;
 
+    fn bigquery_config() -> BigQueryConfig {
+        serde_yaml::from_str(
+            r#"project: analytics-prod
+location: US
+production_schema: prod
+maximum_bytes_billed: 10737418240
+auth: { type: application_default }
+"#,
+        )
+        .unwrap()
+    }
+
     #[test]
     fn renders_clone_and_copy_operations() {
         let source = Relation {
@@ -669,6 +699,13 @@ mod tests {
             url.as_str(),
             "https://bigquery.googleapis.com/bigquery/v2/projects/analytics-prod/queries"
         );
+    }
+
+    #[test]
+    fn query_request_enforces_the_configured_byte_limit() {
+        let request = query_request(&bigquery_config(), "validation", "select 1", 300_000);
+        assert_eq!(request["maximumBytesBilled"], "10737418240");
+        assert_eq!(request["timeoutMs"], 200_000);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -313,6 +313,8 @@ pub struct BigQueryConfig {
     pub project: String,
     pub location: String,
     pub production_schema: String,
+    #[serde(default)]
+    pub maximum_bytes_billed: Option<u64>,
     pub auth: BigQueryAuthConfig,
 }
 
@@ -866,6 +868,12 @@ fn validate_bigquery(account: &AccountConfig, config: &BigQueryConfig) -> Result
             account.name
         );
     }
+    if config.maximum_bytes_billed == Some(0) {
+        bail!(
+            "account {} BigQuery maximum_bytes_billed must be greater than zero",
+            account.name
+        );
+    }
     match &config.auth {
         BigQueryAuthConfig::ApplicationDefault => {}
     }
@@ -1129,6 +1137,7 @@ accounts:
       project: analytics-prod
       location: US
       production_schema: prod
+      maximum_bytes_billed: 10737418240
       auth: { type: application_default }
 "#;
         let config: Config = serde_yaml::from_str(yaml).unwrap();
@@ -1138,6 +1147,16 @@ accounts:
             config.accounts[0].provider,
             ProviderConfig::BigQuery(_)
         ));
+
+        let invalid_limit = yaml.replace("10737418240", "0");
+        let config: Config = serde_yaml::from_str(&invalid_limit).unwrap();
+        assert!(
+            config
+                .validate()
+                .unwrap_err()
+                .to_string()
+                .contains("maximum_bytes_billed")
+        );
 
         let invalid = yaml.replace("production_schema: prod", "production_schema: prod-data");
         let config: Config = serde_yaml::from_str(&invalid).unwrap();

--- a/src/dbt.rs
+++ b/src/dbt.rs
@@ -255,6 +255,8 @@ struct BigQueryProfileOutput {
     location: String,
     threads: u16,
     job_execution_timeout_seconds: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    maximum_bytes_billed: Option<u64>,
 }
 
 impl Manifest {
@@ -1160,6 +1162,7 @@ fn write_profiles(
                     location: bigquery.location.clone(),
                     threads: config.dbt.threads,
                     job_execution_timeout_seconds: config.safety.statement_timeout_seconds,
+                    maximum_bytes_billed: bigquery.maximum_bytes_billed,
                 })
             }
             _ => bail!(
@@ -1665,6 +1668,7 @@ accounts:
       project: analytics-prod
       location: US
       production_schema: prod
+      maximum_bytes_billed: 10737418240
       auth: { type: application_default }
 "#;
         let config: Config = serde_yaml::from_str(yaml).unwrap();
@@ -1684,6 +1688,7 @@ accounts:
         assert!(profile.contains("dataset: check_run"));
         assert!(profile.contains("location: US"));
         assert!(profile.contains("job_execution_timeout_seconds: 420"));
+        assert!(profile.contains("maximum_bytes_billed: 10737418240"));
         assert!(!profile.contains("dataset: prod"));
     }
 }


### PR DESCRIPTION
## Summary
- add an optional BigQuery per-query byte cap to the typed validation config
- apply the cap to both direct comparison requests and dbt-bigquery profiles
- document and test the shared safety contract

## Verification
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- 113 unit tests passed; 14 lineage-only tests require sqlglot, which is absent in this clean worktree