### PR TITLE
Expose warehouse execution links in validation reports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "embrasure-cli"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embrasure-cli"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2024"
 rust-version = "1.88"
 build = "build.rs"

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ The installer verifies the release checksum, installs Embrasure under `%LOCALAPP
 
 Installer options:
 
-- Pin a release: `& $installer -Version 0.5.3`
+- Pin a release: `& $installer -Version 0.5.4`
 - Run without prompts: `& $installer -Quiet`
 - Uninstall: `& $installer -Uninstall`
 
@@ -241,7 +241,7 @@ embrasure check --json --markdown embrasure-check.md
 embrasure check --json --report-version 1
 ```
 
-Published contracts: [v1](schemas/report-v1.schema.json), [v2](schemas/report-v2.schema.json), [v3](schemas/report-v3.schema.json), and [v4](schemas/report-v4.schema.json). V4 adds column lineage and is the default; older versions remain available with `--report-version`.
+Published contracts: [v1](schemas/report-v1.schema.json), [v2](schemas/report-v2.schema.json), [v3](schemas/report-v3.schema.json), and [v4](schemas/report-v4.schema.json). V4 adds column lineage and bounded warehouse execution links and is the default; older versions remain available with `--report-version`.
 
 | Exit code | Meaning |
 |---:|---|

--- a/docs/security-and-data-flow.md
+++ b/docs/security-and-data-flow.md
@@ -33,6 +33,8 @@ The CLI itself makes only these connections:
 
 There is no telemetry or analytics SDK. `embrasure update` is opt-in. Human, interactive `embrasure doctor` output may check for a release at most once every 24 hours. The notice is disabled for JSON output, piped stderr, `CI`, or `NO_UPDATE_NOTIFIER`, and network failures are silent. The local `dbt` process may connect to the configured warehouse or download packages according to the dbt project's own configuration. Normal local validation does not contact Embrasure.
 
+Report v4 can include up to 50 warehouse execution IDs and provider-console links. It does not include SQL text or credentials in that evidence.
+
 ## Data returned to the local process
 
 The configured warehouse returns the comparison evidence used in the local report:

--- a/schemas/report-v4.schema.json
+++ b/schemas/report-v4.schema.json
@@ -24,9 +24,23 @@
     "findings": { "type": "array", "items": { "$ref": "#/$defs/finding" } },
     "coverage_gaps": { "type": "array", "items": { "$ref": "#/$defs/coverage_gap" } },
     "notices": { "type": "array", "items": { "$ref": "#/$defs/notice" } },
-    "execution_errors": { "type": "array", "items": { "type": "string" } }
+    "execution_errors": { "type": "array", "items": { "type": "string" } },
+    "warehouse_executions": {
+      "type": "array", "maxItems": 50,
+      "items": { "$ref": "#/$defs/warehouse_execution" }
+    }
   },
   "$defs": {
+    "warehouse_execution": {
+      "type": "object", "additionalProperties": false,
+      "required": ["provider", "account", "execution_id", "url"],
+      "properties": {
+        "provider": { "enum": ["bigquery", "snowflake", "databricks"] },
+        "account": { "type": "string", "minLength": 1 },
+        "execution_id": { "type": "string", "minLength": 1 },
+        "url": { "type": "string", "format": "uri", "pattern": "^https://" }
+      }
+    },
     "ci_schema": {
       "type": "object", "additionalProperties": false,
       "required": ["account", "database", "schema", "cleaned_up"],

--- a/src/bigquery.rs
+++ b/src/bigquery.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::BTreeMap,
-    sync::Arc,
+    sync::{Arc, Mutex},
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
@@ -18,7 +18,7 @@ use crate::{
     config::{AccountConfig, BigQueryConfig},
     provider::{
         ProviderFuture, QueryExecutor, QueryResult, Relation, ResultColumn, SqlDialect,
-        WarehouseProvider, is_managed_schema,
+        WarehouseExecution, WarehouseProvider, is_managed_schema,
     },
 };
 
@@ -34,6 +34,8 @@ pub struct BigQueryClient {
     query_tag: String,
     timeout_seconds: u64,
     api_root: Url,
+    account_name: String,
+    executions: Arc<Mutex<Vec<WarehouseExecution>>>,
 }
 
 impl BigQueryClient {
@@ -43,6 +45,7 @@ impl BigQueryClient {
         query_tag: String,
         timeout_seconds: u64,
     ) -> Result<Self> {
+        let account_name = account.name.clone();
         let account = account
             .bigquery()
             .context("BigQuery client requires BigQuery account configuration")?;
@@ -61,6 +64,8 @@ impl BigQueryClient {
             query_tag,
             timeout_seconds,
             api_root: Url::parse(API_ROOT)?,
+            account_name,
+            executions: Arc::new(Mutex::new(vec![])),
         })
     }
 
@@ -81,6 +86,14 @@ impl BigQueryClient {
             .job_reference
             .clone()
             .context("BigQuery query response omitted its job reference")?;
+        if let Ok(mut executions) = self.executions.lock() {
+            executions.push(WarehouseExecution::bigquery(
+                &self.account_name,
+                &job.project_id,
+                &job.location,
+                &job.job_id,
+            ));
+        }
 
         while !page.job_complete {
             if started.elapsed() >= Duration::from_secs(self.timeout_seconds) {
@@ -398,6 +411,13 @@ impl QueryExecutor for BigQueryClient {
 }
 
 impl WarehouseProvider for BigQueryClient {
+    fn warehouse_executions(&self) -> Vec<WarehouseExecution> {
+        self.executions
+            .lock()
+            .map(|items| items.clone())
+            .unwrap_or_default()
+    }
+
     fn create_schema<'a>(&'a self, project: &'a str, schema: &'a str) -> ProviderFuture<'a, ()> {
         Box::pin(BigQueryClient::create_schema(self, project, schema))
     }

--- a/src/databricks.rs
+++ b/src/databricks.rs
@@ -1,4 +1,7 @@
-use std::time::{Duration, Instant};
+use std::{
+    sync::{Arc, Mutex},
+    time::{Duration, Instant},
+};
 
 use anyhow::{Context, Result, bail};
 use reqwest::{Client, StatusCode, header};
@@ -12,7 +15,7 @@ use crate::{
     config::{AccountConfig, DatabricksConfig},
     provider::{
         ProviderFuture, QueryExecutor, QueryResult, Relation, ResultColumn, SqlDialect,
-        WarehouseProvider, is_managed_schema,
+        WarehouseExecution, WarehouseProvider, is_managed_schema,
     },
 };
 
@@ -25,6 +28,8 @@ pub struct DatabricksClient {
     account: DatabricksConfig,
     query_tag: String,
     timeout_seconds: u64,
+    account_name: String,
+    executions: Arc<Mutex<Vec<WarehouseExecution>>>,
 }
 
 impl DatabricksClient {
@@ -34,6 +39,7 @@ impl DatabricksClient {
         query_tag: String,
         timeout_seconds: u64,
     ) -> Result<Self> {
+        let account_name = account.name.clone();
         let account = account
             .databricks()
             .context("Databricks client requires Databricks account configuration")?;
@@ -51,6 +57,8 @@ impl DatabricksClient {
             account: account.clone(),
             query_tag,
             timeout_seconds,
+            account_name,
+            executions: Arc::new(Mutex::new(vec![])),
         })
     }
 
@@ -75,6 +83,15 @@ impl DatabricksClient {
                 .await
                 .context("Databricks Statement Execution request failed")?;
             let mut body = parse_response(response).await?;
+            if let Some(execution_id) = body.statement_id.as_deref()
+                && let Ok(mut executions) = self.executions.lock()
+            {
+                executions.push(WarehouseExecution::databricks(
+                    &self.account_name,
+                    &self.workspace_url,
+                    execution_id,
+                ));
+            }
             loop {
                 match body.status.state.as_str() {
                     "PENDING" | "RUNNING" => {
@@ -313,6 +330,13 @@ impl QueryExecutor for DatabricksClient {
 }
 
 impl WarehouseProvider for DatabricksClient {
+    fn warehouse_executions(&self) -> Vec<WarehouseExecution> {
+        self.executions
+            .lock()
+            .map(|items| items.clone())
+            .unwrap_or_default()
+    }
+
     fn create_schema<'a>(&'a self, catalog: &'a str, schema: &'a str) -> ProviderFuture<'a, ()> {
         Box::pin(DatabricksClient::create_schema(self, catalog, schema))
     }

--- a/src/dbt.rs
+++ b/src/dbt.rs
@@ -180,6 +180,7 @@ pub struct DbtContext {
 pub struct BuildResult {
     pub passed: bool,
     pub failures: Vec<BuildFailure>,
+    pub warehouse_executions: Vec<crate::provider::WarehouseExecution>,
 }
 
 #[derive(Debug)]
@@ -934,6 +935,7 @@ pub fn build_models(
         return Ok(BuildResult {
             passed: true,
             failures: vec![],
+            warehouse_executions: vec![],
         });
     }
     let target_path = context.build_target(&account.name);
@@ -967,10 +969,12 @@ pub fn build_models(
         &context.profiles_dir,
         &args,
     )?;
+    let warehouse_executions = load_run_executions(&target_path.join("run_results.json"), account)?;
     if output.status.success() {
         return Ok(BuildResult {
             passed: true,
             failures: vec![],
+            warehouse_executions,
         });
     }
     let mut failures = load_run_failures(&target_path.join("run_results.json"))?;
@@ -983,7 +987,66 @@ pub fn build_models(
     Ok(BuildResult {
         passed: false,
         failures,
+        warehouse_executions,
     })
+}
+
+fn load_run_executions(
+    path: &Path,
+    account: &AccountConfig,
+) -> Result<Vec<crate::provider::WarehouseExecution>> {
+    if !path.exists() {
+        return Ok(vec![]);
+    }
+    let value: Value = serde_json::from_slice(&fs::read(path)?)
+        .with_context(|| format!("invalid dbt run results {}", path.display()))?;
+    let mut executions = vec![];
+    for result in value
+        .get("results")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+    {
+        let Some(response) = result.get("adapter_response").and_then(Value::as_object) else {
+            continue;
+        };
+        let execution = match &account.provider {
+            crate::config::ProviderConfig::BigQuery(config) => {
+                response.get("job_id").and_then(Value::as_str).map(|id| {
+                    crate::provider::WarehouseExecution::bigquery(
+                        &account.name,
+                        &config.project,
+                        &config.location,
+                        id,
+                    )
+                })
+            }
+            crate::config::ProviderConfig::Snowflake(config) => {
+                response.get("query_id").and_then(Value::as_str).map(|id| {
+                    crate::provider::WarehouseExecution::snowflake(
+                        &account.name,
+                        &crate::auth::account_host(&config.account),
+                        id,
+                    )
+                })
+            }
+            crate::config::ProviderConfig::Databricks(config) => response
+                .get("statement_id")
+                .or_else(|| response.get("query_id"))
+                .and_then(Value::as_str)
+                .map(|id| {
+                    crate::provider::WarehouseExecution::databricks(
+                        &account.name,
+                        &config.workspace_url(),
+                        id,
+                    )
+                }),
+        };
+        if let Some(execution) = execution {
+            executions.push(execution);
+        }
+    }
+    Ok(executions)
 }
 
 fn dbt_selector(node: &ManifestNode) -> Result<String> {
@@ -1521,6 +1584,40 @@ mod tests {
     #[test]
     fn malformed_dbt_ls_output_is_not_silently_ignored() {
         assert!(unique_ids("not-json").is_err());
+    }
+
+    #[test]
+    fn dbt_run_results_preserve_bigquery_job_links() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("run_results.json");
+        fs::write(
+            &path,
+            r#"{"results":[{"adapter_response":{"job_id":"job-123"}}]}"#,
+        )
+        .unwrap();
+        let account: AccountConfig = serde_yaml::from_str(
+            r#"
+name: primary
+provider:
+  type: bigquery
+  project: analytics-prod
+  location: US
+  production_schema: prod
+  auth:
+    type: application_default
+"#,
+        )
+        .unwrap();
+
+        let executions = load_run_executions(&path, &account).unwrap();
+
+        assert_eq!(executions.len(), 1);
+        assert_eq!(executions[0].provider, "bigquery");
+        assert_eq!(executions[0].execution_id, "job-123");
+        assert_eq!(
+            executions[0].url,
+            "https://console.cloud.google.com/bigquery?project=analytics-prod&j=bq:US:job-123&page=queryresults"
+        );
     }
 
     #[test]

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -1,6 +1,7 @@
 use std::{future::Future, pin::Pin, sync::Arc};
 
 use anyhow::Result;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     auth::ResolvedAuth,
@@ -11,6 +12,50 @@ use crate::{
 };
 
 pub type ProviderFuture<'a, T> = Pin<Box<dyn Future<Output = Result<T>> + Send + 'a>>;
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct WarehouseExecution {
+    pub provider: String,
+    pub account: String,
+    pub execution_id: String,
+    pub url: String,
+}
+
+impl WarehouseExecution {
+    pub fn bigquery(account: &str, project: &str, location: &str, execution_id: &str) -> Self {
+        Self {
+            provider: "bigquery".into(),
+            account: account.into(),
+            execution_id: execution_id.into(),
+            url: format!(
+                "https://console.cloud.google.com/bigquery?project={project}&j=bq:{location}:{execution_id}&page=queryresults"
+            ),
+        }
+    }
+
+    pub fn snowflake(account: &str, account_host: &str, execution_id: &str) -> Self {
+        Self {
+            provider: "snowflake".into(),
+            account: account.into(),
+            execution_id: execution_id.into(),
+            url: format!(
+                "https://{account_host}/console#/monitoring/queries/detail?queryId={execution_id}"
+            ),
+        }
+    }
+
+    pub fn databricks(account: &str, workspace_url: &str, execution_id: &str) -> Self {
+        Self {
+            provider: "databricks".into(),
+            account: account.into(),
+            execution_id: execution_id.into(),
+            url: format!(
+                "{}/sql/history?queryId={execution_id}",
+                workspace_url.trim_end_matches('/')
+            ),
+        }
+    }
+}
 
 #[derive(Debug, Clone, Default)]
 pub struct QueryResult {
@@ -312,6 +357,10 @@ pub trait QueryExecutor: Send + Sync {
 }
 
 pub trait WarehouseProvider: QueryExecutor {
+    fn warehouse_executions(&self) -> Vec<WarehouseExecution> {
+        vec![]
+    }
+
     fn create_schema<'a>(&'a self, database: &'a str, schema: &'a str) -> ProviderFuture<'a, ()>;
 
     fn copy_table<'a>(
@@ -379,6 +428,28 @@ pub fn is_managed_schema(dialect: SqlDialect, schema: &str, run_schema: &str) ->
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn warehouse_execution_links_use_provider_native_history() {
+        assert_eq!(
+            WarehouseExecution::snowflake(
+                "primary",
+                "org-account.snowflakecomputing.com",
+                "query-1",
+            )
+            .url,
+            "https://org-account.snowflakecomputing.com/console#/monitoring/queries/detail?queryId=query-1"
+        );
+        assert_eq!(
+            WarehouseExecution::databricks(
+                "primary",
+                "https://workspace.cloud.databricks.com/",
+                "statement-1",
+            )
+            .url,
+            "https://workspace.cloud.databricks.com/sql/history?queryId=statement-1"
+        );
+    }
 
     #[test]
     fn dialects_render_their_provider_contracts() {

--- a/src/report.rs
+++ b/src/report.rs
@@ -5,8 +5,11 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     config::{CrossAccountDependency, DownstreamPolicy, Thresholds},
+    provider::WarehouseExecution,
     style::Style,
 };
+
+const MAX_WAREHOUSE_EXECUTIONS: usize = 50;
 
 pub const EXIT_PASS: u8 = 0;
 pub const EXIT_FINDINGS: u8 = 1;
@@ -52,6 +55,8 @@ pub struct Report {
     pub coverage_gaps: Vec<CoverageGap>,
     pub notices: Vec<Notice>,
     pub execution_errors: Vec<String>,
+    #[serde(skip)]
+    pub warehouse_executions: Vec<WarehouseExecution>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -324,6 +329,7 @@ impl Report {
             coverage_gaps: vec![],
             notices: vec![],
             execution_errors: vec![],
+            warehouse_executions: vec![],
         }
     }
 
@@ -339,6 +345,9 @@ impl Report {
         self.findings.dedup();
         self.coverage_gaps.sort();
         self.coverage_gaps.dedup();
+        self.warehouse_executions.sort();
+        self.warehouse_executions.dedup();
+        self.warehouse_executions.truncate(MAX_WAREHOUSE_EXECUTIONS);
         self.notices.sort();
         self.notices.dedup();
         self.validation_scope.validated_models.sort();
@@ -1095,6 +1104,7 @@ struct ReportV4<'a> {
     coverage_gaps: &'a [CoverageGap],
     notices: &'a [Notice],
     execution_errors: &'a [String],
+    warehouse_executions: &'a [WarehouseExecution],
 }
 
 #[derive(Serialize)]
@@ -1136,6 +1146,7 @@ impl<'a> From<&'a Report> for ReportV4<'a> {
             coverage_gaps: &report.coverage_gaps,
             notices: &report.notices,
             execution_errors: &report.execution_errors,
+            warehouse_executions: &report.warehouse_executions,
         }
     }
 }
@@ -1517,6 +1528,14 @@ mod tests {
             invalid_primary_key_reason: None,
             examples_truncated: false,
         });
+        report
+            .warehouse_executions
+            .push(WarehouseExecution::bigquery(
+                "primary",
+                "analytics-prod",
+                "US",
+                "job-123",
+            ));
         report.finalize();
         report
     }
@@ -1711,9 +1730,11 @@ mod tests {
         let v3: serde_json::Value =
             serde_json::from_str(&report.json(ReportVersion::V3).unwrap()).unwrap();
         assert!(v3["impact"].get("column_lineage").is_none());
+        assert!(v3.get("warehouse_executions").is_none());
         let v4: serde_json::Value =
             serde_json::from_str(&report.json(ReportVersion::V4).unwrap()).unwrap();
         assert_eq!(v4["schema_version"], 4);
+        assert_eq!(v4["warehouse_executions"][0]["execution_id"], "job-123");
         assert_eq!(v4["impact"]["column_lineage"].as_array().unwrap().len(), 1);
         assert_eq!(
             v4["impact"]["column_lineage_gaps"]

--- a/src/run.rs
+++ b/src/run.rs
@@ -225,6 +225,11 @@ async fn execute(
         progress.cleanup(0, report.ci_schemas.len());
     }
     cleanup_schemas(config, &clients, &schema, report, options.progress.as_ref()).await;
+    for client in &clients {
+        report
+            .warehouse_executions
+            .extend(client.warehouse_executions());
+    }
     Ok(())
 }
 
@@ -1005,6 +1010,9 @@ async fn execute_with_dbt(
             config.validation.incremental_mode == IncrementalMode::FullRefresh,
         )
         .with_context(|| format!("could not execute dbt build for account {}", account.name))?;
+        report
+            .warehouse_executions
+            .extend(build.warehouse_executions);
         if !build.passed {
             if let Some(progress) = progress {
                 progress.fail_current();

--- a/src/snowflake.rs
+++ b/src/snowflake.rs
@@ -1,5 +1,6 @@
 use std::{
     env, fs,
+    sync::{Arc, Mutex},
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
@@ -26,7 +27,7 @@ use crate::{
     config::{AccountConfig, SnowflakeConfig},
     provider::{
         ProviderFuture, QueryExecutor, QueryResult, Relation, ResultColumn, SqlDialect,
-        WarehouseProvider, is_managed_schema,
+        WarehouseExecution, WarehouseProvider, is_managed_schema,
     },
 };
 
@@ -39,6 +40,8 @@ pub struct SnowflakeClient {
     account: SnowflakeConfig,
     query_tag: String,
     timeout_seconds: u64,
+    account_name: String,
+    executions: Arc<Mutex<Vec<WarehouseExecution>>>,
 }
 
 #[derive(Debug, Serialize)]
@@ -56,6 +59,7 @@ impl SnowflakeClient {
         query_tag: String,
         timeout_seconds: u64,
     ) -> Result<Self> {
+        let account_name = account.name.clone();
         let account = account
             .snowflake()
             .context("Snowflake client requires Snowflake account configuration")?;
@@ -88,6 +92,8 @@ impl SnowflakeClient {
             account: account.clone(),
             query_tag,
             timeout_seconds,
+            account_name,
+            executions: Arc::new(Mutex::new(vec![])),
         })
     }
 
@@ -156,6 +162,15 @@ impl SnowflakeClient {
                 bail!("Snowflake statement failed (HTTP {status}, code {code}): {message}{hint}");
             }
             let handle = body.statement_handle.clone();
+            if let Some(execution_id) = handle.as_deref()
+                && let Ok(mut executions) = self.executions.lock()
+            {
+                executions.push(WarehouseExecution::snowflake(
+                    &self.account_name,
+                    &account_host(&self.account.account),
+                    execution_id,
+                ));
+            }
             let mut result = QueryResult {
                 columns: body
                     .metadata
@@ -337,6 +352,13 @@ impl QueryExecutor for SnowflakeClient {
 }
 
 impl WarehouseProvider for SnowflakeClient {
+    fn warehouse_executions(&self) -> Vec<WarehouseExecution> {
+        self.executions
+            .lock()
+            .map(|items| items.clone())
+            .unwrap_or_default()
+    }
+
     fn create_schema<'a>(&'a self, database: &'a str, schema: &'a str) -> ProviderFuture<'a, ()> {
         Box::pin(SnowflakeClient::create_schema(self, database, schema))
     }


### PR DESCRIPTION
## Summary
- add optional, bounded `warehouse_executions` evidence to report v4
- capture BigQuery job IDs, Snowflake query IDs, and Databricks statement IDs from dbt and direct comparisons
- include only provider, account label, execution ID, and native console URL
- bump the release version to 0.5.4

## Verification
- `cargo fmt --check`
- `cargo test --locked` (137 tests)
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo package --locked --allow-dirty`